### PR TITLE
fix(auth): store Pinia useAuthStore, source de vérité unique (#19)

### DIFF
--- a/.claude/specs/auth-store/design.md
+++ b/.claude/specs/auth-store/design.md
@@ -1,0 +1,541 @@
+# Design Document — Store d'authentification Pinia (`useAuthStore`)
+
+> Issue GitHub **#19** (TIER 0 CRITICAL, épique #16) — recoupe #2/#6 (token XSS) et #11 (token visio).
+> Conforme à `requirements.md` (approuvé). Aucune modification backend (NFR-2 / R12.3).
+> Standards : `lms-backend/PRODUCTION_STANDARDS.md` §1.2, §1.6, §5 ; §6 (« une seule solution »).
+
+## Overview
+
+### Objectif et périmètre
+
+Centraliser **tout** l'état d'authentification du frontend Vue 3 dans un store Pinia unique, `useAuthStore` (`src/stores/auth.js`), qui devient la **source de vérité unique** (R1). Le store :
+
+- détient `user`, `token`, `role` (brut), `institution`, `institutionName`, `meta` (R1.2) ;
+- expose des getters dérivés (`isAuthenticated`, `currentUser`, `userRole`) et des getters d'autorisation (`isAdmin`, `isSupradmin`, `isTeacher`, `isStudent`) **délégués** à `src/constants/roles.js`, jamais réimplémentés (R2.2) ;
+- persiste via **un seul mécanisme** : `sessionStorage`, écrit manuellement dans les actions, hydraté au démarrage (R3, décisions A/E ci-dessous) ;
+- élimine les 13 accès directs et incohérents au storage répartis sur 12 fichiers (R3.4, R4.2, R6).
+
+Le bloc `auth` de `api.js` est conservé comme **façade fine** déléguant au store, afin de ne pas réécrire les 88 appels dans 32 fichiers (R5, décision B).
+
+### Ce que ce design ne fait PAS (hors périmètre, R13)
+
+- Refonte de la gestion d'erreurs (#20).
+- Migration des comparaisons brutes `role === '...'` résiduelles dans les vues (dette #18-FE-2), sauf aux emplacements directement touchés par R4 et R6.
+- `localStorage('userPreferences')` de `StudentSettings.vue:233/239` (préférence UI, pas de l'auth).
+
+### Faits vérifiés sur le code réel (lecture, pas supposition)
+
+| Fait | Preuve (`fichier:ligne`) |
+| --- | --- |
+| Pinia configuré, style `defineStore` composition | `src/main.js:2,43` ; `src/stores/visio.js:18` (`defineStore('visio', () => { ... })`) |
+| **Aucun plugin de persistance Pinia installé** | `package.json:46` (`pinia ^2.1.7` seul ; pas de `pinia-plugin-persistedstate`) |
+| L'intercepteur requête lit `sessionStorage` | `src/services/api.js:28` |
+| `login` écrit token/user/meta/institution en `sessionStorage` | `src/services/api.js:71-78` |
+| `logout` purge `sessionStorage` + `clearAllCache()` | `src/services/api.js:86-90` |
+| Intercepteur 401 purge `sessionStorage` + redirige `/login` | `src/services/api.js:49-59` |
+| Bug `user` : `visio.js:248` lit le **token** en `localStorage` (incohérent) | `src/stores/visio.js:248` |
+| Bug `user` : 6 lecteurs de `localStorage('user')` (jamais écrit par api.js) | `visio.js:347`, `TeacherSeances.vue:357`, `student/StudentSchedule.vue:34`, `teacher/TeacherSchedule.vue:36`, `ForumTopic.vue:199`, `coordinateur/SeanceManagement.vue:309` |
+| `cache.js` scope par `auth.getInstitution() \|\| 'default'` | `src/services/cache.js:10` |
+| Helpers de rôle disponibles, fail-secure | `src/constants/roles.js:75-133` |
+| **api.js est chargé AVANT `createPinia()`** | `main.js:4` importe `router` → `router/index.js:2` importe `auth from '@/services/api'`, évalué au chargement du module, donc avant `main.js:43 app.use(createPinia())` |
+
+Ce dernier fait est l'élément d'architecture central : **toute** lecture du store depuis `api.js` (façade, intercepteurs) doit être **paresseuse** (à l'intérieur d'une fonction exécutée après le montage), jamais au top-level.
+
+---
+
+## Architecture
+
+### Diagramme d'architecture système
+
+```mermaid
+graph TB
+    subgraph Vue["Couche Vue - composants et vues"]
+        V1[Composants visio]
+        V2[Vues planning et forum]
+        V3[Router guard]
+    end
+
+    subgraph Store["Couche etat - source de verite"]
+        AS[useAuthStore<br/>src/stores/auth.js]
+    end
+
+    subgraph Services["Couche services"]
+        FACADE[Facade auth<br/>src/services/api.js]
+        AXIOS[Instance axios api<br/>default export]
+        CACHE[cache.js]
+        ROLES[roles.js<br/>helpers autorisation]
+    end
+
+    subgraph Persist["Persistance unique"]
+        SS[sessionStorage]
+    end
+
+    BE[Backend Laravel<br/>lecture seule]
+
+    V1 -->|token et user| AS
+    V2 -->|currentUser| AS
+    V3 -->|via facade| FACADE
+    FACADE -->|delegue a la volee| AS
+    CACHE -->|getInstitution via facade| FACADE
+    AS -->|getters derives| ROLES
+    AS -->|POST auth login via| AXIOS
+    AS -->|ecrit et lit| SS
+    AXIOS -->|intercepteur lit token a la volee| AS
+    AXIOS -->|HTTP| BE
+```
+
+### Diagramme de flux de données (token)
+
+```mermaid
+graph LR
+    A[Reponse login backend] --> B[useAuthStore.setSession]
+    B --> C[state token user role meta institution]
+    C --> D[sessionStorage ecriture]
+    C --> E[Getters reactifs Pinia]
+    E --> F[Composants visio token]
+    C --> G[Intercepteur axios lit token]
+    G --> H[Header Authorization Bearer]
+```
+
+### Règle anti-cycle ESM (décision C/D — point critique)
+
+Le risque de cycle est `auth.js` ↔ `api.js`. Il est levé par une règle simple et vérifiable :
+
+- **Au top-level** (au chargement des modules) : `auth.js` importe **uniquement** le `default export` `api` (l'instance axios) de `api.js`. `api.js` n'importe **rien** de `auth.js` au top-level. Le graphe de chargement est donc acyclique : `auth.js → api.js (instance axios)`, terminé.
+- **À la volée** (à l'exécution, après montage) : la façade `auth` de `api.js` et les deux intercepteurs appellent `useAuthStore()` **à l'intérieur** de leurs fonctions. Pinia étant alors actif, l'appel réussit. Aucune dépendance circulaire de chargement, car ces références ne sont résolues qu'à l'appel.
+
+```mermaid
+graph TB
+    subgraph Chargement["Au chargement - acyclique"]
+        AUTHJS[auth.js] -->|import default| APIJS[api.js instance axios]
+    end
+    subgraph Execution["A l execution - apres montage Pinia"]
+        FAC[Facade auth methodes] -.->|useAuthStore a la volee| STORE[useAuthStore]
+        INT[Intercepteurs axios] -.->|useAuthStore a la volee| STORE
+        STORE -.->|api.post auth login| APIJS
+    end
+```
+
+Pourquoi `auth.js` importe l'instance axios plutôt que de réutiliser `auth.login` : le store doit émettre le `POST /auth/login` lui-même (R1.4) sans dépendre de la façade (qui, elle, délègue au store) — sinon on crée une boucle d'appel `façade.login → store.login → façade.login`. Le store fait donc l'appel HTTP brut via l'instance `api`, et la façade `auth.login` ne fait que `return useAuthStore().login(...)`.
+
+---
+
+## Décisions tranchées
+
+> Conforme à PRODUCTION_STANDARDS §6 : une seule solution par point, justifiée par preuve. Pas de « A ou B » laissé ouvert.
+
+### A — Mécanisme de persistance : `sessionStorage`, écriture manuelle dans les actions, hydratation au démarrage
+
+**Décision.** Persistance manuelle dans le store via `sessionStorage`, hydratée à l'initialisation du state.
+
+**Justification.**
+1. `sessionStorage` est **l'état de fait actuel** d'`api.js` (`api.js:28,71-78,86-89`). Le conserver évite tout changement de sémantique de session pour l'utilisateur et satisfait R3.2/R11.1 (jamais `localStorage` pour le token → atténuation XSS #2/#6).
+2. **Écriture manuelle, pas de plugin.** `package.json:46` ne contient aucun plugin de persistance (`pinia-plugin-persistedstate` absent). PRODUCTION_STANDARDS et NFR du projet poussent à ne pas ajouter de dépendance évitable ; l'écriture manuelle dans 2 actions (`setSession`, `setInstitution`) + 1 dans `logout` est triviale et entièrement testable. **Décision : ne pas ajouter de dépendance.**
+
+**Compromis documenté (R3.5 / R11.3), sémantique EXACTE de `sessionStorage` :**
+
+- `sessionStorage` **survit au rechargement de la même page (F5)** et à la navigation interne — il n'est PAS perdu au refresh d'onglet. C'est pourquoi l'hydratation au démarrage (décision E) est nécessaire et suffisante pour qu'un F5 ne déconnecte pas l'utilisateur.
+- `sessionStorage` est **effacé à la fermeture de l'onglet/fenêtre** et **n'est pas partagé entre onglets** (chaque onglet a son propre espace ; un nouvel onglet démarre déconnecté).
+
+Ce compromis (pas de SSO multi-onglets, session liée à la durée de vie de l'onglet) est un **choix de sécurité assumé** : il réduit la fenêtre d'exposition du token et est aligné sur le comportement déjà en place.
+
+### B — `auth` de `api.js` devient une FAÇADE FINE déléguant au store
+
+**Décision.** Le bloc `auth` (`api.js:66-162`) est conservé et réécrit en façade fine ; **les 32 fichiers consommateurs ne sont pas touchés** (sauf ceux ciblés par R4/R6 qui migrent vers le store directement).
+
+**Justification.**
+1. **Non-régression R5** : 88 appels dans 32 fichiers (dont le router guard, `router/index.js:2`, et `cache.js:1`). Migrer 32 fichiers multiplie la surface de régression sans gain fonctionnel. La façade satisfait R5.1/R5.2/R5.3 (façade fine, pas de duplication de logique).
+2. **Appel d'un store Pinia hors composant.** `useAuthStore()` peut être appelé hors d'un composant **dès lors que Pinia est actif** (créé `main.js:43`). Comme `api.js` est chargé AVANT (preuve : `main.js:4 → router/index.js:2`), appeler `useAuthStore()` au **top-level** d'`api.js` lèverait `getActivePinia()` / « no active Pinia ». **Solution : appeler `useAuthStore()` DANS chaque méthode de la façade**, à la volée — au moment de l'appel, l'app est montée et Pinia actif.
+
+### C — Le store COEXISTE avec la façade ; le store ne dépend pas de la façade pour l'état
+
+**Décision.** `useAuthStore` est la source de vérité. La façade `auth` coexiste pour les 88 appels et **délègue** au store. Le store ne lit jamais la façade : il importe l'instance axios `default` de `api.js` pour le seul `POST /auth/login`.
+
+**Justification.** Voir « Règle anti-cycle ESM » ci-dessus. Cette structure satisfait R5.2 (tout résultat provient du store), R1.4 (le store fait l'appel HTTP) et évite la boucle d'appel et le cycle de chargement.
+
+### D — Intercepteurs axios lisent le store À LA VOLÉE
+
+**Décision.**
+- Intercepteur **requête** (`api.js:26-37`) : `const token = useAuthStore().token` **dans** la fonction `(config) => {...}`. Si présent → `Authorization: Bearer <token>` ; sinon, aucun header (R7.1/7.2/7.3).
+- Intercepteur **réponse 401** (`api.js:49-59`) : `useAuthStore().logout()` (purge state + storage), puis redirection `/login` hors page de login (R7.4 ; comportement de redirection conservé).
+
+**Justification.** Les fonctions d'intercepteur s'exécutent **à chaque requête**, donc bien après le montage : Pinia est actif, `useAuthStore()` réussit. Définir l'intercepteur au top-level n'évalue pas `useAuthStore()` au chargement — seul le corps de la fonction l'appelle, à l'exécution. R10.5 (issue #11) : comme le login écrit le token dans le store et l'intercepteur le lit depuis le même store, **token écrit ≡ token lu** — plus aucun mismatch `localStorage`/`sessionStorage`.
+
+### E — Hydratation au démarrage
+
+**Décision.** Le state initial du store est lu depuis `sessionStorage` à la définition du store (fonction d'hydratation appelée dans le `state`/setup). Les écritures se font dans `setSession`, `setInstitution`, `logout`.
+
+**Justification.** Sans hydratation, un F5 (qui conserve `sessionStorage`, cf. décision A) repartirait avec un store vide en mémoire → déconnexion perçue à tort. L'hydratation reconstruit l'état en mémoire à partir du storage survivant. Cohérence persistance↔hydratation : **même clés, même mécanisme** (`sessionStorage`), lecture au boot / écriture aux mutations.
+
+---
+
+## Composants et Interfaces
+
+### `src/stores/auth.js` — `useAuthStore`
+
+Style `defineStore` composition (cohérent `visio.js:18`, R1.1). Responsabilité unique : détenir et muter l'état d'auth (SRP, PRODUCTION_STANDARDS §1.6-S). DIP (§1.6-D) : la logique de rôle est **injectée par dérivation** depuis `roles.js`, non dupliquée (R2.2).
+
+#### State (R1.2)
+
+| Champ | Type | Source au login | Persisté |
+| --- | --- | --- | --- |
+| `user` | `object \| null` | `response.data.user` | oui (`sessionStorage['user']`) |
+| `token` | `string \| null` | `response.data.token` | oui (`sessionStorage['token']`) |
+| `role` | `string \| null` | `response.data.user.role` (brut) | dérivable de `user`, persisté via `user` |
+| `institution` | `string \| null` | `response.meta.institution` | oui (`sessionStorage['institution']`) |
+| `institutionName` | `string \| null` | `response.meta.institution_name` | via `meta` |
+| `meta` | `object \| null` | `response.meta` | oui (`sessionStorage['meta']`) |
+
+> `role` est exposé comme le rôle **brut** (R1.3, R2.1). Pour éviter la redondance d'état, `role` est un getter dérivé de `user?.role` plutôt qu'un champ dupliqué — une seule raison de changer (§1.6-S). Le rôle **normalisé** est exposé séparément (getter dérivé de `normalizeRole`).
+
+#### Getters
+
+| Getter | Dérivation | Exigence |
+| --- | --- | --- |
+| `isAuthenticated` | `!!token` | R2.1, R8.5 |
+| `currentUser` | `user ?? null` (jamais `{}`) | R2.1, R4.4 |
+| `userRole` | `user?.role ?? null` (brut) | R2.1 |
+| `normalizedRole` | `normalizeRole(user?.role)` | R1.3 |
+| `isAdmin` | `roleIsAdmin(user)` | R2.2, R2.5 (admin\|supradmin) |
+| `isSupradmin` | `roleIsSupradmin(user)` | R2.2 |
+| `isTeacher` | `roleIsTeacher(user)` | R2.2 |
+| `isStudent` | `roleIsStudent(user)` | R2.2 |
+| `institutionSlug` | `meta?.institution ?? institution ?? null` | R8.1, R8.2 (parité `api.js:137-140`) |
+| `institutionDisplayName` | `meta?.institution_name ?? null` | parité `api.js:143-146` |
+
+Fail-secure (R2.3) : tous les getters d'autorisation héritent du fail-secure de `roles.js` (rôle `null`/inconnu → `false`, `roles.js:99-133`). Réactivité (R2.4, R9) : getters Pinia → recalcul automatique à chaque mutation de `user`/`token`.
+
+#### Actions
+
+| Action | Signature | Comportement | Exigence |
+| --- | --- | --- | --- |
+| `login` | `async (username, password)` | `POST /auth/login` via instance axios `api` ; si `success && data` → `setSession(data, meta)` ; retourne la réponse brute (parité `api.js:67-83`) | R1.4, R5.2, R9.1 |
+| `setSession` | `(data, meta)` | peuple `user`, `token` (+ `meta`, `institution`, `institutionName` si `meta`) ; écrit `sessionStorage` | R1.4 |
+| `setInstitution` | `(slug)` | met à jour `institution` + `sessionStorage['institution']` (parité `api.js:159-161`) | R8.3 |
+| `logout` | `()` | purge **tout** le state (`user/token/role/institution/institutionName/meta`) ; `sessionStorage.removeItem` des 4 clés ; `clearAllCache()` | R8.4, R8.5, R7.4 |
+| `me` | `async ()` | `GET /auth/me` via instance axios (parité `api.js:93-95`) | R5.1 |
+| `fetchActiveInstitutions` | `async ()` | `GET /institutions/active` (parité `api.js:154-156`) | R5.1 |
+| `$hydrate` (interne) | `()` | lit `sessionStorage` → reconstruit le state initial | R3, E |
+
+> `me`, `fetchActiveInstitutions` font des appels HTTP sans muter l'état d'auth : ils sont placés ici pour que la façade ait un point de délégation unique (R5.3). Le module reste sous la limite de taille (§5) ; sinon, extraction d'un `authApi.js` (appels HTTP) injecté dans le store (DIP, §1.6-D).
+
+### `src/services/api.js` — façade `auth` réécrite (fine)
+
+Chaque méthode délègue au store, appelé **à la volée** (décision B/D). Exemple de forme (illustratif, pas le code final) :
+
+```js
+import api from … // instance axios, default (déjà présent)
+import { useAuthStore } from '../stores/auth' // import top-level OK : auth.js n'importe pas la façade
+
+export const auth = {
+  login: (u, p) => useAuthStore().login(u, p),         // store appelé à la volée
+  logout: () => useAuthStore().logout(),
+  me: () => useAuthStore().me(),
+  getUser: () => useAuthStore().currentUser,
+  getMeta: () => useAuthStore().meta,
+  isAuthenticated: () => useAuthStore().isAuthenticated,
+  getUserRole: () => useAuthStore().userRole,
+  hasRole: (r) => roleHasRole(useAuthStore().currentUser, r),
+  isAdmin: () => useAuthStore().isAdmin,
+  isTeacher: () => useAuthStore().isTeacher,
+  isStudent: () => useAuthStore().isStudent,
+  isSupradmin: () => useAuthStore().isSupradmin,
+  getInstitution: () => useAuthStore().institutionSlug,
+  getInstitutionName: () => useAuthStore().institutionDisplayName,
+  setInstitution: (s) => useAuthStore().setInstitution(s),
+  getActiveInstitutions: () => useAuthStore().fetchActiveInstitutions(),
+}
+```
+
+> Note de chargement : `import { useAuthStore }` au top-level d'`api.js` est sûr (importer la **définition** d'un store n'appelle pas `getActivePinia`). Seul **l'appel** `useAuthStore()` requiert Pinia actif, d'où l'appel systématique dans le corps des méthodes.
+
+### `roles.js`, `cache.js` — inchangés
+
+`roles.js` : réutilisé tel quel (R2.2, aucune modif). `cache.js:10` : continue d'appeler `auth.getInstitution()` (façade) → délègue à `institutionSlug` du store (R8.1, même valeur qu'aujourd'hui).
+
+---
+
+## Data Models
+
+### Définitions des structures (annotées TypeScript pour clarté, code JS)
+
+```ts
+interface AuthMeta {
+  institution?: string         // slug tenant
+  institution_name?: string    // libellé tenant
+  [k: string]: unknown
+}
+
+interface AuthUser {
+  role?: string                // rôle BRUT backend (alias EN/FR), normalisé via roles.js
+  [k: string]: unknown         // forme exacte non figée côté front (NFR-2 : pas de modif backend)
+}
+
+interface AuthState {
+  user: AuthUser | null
+  token: string | null
+  institution: string | null
+  institutionName: string | null
+  meta: AuthMeta | null
+}
+
+// Réponse login backend (parité api.js:68-79, lecture seule)
+interface LoginResponse {
+  success: boolean
+  data?: { token: string; user: AuthUser }
+  meta?: AuthMeta
+}
+```
+
+### Clés de persistance `sessionStorage` (mécanisme unique)
+
+| Clé | Contenu | Écrite par | Lue par |
+| --- | --- | --- | --- |
+| `token` | `string` | `setSession` | `$hydrate`, intercepteur requête (via store) |
+| `user` | `JSON(AuthUser)` | `setSession` | `$hydrate` |
+| `meta` | `JSON(AuthMeta)` | `setSession` | `$hydrate` |
+| `institution` | `string` | `setSession`, `setInstitution` | `$hydrate` |
+
+> Clés identiques à l'existant (`api.js:71-78`) : pas de migration de données pour les sessions en cours. R3.3 : écriture et lecture au **même** emplacement (`sessionStorage`). La clé `localStorage('token')` lue par `visio.js:248` disparaît (R3.4).
+
+### Diagramme du modèle de données
+
+```mermaid
+classDiagram
+    class useAuthStore {
+        +user
+        +token
+        +institution
+        +institutionName
+        +meta
+        +isAuthenticated
+        +currentUser
+        +userRole
+        +normalizedRole
+        +isAdmin
+        +isSupradmin
+        +isTeacher
+        +isStudent
+        +institutionSlug
+        +login()
+        +logout()
+        +setSession()
+        +setInstitution()
+        +me()
+    }
+    class rolesModule {
+        +normalizeRole()
+        +isAdmin()
+        +isSupradmin()
+        +isTeacher()
+        +isStudent()
+        +hasRole()
+    }
+    class authFacade {
+        +login()
+        +logout()
+        +getUser()
+        +getInstitution()
+    }
+    useAuthStore ..> rolesModule : derive getters
+    authFacade ..> useAuthStore : delegue a la volee
+```
+
+---
+
+## Business Process
+
+### Processus 1 : Login
+
+```mermaid
+sequenceDiagram
+    participant C as Composant Login
+    participant F as Facade auth api.js
+    participant S as useAuthStore
+    participant AX as Instance axios api
+    participant BE as Backend
+    participant SS as sessionStorage
+
+    C->>F: auth.login(username, password)
+    F->>S: useAuthStore().login(...)
+    S->>AX: api.post auth login
+    AX->>BE: POST auth login
+    BE-->>AX: success data token user meta
+    AX-->>S: response
+    alt success et data
+        S->>S: setSession(data, meta)
+        S->>SS: setItem token user meta institution
+        S-->>S: getters reactifs recalcules
+    end
+    S-->>F: response
+    F-->>C: response
+```
+
+### Processus 2 : Logout
+
+```mermaid
+sequenceDiagram
+    participant C as Composant ou intercepteur 401
+    participant F as Facade auth
+    participant S as useAuthStore
+    participant SS as sessionStorage
+    participant CA as clearAllCache
+
+    C->>F: auth.logout()
+    F->>S: useAuthStore().logout()
+    S->>S: reset user token institution institutionName meta
+    S->>SS: removeItem token user meta institution
+    S->>CA: clearAllCache()
+    S-->>S: isAuthenticated false currentUser null
+    S-->>F: void
+    F-->>C: void
+```
+
+### Processus 3 : Intercepteurs axios (token requête + 401 réponse)
+
+```mermaid
+flowchart TD
+    A[Requete sortante] --> B[Intercepteur requete]
+    B --> C[useAuthStore appele a la volee]
+    C --> D{token present}
+    D -->|oui| E[Header Authorization Bearer token]
+    D -->|non| F[Aucun header Authorization]
+    E --> G[Envoi requete]
+    F --> G
+    G --> H{Reponse}
+    H -->|2xx| I[Retour response.data]
+    H -->|401| J[useAuthStore.logout purge state et storage]
+    J --> K{Sur page login}
+    K -->|non| L[Redirection vers login]
+    K -->|oui| M[Pas de redirection]
+```
+
+### Processus 4 : Hydratation au démarrage
+
+```mermaid
+flowchart TD
+    A[Chargement app] --> B[main.js app.use createPinia]
+    B --> C[Premier useAuthStore]
+    C --> D[hydrate lit sessionStorage]
+    D --> E{token present en storage}
+    E -->|oui| F[State reconstruit user token meta institution]
+    E -->|non| G[State vide isAuthenticated false]
+    F --> H[Getters reactifs prets]
+    G --> H
+```
+
+---
+
+## Error Handling
+
+> La refonte globale d'erreurs (#20) est hors périmètre (R13.1). On préserve le comportement existant et on applique le fail-secure.
+
+| Cas | Comportement | Exigence |
+| --- | --- | --- |
+| `login` HTTP échoue / `success === false` | l'action ne mute pas le state (pas de `setSession`) ; la réponse/erreur remonte à l'appelant comme aujourd'hui (`api.js:67-83`) | R5.4 |
+| `401` sur toute requête | intercepteur réponse → `useAuthStore().logout()` (purge state+storage) + redirection `/login` hors login ; **aucune donnée sensible journalisée** (parité `roles.js:178-181` / `logRoleDecision`) | R7.4, R11.4 |
+| Rôle `null` / inconnu | getters d'autorisation → `false` (fail-secure hérité de `roles.js`) | R2.3 |
+| `currentUser` sans utilisateur | renvoie `null` explicite, **jamais `{}`** | R4.3, R4.4 |
+| Token absent pour visio Beacon | la fonctionnalité visio gère explicitement (ne pas envoyer le Beacon, `console.warn`), **sans** storage de secours incohérent | R6.5 |
+| `sessionStorage` JSON corrompu à l'hydratation | `try/catch` autour du `JSON.parse` → state vide (déconnecté), pas de crash au boot | robustesse, parité tolérante `api.js:98-99` |
+| Pas de secret en clair | la façade et le store ne loggent ni token ni secret ; pas de secret embarqué | R11.2 |
+
+---
+
+## Testing Strategy
+
+Vitest installé (`package.json:9-11,57,66` ; #21). Tests unitaires écrits **avant** l'implémentation (TDD, skill production-grade). Isolation Pinia : `setActivePinia(createPinia())` en `beforeEach` ; `sessionStorage` simulé (jsdom, `package.json:61`) ou stub injecté ; appels HTTP `api` mockés (`vi.mock`).
+
+### Cas de test (`src/stores/__tests__/auth.spec.js`)
+
+| # | Scénario | Assertions | Exigence |
+| --- | --- | --- | --- |
+| T1 | `login` réussi | store peuplé (`user`, `token`, `role`, `institution`, `meta`) **et** `sessionStorage` écrit aux 4 clés | R10.2 |
+| T2 | `login` échec (`success:false`) | state inchangé, pas d'écriture storage | R5.4 |
+| T3 | `logout` | state + storage entièrement purgés, `clearAllCache` appelé (mock), `isAuthenticated===false`, `currentUser===null` | R10.3, R8.4 |
+| T4 | Getters autorisation dérivent de `roles.js` | alias (`teacher`→enseignant, `student`→etudiant, `superAdmin`→supradmin) reconnus ; rôle inconnu/`null`→`false` (fail-secure) ; `isAdmin` = admin\|supradmin | R10.4, R2.2, R2.5 |
+| T5 | **Régression #11** : token intercepteur ≡ token login | après `login`, le token lu par le store (que lit l'intercepteur) est **identique** à celui écrit ; aucun accès `localStorage` | R10.5 |
+| T6 | **Bug `user`** | après `login`, `currentUser` = l'utilisateur (jamais `{}`) ; sans login, `currentUser===null` | R10.6, R4.3, R4.4 |
+| T7 | Hydratation | `sessionStorage` pré-rempli → nouveau store hydraté → `isAuthenticated===true`, `currentUser` correct | E, R3 |
+| T8 | `setInstitution` | met à jour `institutionSlug` + `sessionStorage['institution']` | R8.3 |
+| T9 | Réactivité | un `computed`/watch sur `isAuthenticated` réagit à `login`/`logout` sans rechargement | R9.1, R9.2 |
+| T10 | Façade délègue | `auth.getUser()`/`auth.getInstitution()` renvoient les valeurs du store (LSP : façade substituable au store du point de vue appelant) | R5.2, R5.3 |
+
+### Tests de non-régression hors store (manuels/ciblés)
+
+- Migration des 6 lecteurs `localStorage('user')` (R4.2) et des 6 lecteurs de token visio (R6) : vérifier qu'aucun `localStorage.getItem('user')` ni `sessionStorage.getItem('token')` direct ne subsiste à ces emplacements (grep de contrôle).
+
+---
+
+## Mapping de migration (12 fichiers)
+
+> R4 (user) + R6 (token visio). Les autres consommateurs de la façade (~30 fichiers) restent inchangés (décision B).
+
+### Token (R6) — lire depuis le store, plus de storage direct
+
+| Fichier:ligne | Avant | Après |
+| --- | --- | --- |
+| `src/stores/visio.js:248` | `localStorage.getItem('token')` | `useAuthStore().token` (si `null` → ne pas envoyer Beacon, R6.5) |
+| `src/composables/useVisioParticipation.js:223` | `sessionStorage.getItem('token')` | `useAuthStore().token` |
+| `src/components/visio/ParticipantsModal.vue:429,478` | `sessionStorage.getItem('token')` | `useAuthStore().token` |
+| `src/components/visio/VisioManager.vue:398` | `sessionStorage.getItem('token')` | `useAuthStore().token` |
+| `src/views/attendance/SeanceAttendanceHistory.vue:537,586` | `sessionStorage.getItem('token')` | `useAuthStore().token` |
+| `src/services/api.js:28` (intercepteur) | `sessionStorage.getItem('token')` | `useAuthStore().token` à la volée (décision D) |
+
+### User (R4) — lire `currentUser` du store, plus de `localStorage('user')`
+
+| Fichier:ligne | Avant | Après |
+| --- | --- | --- |
+| `src/stores/visio.js:347` | `JSON.parse(localStorage.getItem('user') \|\| '{}')` | `useAuthStore().currentUser` |
+| `src/views/TeacherSeances.vue:357` | idem | `useAuthStore().currentUser` |
+| `src/views/student/StudentSchedule.vue:34` | idem (`ref(...)`) | `computed(() => useAuthStore().currentUser)` (réactif, R9.3) |
+| `src/views/teacher/TeacherSchedule.vue:36` | idem (`ref(...)`) | `computed(() => useAuthStore().currentUser)` |
+| `src/views/ForumTopic.vue:199` | idem (Options API) | `this.currentUser = useAuthStore().currentUser` (store hors `<script setup>` : `useAuthStore()` dans `created`) |
+| `src/views/coordinateur/SeanceManagement.vue:309` | idem | `useAuthStore().currentUser` |
+
+> Note `visio.js` (store qui lit un autre store) : `useAuthStore()` est appelé **dans** l'action `handleTeacherExit`/`sendLeaveVisioBeacon` (à la volée), jamais au setup du store visio, pour rester robuste à l'ordre d'init.
+
+---
+
+## Dette tracée
+
+| ID | Dette | Risque | Échéance |
+| --- | --- | --- | --- |
+| #19-D1 | `sessionStorage` reste accessible au JS (atténuation XSS partielle, pas cookie `HttpOnly`). | Token lisible si XSS. Mitigé : pas de `localStorage`, session courte (onglet). | Cible long terme #2/#6 : cookie `HttpOnly`/`SameSite` (nécessiterait **modif backend**, hors périmètre NFR-2). Tracé, non payé ici. |
+| #19-D2 | Comparaisons brutes `role === 'enseignant'` résiduelles hors des 12 fichiers migrés (#18-FE-2). | Incohérence de normalisation. | Hors périmètre R13.2 ; migration globale ultérieure. |
+| #19-D3 | Forme de `AuthUser` non typée strictement (pas de schéma figé front). | Champs backend non garantis. | Acceptable : NFR-2 interdit toute modif backend ; le store ne raisonne que sur `role` (normalisé via `roles.js`). |
+
+---
+
+## Conformité PRODUCTION_STANDARDS
+
+| Règle | Application | Preuve |
+| --- | --- | --- |
+| §1.1 / §5 Zero God Code (≤300 l.) | `auth.js` focalisé (state + getters + ~6 actions courtes). Si débordement → extraction `authApi.js` (appels HTTP) injecté (DIP). | Conception dimensionnée ; contrôle au commit |
+| §1.2 Sécurité | Token **jamais** en `localStorage` (R3.2/R11.1) ; aucun secret en clair (R11.2) ; pas de log de donnée sensible au 401 (R11.4) | `roles.js:178-181` réutilisé |
+| §1.6-S SRP | Store = une raison de changer (l'état d'auth) ; façade = adaptation de compat ; rôle = `roles.js` | — |
+| §1.6-D DIP | Le store **dérive** la logique de rôle de `roles.js` (abstraction unique), n'instancie aucune logique d'autorisation en propre | R2.2 |
+| §1.6-L LSP | La façade `auth` est substituable au store du point de vue des 88 appelants ; le store est mockable en test (T1-T10) | R5.3, T10 |
+| §1.6-O OCP | Nouveaux comportements via getters/actions ajoutés, pas en éditant les consommateurs | décision B |
+| §6 Une seule solution | Décisions A-E : une option tranchée chacune, justifiée par lecture du code | section « Décisions tranchées » |
+| NFR-2 / R12.3 | Aucune modification backend (tout est côté front + storage navigateur) | — |
+
+---
+
+## Traçabilité Design → Requirements
+
+| Exigence | Couverte par |
+| --- | --- |
+| R1 (store source de vérité) | State, Actions, décision C |
+| R2 (getters dérivés `roles.js`) | Getters, T4 |
+| R3 (persistance unique) | Décision A, Clés `sessionStorage`, T1/T7 |
+| R4 (bug `user`) | Getter `currentUser`, Mapping user, T6 |
+| R5 (API `auth` préservée) | Décision B, Façade, T10 |
+| R6 (visio token/user via store) | Mapping token, décision D, T5 |
+| R7 (intercepteur via store) | Décision D, Processus 3 |
+| R8 (multi-tenant + purge logout) | `institutionSlug`, `setInstitution`, `logout`, T3/T8 |
+| R9 (réactivité) | Getters Pinia, Processus 1/2, T9 |
+| R10 (tests Vitest) | Testing Strategy T1-T10 |
+| R11 (sécurité non-fonctionnelle) | Décision A (compromis), Error Handling, Dette #19-D1 |
+| R12 (conception/structure) | Conformité PRODUCTION_STANDARDS |
+| R13 (hors périmètre) | Overview « ce que ce design ne fait PAS », Dette #19-D2 |

--- a/.claude/specs/auth-store/requirements.md
+++ b/.claude/specs/auth-store/requirements.md
@@ -1,0 +1,200 @@
+# Requirements Document — Store d'authentification Pinia (`useAuthStore`)
+
+## Introduction
+
+Cette fonctionnalité crée un **store Pinia unique d'authentification** (`useAuthStore`) pour le frontend Vue 3 (`lms-frontend`), afin de centraliser tout l'état d'authentification (`user`, `token`, `role` brut + normalisé, `institution`, `institutionName`, `meta`) et de mettre fin à l'accès dispersé et **incohérent** au storage navigateur.
+
+Il s'agit de l'issue GitHub **#19**, classée **TIER 0 CRITICAL** de la roadmap d'audit (épique **#16**). Elle recoupe les issues **#2** et **#6** (token en `localStorage` = risque XSS) et **#11** (token lu depuis `localStorage` dans les composants visio).
+
+### Contexte vérifié sur le code réel (grep, 2026-06-14)
+
+Treize emplacements répartis sur douze fichiers accèdent au storage d'authentification. Deux familles de défauts confirmées :
+
+**Incohérence du token (`sessionStorage` vs `localStorage`)** — vérifiée par grep :
+
+| Fichier | Emplacement | Storage lu/écrit |
+| --- | --- | --- |
+| `src/services/api.js` | l.28 (intercepteur, lecture), l.71 (login, écriture), l.51/86 (logout, suppression) | **`sessionStorage`** |
+| `src/stores/visio.js` | l.248 (`sendLeaveVisioBeacon`, lecture token) | **`localStorage`** (incohérent — l'intercepteur écrit en `sessionStorage`, donc ce token y est probablement absent/périmé) |
+| `src/composables/useVisioParticipation.js` | l.223 (`sendLeaveVisioBeacon`, lecture token) | `sessionStorage` (contourne `api.js`) |
+| `src/components/visio/ParticipantsModal.vue` | l.429, l.478 (lecture token) | `sessionStorage` (contourne `api.js`) |
+| `src/components/visio/VisioManager.vue` | l.398 (lecture token) | `sessionStorage` (contourne `api.js`) |
+| `src/views/attendance/SeanceAttendanceHistory.vue` | l.537, l.586 (lecture token) | `sessionStorage` (contourne `api.js`) |
+
+**Bug latent `user` (`sessionStorage` vs `localStorage`)** — vérifié par grep :
+
+- `api.js` **écrit** `user` en `sessionStorage` (l.72) et le **lit** en `sessionStorage` (`getUser`, l.98).
+- Mais **6 emplacements lisent `user` en `localStorage`** (clé que `api.js` ne remplit jamais), où `JSON.parse(localStorage.getItem('user') || '{}')` vaut donc probablement `{}` (bug réel) :
+  - `src/stores/visio.js:347` (`handleTeacherExit`)
+  - `src/views/TeacherSeances.vue:357`
+  - `src/views/student/StudentSchedule.vue:34`
+  - `src/views/teacher/TeacherSchedule.vue:36`
+  - `src/views/ForumTopic.vue:199`
+  - `src/views/coordinateur/SeanceManagement.vue:309`
+
+> Correction du contexte d'entrée : la lecture de `localStorage('user')` concerne **6 emplacements** (1 store visio + 5 vues), pas 5. Confirmé par grep le 2026-06-14.
+
+### État existant vérifié
+
+- **Pinia est déjà configuré** : `src/main.js:2` (`import { createPinia }`), l.43 (`app.use(createPinia())`). Un store existe déjà : `src/stores/visio.js` (`useVisioStore`, `defineStore` en style composition).
+- Le bloc `auth` de `api.js` expose déjà une API publique large, consommée par **88 occurrences dans 32 fichiers** (grep confirmé) : `login`, `logout`, `me`, `getUser`, `getMeta`, `isAuthenticated`, `getUserRole`, `getInstitution`, `getInstitutionName`, `setInstitution`, `getActiveInstitutions`, `hasRole`, `isAdmin`, `isTeacher`, `isStudent`, `isSupradmin`.
+- `src/constants/roles.js` (livré en #18) fournit `normalizeRole`, `hasRole`, `isAdmin`, `isSupradmin`, `isTeacher`, `isStudent`, `isAdminScope`, `getDashboardRoute`, `getRoleDisplayName`, `canActivate`. Les getters d'autorisation du store **doivent en dériver** (ne pas réimplémenter la logique de rôle). `api.js` délègue déjà à ce module depuis #18.
+- **Vitest est installé** (#21). Le store doit être testable en isolation (`setActivePinia` / `createTestingPinia`).
+- `src/services/cache.js:10` lit `auth.getInstitution() || 'default'` pour scoper le cache par tenant : le store doit préserver cette capacité.
+- **Hors périmètre confirmé** : `src/views/student/StudentSettings.vue:233/239` utilise `localStorage('userPreferences')`, qui est une **préférence UI** et non de l'état d'auth — à ne pas confondre avec ce store.
+
+### Décisions laissées au design (le présent document pose le QUOI, pas le COMMENT)
+
+Le document de conception tranchera : (a) le mécanisme exact de persistance (`sessionStorage` confirmé ? plugin de persistance Pinia ou écriture manuelle ?) ; (b) façade fine `api.js` *vs* migration des appelants vers le store ; (c) si le store **remplace** le bloc `auth` de `api.js` ou **coexiste** avec lui.
+
+---
+
+## Requirements
+
+### Requirement 1 — Store Pinia unique, source de vérité de l'état d'auth
+
+**User Story:** En tant que développeur frontend, je veux un store Pinia unique `useAuthStore` qui détient tout l'état d'authentification, afin de disposer d'une source de vérité unique au lieu d'accès dispersés au storage.
+
+#### Acceptance Criteria
+
+1. WHERE le module `src/stores/auth.js` est défini, le store `useAuthStore` SHALL être créé via `defineStore` (cohérent avec le style du store existant `src/stores/visio.js`).
+2. WHERE le store `useAuthStore` expose son état, il SHALL contenir au minimum : `user`, `token`, `role` (rôle brut tel que reçu du backend), `institution` (slug), `institutionName`, et `meta`.
+3. WHERE le store expose un rôle, il SHALL fournir à la fois le rôle **brut** (tel que renvoyé par le backend dans `data.user.role`) et le rôle **normalisé** dérivé via `normalizeRole` de `src/constants/roles.js`.
+4. WHERE le store expose des comportements, il SHALL fournir les actions `login`, `logout`, `setSession`, et `setInstitution`.
+5. WHEN un composant ou un service a besoin de l'état d'authentification, THEN il SHALL pouvoir l'obtenir depuis `useAuthStore` sans lire directement `localStorage` ni `sessionStorage`.
+
+### Requirement 2 — Getters dérivés, autorisation déléguée à `roles.js`
+
+**User Story:** En tant que développeur frontend, je veux des getters d'authentification et d'autorisation exposés par le store, afin de prendre des décisions d'accès cohérentes sans réimplémenter la logique de rôle.
+
+#### Acceptance Criteria
+
+1. WHERE le store expose des getters d'état, il SHALL fournir `isAuthenticated`, `currentUser`, et `userRole` (rôle brut).
+2. WHERE le store expose des getters d'autorisation (`isAdmin`, `isSupradmin`, `isTeacher`, `isStudent`), ils SHALL être **dérivés** des fonctions correspondantes de `src/constants/roles.js` et NE SHALL PAS réimplémenter de comparaison de chaîne de rôle.
+3. WHEN le rôle de l'utilisateur est inconnu, `null`, ou non reconnu par la table d'alias de `roles.js`, THEN tout getter d'autorisation SHALL renvoyer `false` (comportement fail-secure, conforme à `roles.js`).
+4. WHEN l'état `user` ou `token` du store change (login/logout/`setSession`), THEN `isAuthenticated`, `currentUser` et les getters d'autorisation SHALL refléter immédiatement la nouvelle valeur (réactivité Pinia).
+5. WHERE le périmètre admin strict est évalué (`isAdmin`), il SHALL rester aligné sur le backend (`admin | supradmin`) tel que déjà implémenté par `roleIsAdmin`.
+
+### Requirement 3 — Mécanisme de persistance unique et cohérent
+
+**User Story:** En tant qu'ingénieur sécurité/mainteneur, je veux un mécanisme de persistance unique du token et de l'état d'auth, afin d'éliminer l'accès mixte `localStorage`/`sessionStorage` actuel et de réduire la surface XSS.
+
+#### Acceptance Criteria
+
+1. WHERE le store persiste l'état d'authentification, il SHALL utiliser **un seul et unique mécanisme de persistance** (le design tranche le mécanisme exact).
+2. WHERE le token est persisté, il NE SHALL PAS être écrit dans `localStorage` (atténuation du risque XSS, recoupe #2 et #6).
+3. WHEN le token est persisté puis relu, THEN l'emplacement d'écriture et l'emplacement de lecture SHALL être identiques (plus aucun mismatch `localStorage` écrit / `localStorage` lu vs `sessionStorage`).
+4. WHERE le code accède au token d'authentification après cette fonctionnalité, il NE SHALL PAS exister d'accès direct au token mêlant `localStorage` et `sessionStorage` (les incohérences `visio.js:248` en `localStorage` vs `api.js` en `sessionStorage` SHALL être supprimées).
+5. WHERE le compromis du mécanisme retenu (par ex. `sessionStorage` = pas de persistance multi-onglets, perte au refresh selon le mécanisme) existe, il SHALL être documenté comme choix de sécurité assumé.
+
+### Requirement 4 — Correction du bug `user` lu en `localStorage`
+
+**User Story:** En tant qu'utilisateur, je veux que mon profil (`currentUser`) soit toujours correctement résolu dans les vues, afin de ne plus subir d'écrans qui le considèrent vide à cause d'une mauvaise clé de storage.
+
+#### Acceptance Criteria
+
+1. WHERE un composant ou un store lit l'utilisateur courant, il SHALL l'obtenir depuis `useAuthStore` et NE SHALL PAS exécuter `JSON.parse(localStorage.getItem('user') || '{}')`.
+2. WHEN les 6 emplacements identifiés (`src/stores/visio.js:347`, `src/views/TeacherSeances.vue:357`, `src/views/student/StudentSchedule.vue:34`, `src/views/teacher/TeacherSchedule.vue:36`, `src/views/ForumTopic.vue:199`, `src/views/coordinateur/SeanceManagement.vue:309`) sont migrés, THEN aucun d'eux NE SHALL lire `user` depuis `localStorage`.
+3. WHEN un utilisateur est authentifié et qu'un composant lit `currentUser` via le store, THEN la valeur retournée NE SHALL PAS être un objet vide `{}` causé par une erreur de clé ou de storage.
+4. IF aucun utilisateur n'est authentifié, THEN `currentUser` SHALL renvoyer une valeur d'absence explicite et cohérente (`null`), et non un objet `{}` ambigu.
+
+### Requirement 5 — Préservation de l'API publique `auth` (pas de régression)
+
+**User Story:** En tant que mainteneur, je veux que les 88 appels existants à l'API `auth.*` continuent de fonctionner, afin que l'introduction du store ne casse aucun des 32 fichiers consommateurs.
+
+#### Acceptance Criteria
+
+1. WHERE le bloc `auth` de `api.js` est consommé (88 occurrences dans 32 fichiers, grep 2026-06-14), l'ensemble des méthodes publiques actuelles (`login`, `logout`, `me`, `getUser`, `getMeta`, `isAuthenticated`, `getUserRole`, `getInstitution`, `getInstitutionName`, `setInstitution`, `getActiveInstitutions`, `hasRole`, `isAdmin`, `isTeacher`, `isStudent`, `isSupradmin`) SHALL rester appelables avec une sémantique inchangée OU les appelants SHALL être migrés vers le store sans perte de comportement (le design tranche entre façade et migration).
+2. WHEN un appelant existant invoque une méthode de l'API publique `auth`, THEN le résultat SHALL provenir (directement ou indirectement) du store comme source de vérité unique.
+3. WHERE l'API publique `auth` est conservée comme façade, elle SHALL être une façade fine déléguant au store et NE SHALL PAS dupliquer la logique d'état ou de rôle.
+4. WHEN la fonctionnalité est livrée, THEN aucun fichier consommateur ne SHALL voir son comportement d'authentification régresser par rapport au comportement correct attendu (les comportements actuellement *bogués*, ex. lecture `localStorage('user')`, étant corrigés et non préservés).
+
+### Requirement 6 — Visio : token et user lus via le store
+
+**User Story:** En tant qu'utilisateur d'une séance visio, je veux que les fonctionnalités visio lisent le token et l'utilisateur depuis le store, afin que la visioconférence ne tombe plus en panne à cause d'un token absent/périmé (issue #11).
+
+#### Acceptance Criteria
+
+1. WHERE `src/stores/visio.js` lit le token (l.248) ou l'utilisateur (l.347), il SHALL obtenir ces valeurs depuis `useAuthStore` et NE SHALL PAS lire `localStorage`/`sessionStorage` directement.
+2. WHERE `src/composables/useVisioParticipation.js` lit le token (l.223), il SHALL l'obtenir depuis `useAuthStore`.
+3. WHERE les composants visio `src/components/visio/ParticipantsModal.vue` (l.429, l.478), `src/components/visio/VisioManager.vue` (l.398), et la vue `src/views/attendance/SeanceAttendanceHistory.vue` (l.537, l.586) lisent le token, ils SHALL l'obtenir depuis `useAuthStore`.
+4. WHEN une fonctionnalité visio a besoin du token (y compris pour l'API Beacon de `sendLeaveVisioBeacon`), THEN le token fourni SHALL être celui détenu par le store, garantissant la cohérence avec le token utilisé par l'intercepteur axios.
+5. WHEN le token est requis mais absent du store, THEN la fonctionnalité visio SHALL gérer ce cas explicitement (comportement existant : ne pas envoyer le Beacon, journaliser) sans accéder à un storage de secours incohérent.
+
+### Requirement 7 — Intercepteur axios lit le token depuis le store
+
+**User Story:** En tant que développeur frontend, je veux que l'intercepteur axios lise le token depuis le store, afin que tout le code utilise une abstraction unique du stockage du token.
+
+#### Acceptance Criteria
+
+1. WHERE l'intercepteur de requête axios de `api.js` (l.26-37) attache l'en-tête `Authorization`, il SHALL obtenir le token depuis `useAuthStore` (directement ou via la façade) et NE SHALL PAS lire `sessionStorage.getItem('token')` en direct.
+2. WHEN une requête sortante est émise et qu'un token existe dans le store, THEN l'intercepteur SHALL ajouter l'en-tête `Authorization: Bearer <token>`.
+3. WHEN une requête sortante est émise et qu'aucun token n'existe dans le store, THEN l'intercepteur NE SHALL PAS ajouter d'en-tête `Authorization`.
+4. WHEN une réponse `401` est reçue (intercepteur de réponse, l.49-59), THEN le store SHALL être purgé de son état d'authentification (le storage suivant le store), conservant le comportement de redirection vers `/login` hors page de login.
+
+### Requirement 8 — Multi-tenant et purge complète au logout
+
+**User Story:** En tant qu'utilisateur multi-tenant, je veux que le slug d'institution reste disponible pour scoper le cache et que la déconnexion purge tout, afin d'éviter toute fuite de données entre tenants ou entre sessions.
+
+#### Acceptance Criteria
+
+1. WHERE `src/services/cache.js:10` appelle `auth.getInstitution() || 'default'` pour scoper le cache par tenant, la résolution du slug d'institution SHALL rester fonctionnelle via le store (directement ou via la façade), retournant la même valeur qu'aujourd'hui pour une session donnée.
+2. WHEN `login` réussit et que `meta.institution` est présent, THEN le store SHALL exposer ce slug via son getter d'institution.
+3. WHEN `setInstitution(slug)` est invoqué, THEN le store SHALL mettre à jour le slug d'institution courant et le persister selon le mécanisme unique retenu.
+4. WHEN `logout` est invoqué, THEN le store SHALL purger l'intégralité de son état d'auth (`user`, `token`, `role`, `institution`, `institutionName`, `meta`), purger le storage persistant correspondant, ET invoquer `clearAllCache()` (comportement actuel de `api.js` l.90).
+5. WHEN `logout` est terminé, THEN `isAuthenticated` SHALL renvoyer `false` et `currentUser` SHALL renvoyer `null`.
+
+### Requirement 9 — Réactivité de l'état d'authentification
+
+**User Story:** En tant qu'utilisateur, je veux que l'interface réagisse immédiatement à ma connexion et à ma déconnexion, afin de ne pas voir d'état d'authentification périmé qui nécessiterait un rechargement.
+
+#### Acceptance Criteria
+
+1. WHEN `login` peuple le store, THEN tout composant lisant l'état d'auth via le store SHALL observer la mise à jour de manière réactive, sans rechargement de page.
+2. WHEN `logout` purge le store, THEN tout composant lisant l'état d'auth via le store SHALL observer le passage à l'état non authentifié de manière réactive.
+3. WHERE l'état d'auth est consommé dans un composant Vue, il SHALL l'être via les getters réactifs du store (et non via une lecture ponctuelle de storage brut qui ne déclenche aucune réactivité).
+
+### Requirement 10 — Tests Vitest du store et des régressions
+
+**User Story:** En tant que mainteneur, je veux une couverture de tests unitaires du store, afin de garantir la non-régression des bugs corrigés (#11, bug `user`) et le comportement attendu de l'authentification.
+
+#### Acceptance Criteria
+
+1. WHERE le store est testé, il SHALL l'être en isolation avec Pinia (`setActivePinia(createPinia())` ou `createTestingPinia`), sans dépendance à un navigateur réel.
+2. WHEN un test simule un `login` réussi, THEN il SHALL vérifier que le store est peuplé (`user`, `token`, `role`, `institution`, `meta`) ET que l'état est persisté selon le mécanisme retenu.
+3. WHEN un test simule un `logout`, THEN il SHALL vérifier que le store et le storage sont entièrement purgés, que `clearAllCache` est invoqué, que `isAuthenticated === false` et `currentUser === null`.
+4. WHERE les getters d'autorisation sont testés, ils SHALL être vérifiés comme dérivant de `src/constants/roles.js` (y compris la normalisation d'alias et le fail-secure sur rôle inconnu).
+5. WHEN un test reproduit le scénario de l'issue #11, THEN il SHALL vérifier que le token lu par l'intercepteur axios est **identique** au token écrit au login (plus aucun mismatch `localStorage`/`sessionStorage`).
+6. WHEN un test reproduit le bug `user`, THEN il SHALL vérifier que `currentUser` n'est jamais `{}` par erreur de clé/storage, mais bien l'utilisateur authentifié (ou `null` si non authentifié).
+
+### Requirement 11 — Exigences de sécurité (non fonctionnelles)
+
+**User Story:** En tant qu'ingénieur sécurité, je veux que le store respecte les standards de sécurité de l'audit, afin de réduire l'exposition du token et des secrets côté client (issues #2, #6 ; PRODUCTION_STANDARDS §1.6).
+
+#### Acceptance Criteria
+
+1. WHERE le token d'authentification est stocké, il NE SHALL PAS l'être dans `localStorage`.
+2. WHERE le code du store et de sa façade est livré, il NE SHALL PAS exposer de secret en clair (clé API, mot de passe, secret de signature) côté client.
+3. WHERE le mécanisme de persistance retenu implique un compromis (par ex. `sessionStorage` : absence de persistance multi-onglets et perte de session au rechargement complet selon le mécanisme), ce compromis SHALL être documenté explicitement comme décision de sécurité assumée.
+4. WHEN une erreur d'authentification (`401`) survient, THEN aucune donnée d'auth sensible NE SHALL être journalisée (cohérent avec `logRoleDecision` de `roles.js` qui exclut nom et email, et avec la désactivation des `console.log` en production, #15).
+
+### Requirement 12 — Exigences non fonctionnelles de conception et de structure
+
+**User Story:** En tant que mainteneur, je veux que le store respecte les standards de production du projet, afin de garder une base maintenable et conforme à `CONTRIBUTING` et `PRODUCTION_STANDARDS`.
+
+#### Acceptance Criteria
+
+1. WHERE le store est conçu, il SHALL respecter PRODUCTION_STANDARDS §1.6 (SOLID/DIP) : le store est la source de vérité, les helpers de rôle sont injectés/dérivés depuis `roles.js` (pas de duplication de logique d'autorisation).
+2. WHERE le store et la façade sont dimensionnés, ils SHALL respecter les limites de taille de PRODUCTION_STANDARDS §5 (store/service focalisés, pas de god-module) ; si une responsabilité déborde, elle SHALL être extraite.
+3. WHERE des modifications sont apportées, elles NE SHALL PAS toucher au backend (aucune modification backend autorisée).
+4. WHERE le code est livré, il SHALL respecter les conventions de `CONTRIBUTING` du dépôt.
+
+### Requirement 13 — Périmètre exclu (hors scope explicite)
+
+**User Story:** En tant que mainteneur, je veux que le périmètre de cette fonctionnalité soit délimité sans ambiguïté, afin d'éviter le glissement de périmètre vers d'autres issues.
+
+#### Acceptance Criteria
+
+1. WHERE la refonte de la gestion d'erreurs est concernée (issue #20), elle SHALL être considérée hors périmètre de cette fonctionnalité.
+2. WHERE des comparaisons de rôle brutes résiduelles `role === '...'` subsistent dans les vues (dette #18-FE-2), leur migration complète SHALL être considérée hors périmètre (sauf pour les emplacements directement modifiés par les exigences 4 et 6).
+3. WHERE `src/views/student/StudentSettings.vue:233/239` utilise `localStorage('userPreferences')`, cela SHALL être reconnu comme une préférence UI et NON comme de l'état d'auth, donc hors périmètre de ce store.

--- a/.claude/specs/auth-store/tasks.md
+++ b/.claude/specs/auth-store/tasks.md
@@ -1,0 +1,122 @@
+# Plan d'implémentation — Store d'authentification Pinia (`useAuthStore`)
+
+> Issue **#19** (TIER 0 CRITICAL, épique #16). Conforme à `requirements.md` et `design.md` (approuvés).
+> Aucune modification backend (R12.3 / NFR-2). Aucune tâche non technique.
+> TDD via Vitest (#21) : les tests T1-T10 du store sont écrits AVANT/AVEC l'implémentation (rouge → vert).
+>
+> **Ordre imposé par le design** (dépendances de fichiers) :
+> 1. Tests Vitest du store (rouge) → 2. Store `auth.js` (vert) → 3. Façade `api.js` → 4. Intercepteurs `api.js` → 5. Token visio (R6) → 6. User (R4) → 7. Vérification finale.
+>
+> **Conflits de fichiers (séquentiel obligatoire)** :
+> - `src/services/api.js` : touché par les tâches **3** (façade) puis **4** (intercepteurs) → enchaîner, ne pas paralléliser.
+> - `src/stores/visio.js` : touché par les tâches **5** (token l.248) puis **6** (user l.347) → enchaîner.
+
+---
+
+- [x] 1. Écrire les tests Vitest du store (TDD — phase ROUGE)
+  - Créer `src/stores/__tests__/auth.spec.js` couvrant les 10 scénarios T1-T10 du design (section Testing Strategy). À ce stade `src/stores/auth.js` n'existe pas encore → la suite DOIT échouer (rouge), prouvant que les tests exercent bien le code à venir.
+  - Mise en place de l'isolation : `beforeEach(() => setActivePinia(createPinia()))` ; simuler `sessionStorage` via jsdom (`environment: jsdom`, déjà dans la config Vitest #21) et le réinitialiser entre tests (`sessionStorage.clear()`).
+  - Mocker l'instance axios `api` (default export de `@/services/api`) via `vi.mock('@/services/api', ...)` pour contrôler la réponse de `POST /auth/login`, `GET /auth/me`, `GET /institutions/active` sans réseau réel. Mocker `clearAllCache` de `@/services/cache` (`vi.mock`) pour T3.
+  - T1 (login réussi, R10.2) : après `login`, le store est peuplé (`user`, `token`, `userRole`, `institutionSlug`, `meta`) ET `sessionStorage` contient les 4 clés (`token`, `user`, `meta`, `institution`).
+  - T2 (login échec `success:false`, R5.4) : state inchangé (toujours vide), aucune écriture `sessionStorage`.
+  - T3 (logout, R10.3/R8.4) : state + storage entièrement purgés (4 `removeItem`), `clearAllCache` appelé (mock asserté), `isAuthenticated === false`, `currentUser === null`.
+  - T4 (getters d'autorisation dérivés de `roles.js`, R10.4/R2.2/R2.5) : alias reconnus (`teacher`→enseignant, `student`→etudiant, `superAdmin`→supradmin) ; rôle inconnu/`null` → tous les getters d'autorisation `false` (fail-secure) ; `isAdmin` vrai pour `admin` ET `supradmin` uniquement.
+  - T5 (régression #11, R10.5) : après `login`, `useAuthStore().token` (ce que lit l'intercepteur) est **identique** au token reçu en réponse ; aucun accès `localStorage` simulé n'est requis pour le retrouver.
+  - T6 (bug `user`, R10.6/R4.3/R4.4) : après `login`, `currentUser` égale l'utilisateur (jamais `{}`) ; sans login, `currentUser === null`.
+  - T7 (hydratation, décision E / R3) : pré-remplir `sessionStorage` (token/user/meta/institution), instancier un nouveau store, appeler `$hydrate` → `isAuthenticated === true`, `currentUser` correct, `institutionSlug` correct.
+  - T8 (`setInstitution`, R8.3) : met à jour `institutionSlug` ET `sessionStorage.getItem('institution')`.
+  - T9 (réactivité, R9.1/R9.2) : un `computed(() => store.isAuthenticated)` (ou `watch`) reflète `login` puis `logout` sans rechargement.
+  - T10 (façade délègue, R5.2/R5.3) : importer la façade `auth` de `@/services/api`, appeler `auth.getUser()` / `auth.getInstitution()` après un `login` du store et vérifier qu'elles renvoient les valeurs du store. (Ce test passera complètement après la tâche 3 ; à l'étape 1 il peut être marqué `it.todo`/`it.skip` documenté, puis activé.)
+  - Critère de complétion : `npm run test -- src/stores/__tests__/auth.spec.js` s'exécute et **échoue** (module `auth.js` introuvable / store absent) ; la structure des 10 cas est en place.
+  - _Requirements: R10.1, R10.2, R10.3, R10.4, R10.5, R10.6_ ; _Design: Testing Strategy (T1-T10), décisions A/E_
+
+- [x] 2. Implémenter le store `src/stores/auth.js` (TDD — phase VERTE)
+  - Créer `src/stores/auth.js` avec `useAuthStore` en `defineStore('auth', () => { ... })` (style composition, cohérent `visio.js:18`, R1.1). Au top-level, importer UNIQUEMENT l'instance axios `default` de `@/services/api` (`import api from '@/services/api'`) et les helpers de `@/constants/roles` + `clearAllCache` de `@/services/cache`. NE PAS appeler `useAuthStore()` au top-level (anti-cycle ESM, décision C/D).
+  - **State (R1.2)** : `user` (`ref(null)`), `token` (`ref(null)`), `institution` (`ref(null)`), `institutionName` (`ref(null)`), `meta` (`ref(null)`). `role` n'est PAS un champ d'état dupliqué : il est exposé comme getter dérivé de `user.role` (design Data Models, note §189).
+  - **Getters (réactifs, R2.4/R9)** : `isAuthenticated` = `!!token` ; `currentUser` = `user ?? null` (JAMAIS `{}`, R4.4) ; `userRole` = `user?.role ?? null` (brut, R2.1) ; `normalizedRole` = `normalizeRole(user?.role)` (R1.3) ; `isAdmin`/`isSupradmin`/`isTeacher`/`isStudent` dérivés des fonctions homonymes de `@/constants/roles` (R2.2, fail-secure hérité R2.3) ; `institutionSlug` = `meta?.institution ?? institution ?? null` (parité `api.js:137-140`, R8.1/R8.2) ; `institutionDisplayName` = `meta?.institution_name ?? null` (parité `api.js:143-146`).
+  - **Actions** : `setSession(data, meta)` peuple `user`/`token` (+ `meta`/`institution`/`institutionName` si `meta`) et écrit `sessionStorage` (clés `token`, `user`, `meta`, `institution`) ; `setInstitution(slug)` met à jour `institution` + `sessionStorage['institution']` (parité `api.js:159-161`, R8.3) ; `login(username, password)` fait `POST /auth/login` via `api`, si `success && data` → `setSession(data, meta)`, retourne la réponse brute (parité `api.js:67-83`, R1.4/R5.2) ; `logout()` purge tout le state + `removeItem` des 4 clés + `clearAllCache()` (R8.4/R8.5/R7.4) ; `me()` = `GET /auth/me` via `api` (parité `api.js:93-95`) ; `fetchActiveInstitutions()` = `GET /institutions/active` (parité `api.js:154-156`) ; `$hydrate()` lit `sessionStorage` et reconstruit le state initial, avec `try/catch` autour des `JSON.parse` (JSON corrompu → state vide, pas de crash au boot — design Error Handling §440).
+  - Respecter la limite de taille PRODUCTION_STANDARDS §5 (≤ ~300 l.) ; si débordement, extraire les appels HTTP dans un `authApi.js` injecté (DIP) — sinon conserver inline.
+  - Critère de complétion : `npm run test -- src/stores/__tests__/auth.spec.js` passe **tous** les cas T1-T9 au vert (T10 dépend de la tâche 3) ; aucun `useAuthStore()` au top-level (`grep -n "useAuthStore()" src/stores/auth.js` ne retourne que des appels dans le corps des actions, le cas échéant).
+  - _Requirements: R1.1, R1.2, R1.3, R1.4, R2.1, R2.2, R2.3, R2.4, R2.5, R3, R4.3, R4.4, R8.1, R8.2, R8.3, R8.4, R8.5, R9_ ; _Design: décisions A/C/E, State, Getters, Actions, Data Models, Error Handling_
+
+- [x] 3. Réécrire le bloc `auth` de `api.js` en façade fine (conflit fichier : avant tâche 4)
+  - Modifier `src/services/api.js` : remplacer le bloc `auth` (≈ `api.js:66-162`) par une façade fine. Ajouter au top-level `import { useAuthStore } from '../stores/auth'` (importer la DÉFINITION ne déclenche pas `getActivePinia` — sûr car `auth.js` n'importe PAS la façade, décision B/C, note design §250). Chaque méthode appelle `useAuthStore()` **à la volée** dans son corps.
+  - Conserver les **16 méthodes publiques** avec sémantique identique (R5.1) : `login`, `logout`, `me`, `getUser` (→ `currentUser`), `getMeta` (→ `meta`), `isAuthenticated`, `getUserRole` (→ `userRole`), `getInstitution` (→ `institutionSlug`), `getInstitutionName` (→ `institutionDisplayName`), `setInstitution`, `getActiveInstitutions` (→ `fetchActiveInstitutions`), `hasRole`, `isAdmin`, `isTeacher`, `isStudent`, `isSupradmin`. `hasRole(r)` délègue à `roleHasRole(useAuthStore().currentUser, r)` (pas de réimplémentation, R5.3).
+  - Supprimer de `api.js` toute logique d'état/storage désormais détenue par le store (écriture/lecture `sessionStorage` du bloc `auth`, gestion de `user`/`meta`/`institution`). La façade NE DOIT PAS dupliquer la logique de rôle ni d'état (R5.3).
+  - Critère de complétion : T10 passe au vert (`auth.getUser()`/`auth.getInstitution()` renvoient les valeurs du store) ; `grep -n "sessionStorage" src/services/api.js` ne montre plus d'accès dans le bloc façade `auth` (l'intercepteur est traité en tâche 4) ; les 16 méthodes restent exportées.
+  - _Requirements: R5.1, R5.2, R5.3, R8.1_ ; _Design: décision B/C, « façade auth réécrite », T10_
+
+- [x] 4. Réécrire les 2 intercepteurs axios de `api.js` (conflit fichier : après tâche 3)
+  - Modifier `src/services/api.js` — intercepteur **requête** (≈ `api.js:26-37`) : lire `const token = useAuthStore().token` **à l'intérieur** de la fonction `(config) => {...}` (jamais au top-level). Si token présent → `config.headers.Authorization = 'Bearer ' + token` ; sinon NE PAS ajouter le header (R7.1/R7.2/R7.3). Supprimer `sessionStorage.getItem('token')` direct (mapping design §483).
+  - Intercepteur **réponse 401** (≈ `api.js:49-59`) : appeler `useAuthStore().logout()` (purge state + storage + `clearAllCache`) puis conserver la redirection vers `/login` **hors** page de login (R7.4). Aucune donnée d'auth sensible journalisée (R11.4).
+  - Vérifier l'absence de cycle de chargement : `auth.js` n'importe que l'instance axios `default` ; `api.js` n'appelle `useAuthStore()` qu'à la volée dans les corps de fonctions (décision D, règle anti-cycle ESM design §100-119).
+  - Critère de complétion : `grep -n "sessionStorage.getItem('token')" src/services/api.js` retourne 0 résultat ; `npm run build` réussit (pas de cycle ESM bloquant) ; un test de fumée (ou T5 déjà vert) confirme token écrit ≡ token lu.
+  - _Requirements: R7.1, R7.2, R7.3, R7.4, R11.4, R10.5_ ; _Design: décision D, Processus 3, règle anti-cycle ESM_
+
+- [x] 5. Migrer les 6 lecteurs de token visio vers `useAuthStore().token` (R6) — `visio.js` avant tâche 6
+  - `src/stores/visio.js:248` (`sendLeaveVisioBeacon`) : remplacer `localStorage.getItem('token')` par `useAuthStore().token` appelé **à la volée DANS l'action** (jamais au setup du store visio, design §496). Si token `null` → ne PAS envoyer le Beacon, journaliser (`console.warn`), comportement existant (R6.5). Supprime aussi l'incohérence `localStorage`→`sessionStorage` (R3.4).
+  - `src/composables/useVisioParticipation.js:223` : remplacer `sessionStorage.getItem('token')` par `useAuthStore().token` (appel dans la fonction).
+  - `src/components/visio/ParticipantsModal.vue:429` et `:478` : remplacer les 2 lectures `sessionStorage.getItem('token')` par `useAuthStore().token`.
+  - `src/components/visio/VisioManager.vue:398` : remplacer `sessionStorage.getItem('token')` par `useAuthStore().token`.
+  - `src/views/attendance/SeanceAttendanceHistory.vue:537` et `:586` : remplacer les 2 lectures `sessionStorage.getItem('token')` par `useAuthStore().token`.
+  - Pour chaque composant `<script setup>`, importer `useAuthStore` et l'appeler dans la fonction qui en a besoin (robuste à l'ordre d'init, R6.4).
+  - Critère de complétion : `grep -rn "sessionStorage.getItem('token')" src/composables/useVisioParticipation.js src/components/visio/ParticipantsModal.vue src/components/visio/VisioManager.vue src/views/attendance/SeanceAttendanceHistory.vue` → 0 résultat ; `grep -n "localStorage.getItem('token')" src/stores/visio.js` → 0 résultat ; `npm run build` réussit.
+  - _Requirements: R6.1, R6.2, R6.3, R6.4, R6.5, R3.4_ ; _Design: Mapping token (R6), décision D, note visio §496_
+
+- [x] 6. Migrer les 6 lecteurs de `localStorage('user')` vers `useAuthStore().currentUser` (R4) — `visio.js` après tâche 5
+  - `src/stores/visio.js:347` (`handleTeacherExit`) : remplacer `JSON.parse(localStorage.getItem('user') || '{}')` par `useAuthStore().currentUser` appelé **à la volée dans l'action** (R4.1/R4.2).
+  - `src/views/TeacherSeances.vue:357` : remplacer la lecture `localStorage('user')` par `useAuthStore().currentUser`.
+  - `src/views/student/StudentSchedule.vue:34` : passer de `ref(JSON.parse(localStorage.getItem('user') || '{}'))` à `computed(() => useAuthStore().currentUser)` pour la réactivité (R9.3, design §491).
+  - `src/views/teacher/TeacherSchedule.vue:36` : idem → `computed(() => useAuthStore().currentUser)` (R9.3).
+  - `src/views/ForumTopic.vue:199` (Options API) : appeler `useAuthStore()` dans `created`/`setup` et affecter `this.currentUser = useAuthStore().currentUser` (store hors `<script setup>`, design §493).
+  - `src/views/coordinateur/SeanceManagement.vue:309` : remplacer la lecture `localStorage('user')` par `useAuthStore().currentUser`.
+  - Vérifier qu'aucun de ces emplacements ne traite plus `currentUser` comme `{}` (R4.3) : adapter les usages aval qui supposaient un objet non-null (garde `?.`/valeur par défaut sûre si nécessaire).
+  - Critère de complétion : `grep -rn "localStorage.getItem('user')" src/stores/visio.js src/views/TeacherSeances.vue src/views/student/StudentSchedule.vue src/views/teacher/TeacherSchedule.vue src/views/ForumTopic.vue src/views/coordinateur/SeanceManagement.vue` → 0 résultat ; `npm run build` réussit ; StudentSchedule/TeacherSchedule utilisent bien `computed`.
+  - _Requirements: R4.1, R4.2, R4.3, R4.4, R9.3_ ; _Design: Mapping user (R4), notes §491/§493/§496_
+
+- [x] 7. Vérification finale et non-régression
+  - Exécuter `npm run test` (Vitest) : la suite `src/stores/__tests__/auth.spec.js` (T1-T10) est **entièrement verte**.
+  - Exécuter `npm run test:contract` : toujours vert (non-régression du contrat API #17).
+  - Exécuter `npm run build` : build de production réussi (aucun cycle ESM, aucune erreur de compilation introduite par les tâches 2-6).
+  - Grep de preuve d'éradication du storage direct (doivent tous retourner 0) :
+    - `grep -rn "localStorage.getItem('user')"` dans les 6 fichiers migrés (R4) → 0.
+    - `grep -rn "sessionStorage.getItem('token')"` dans les 5 fichiers/composants visio migrés + l'intercepteur `api.js` (R6/R7) → 0.
+    - `grep -n "localStorage.getItem('token')" src/stores/visio.js` → 0.
+  - Confirmer la non-régression de la façade : `grep -rn "auth\." src/` montre que les ~30 autres fichiers consommateurs (88 appels, 32 fichiers) de `auth.*` restent **inchangés** et que les 16 méthodes publiques existent toujours dans `api.js` (vérifier la liste exportée). Aucune modification de comportement pour ces appelants.
+  - Confirmer le hors-périmètre intact : `src/views/student/StudentSettings.vue:233/239` (`localStorage('userPreferences')`) NON touché (R13.3) ; aucune migration des comparaisons brutes `role === '...'` hors des 12 fichiers ciblés (R13.2) ; aucune modification backend (R12.3).
+  - Critère de complétion : les 3 commandes passent au vert et les 3 catégories de grep retournent 0, prouvant l'élimination des 13 accès directs et la non-régression des 88 appels de façade.
+  - _Requirements: R3.3, R3.4, R4.2, R5.1, R5.4, R6, R7, R10, R11.1, R12.3, R13.2, R13.3_ ; _Design: Mapping de migration, Testing Strategy (non-régression), Conformité PRODUCTION_STANDARDS_
+
+---
+
+## Diagramme de dépendances des tâches
+
+```mermaid
+flowchart TD
+    T1[Tache 1: Tests Vitest store T1-T10 - ROUGE]
+    T2[Tache 2: Implementer auth.js store - VERT]
+    T3[Tache 3: Facade fine api.js bloc auth]
+    T4[Tache 4: Intercepteurs axios api.js]
+    T5[Tache 5: Migrer 6 lecteurs token visio R6]
+    T6[Tache 6: Migrer 6 lecteurs user R4]
+    T7[Tache 7: Verification finale + non-regression]
+
+    T1 --> T2
+    T2 --> T3
+    T3 --> T4
+    T2 --> T5
+    T2 --> T6
+    T4 --> T7
+    T5 --> T6
+    T6 --> T7
+    T4 --> T6
+
+    style T2 fill:#c8e6c9
+    style T7 fill:#e1f5fe
+```
+
+> **Notes de parallélisation / séquencement** :
+> - `api.js` est touché par T3 puis T4 → **séquentiel obligatoire** (même fichier).
+> - `src/stores/visio.js` est touché par T5 (token) puis T6 (user) → **séquentiel obligatoire** (même fichier).
+> - T5 (composants visio hors `visio.js`) peut démarrer dès T2 finie ; T6 dépend de T2 et, pour `visio.js`, de T5.
+> - T7 ne démarre qu'après T4 ET T6 (toutes les migrations + intercepteurs intégrés).

--- a/src/components/visio/ParticipantsModal.vue
+++ b/src/components/visio/ParticipantsModal.vue
@@ -277,6 +277,7 @@
 
 <script>
 import lmsService from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 
 export default {
   name: 'ParticipantsModal',
@@ -426,7 +427,7 @@ export default {
         console.log('[ParticipantsModal] Export PDF de la séance', this.seanceId)
 
         const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
-        const token = sessionStorage.getItem('token')
+        const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
         const url = `${API_URL}/lms/seances/${this.seanceId}/export/presences/pdf`
@@ -475,7 +476,7 @@ export default {
         console.log('[ParticipantsModal] Export Excel de la séance', this.seanceId)
 
         const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
-        const token = sessionStorage.getItem('token')
+        const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
         const url = `${API_URL}/lms/seances/${this.seanceId}/export/presences/excel`

--- a/src/components/visio/VisioManager.vue
+++ b/src/components/visio/VisioManager.vue
@@ -138,6 +138,7 @@
 <script>
 import { auth } from '@/services/api'
 import lmsService from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 import jitsiService from '@/services/jitsi'
 import ParticipantsModal from './ParticipantsModal.vue'
 import { useVisioStore } from '@/stores/visio'
@@ -395,7 +396,7 @@ export default {
         console.log('[VisioManager] Téléchargement liste de présence PDF...')
 
         const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
-        const token = sessionStorage.getItem('token')
+        const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
         const url = `${API_URL}/lms/seances/${this.seance.id}/export/presences/pdf`

--- a/src/composables/useVisioParticipation.js
+++ b/src/composables/useVisioParticipation.js
@@ -1,5 +1,6 @@
 import { ref, onBeforeUnmount } from 'vue'
 import lmsService from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 
 /**
  * Composable pour gérer la participation à une visioconférence
@@ -220,7 +221,7 @@ export function useVisioParticipation(seanceId) {
   const sendLeaveVisioBeacon = async () => {
     try {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/seances/${seanceId}/leave-visio`
-      const token = sessionStorage.getItem('token')
+      const token = useAuthStore().token
 
       if (!token) {
         console.warn('[useVisioParticipation] Pas de token, impossible d\'envoyer Beacon')

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,15 +1,13 @@
 import axios from 'axios'
-import { clearAllCache } from './cache'
 import notificationsService from './notifications'
-// Import relatif (pas l'alias @) : le runner natif des tests de contrat (#17) ne
-// résout que les chemins relatifs. Délégation de la logique de rôle (#18).
-import {
-  hasRole as roleHasRole,
-  isAdmin as roleIsAdmin,
-  isTeacher as roleIsTeacher,
-  isStudent as roleIsStudent,
-  isSupradmin as roleIsSupradmin,
-} from '../constants/roles'
+// Imports relatifs (pas l'alias @) : le runner natif des tests de contrat (#17) ne
+// résout que les chemins relatifs.
+import { hasRole as roleHasRole } from '../constants/roles'
+// useAuthStore : on importe la DÉFINITION au top-level (sûr) ; on n'APPELLE
+// useAuthStore() qu'à la volée dans les méthodes (Pinia actif à l'exécution).
+// Cycle api.js <-> auth.js sans danger : aucune des deux références n'est utilisée
+// au chargement du module, seulement dans les corps de fonctions (#19, décision C/D).
+import { useAuthStore } from '../stores/auth'
 
 const api = axios.create({
   // Optional chaining : `import.meta.env` est injecté par Vite au build/dev, mais
@@ -25,7 +23,10 @@ const api = axios.create({
 // Intercepteur : ajouter uniquement le token Bearer
 api.interceptors.request.use(
   (config) => {
-    const token = sessionStorage.getItem('token')
+    // Token lu DEPUIS le store à la volée (#19) — source unique, fin du mix
+    // localStorage/sessionStorage. useAuthStore() est sûr ici : l'intercepteur
+    // s'exécute à chaque requête, donc après le montage (Pinia actif).
+    const token = useAuthStore().token
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
@@ -45,12 +46,9 @@ api.interceptors.response.use(
   (error) => {
     console.error('❌ API Error:', error.config?.url, error.response?.status)
 
-    // Si erreur 401, déconnecter l'utilisateur
+    // Si erreur 401, déconnecter l'utilisateur via le store (purge state + storage + cache)
     if (error.response?.status === 401) {
-      console.warn('Session expirée - Déconnexion automatique')
-      sessionStorage.removeItem('token')
-      sessionStorage.removeItem('user')
-      sessionStorage.removeItem('meta')
+      useAuthStore().logout()
 
       // Ne rediriger que si on n'est pas déjà sur la page de login
       if (!window.location.pathname.includes('/login')) {
@@ -62,103 +60,28 @@ api.interceptors.response.use(
   }
 )
 
-// Fonctions d'authentification
+// Façade d'authentification — délègue au store Pinia useAuthStore (#19).
+// L'état (user/token/meta/institution) vit DANS le store ; cette façade conserve
+// l'API publique consommée par 32 fichiers (88 appels) sans la réécrire. Chaque
+// méthode appelle useAuthStore() À LA VOLÉE (Pinia actif à l'exécution).
 export const auth = {
-  async login(username, password) {
-    const response = await api.post('/auth/login', { username, password })
-
-    if (response.success && response.data) {
-      sessionStorage.setItem('token', response.data.token)
-      sessionStorage.setItem('user', JSON.stringify(response.data.user))
-
-      if (response.meta) {
-        sessionStorage.setItem('meta', JSON.stringify(response.meta))
-        if (response.meta.institution) {
-          sessionStorage.setItem('institution', response.meta.institution)
-        }
-      }
-    }
-
-    return response
-  },
-
-  logout() {
-    sessionStorage.removeItem('token')
-    sessionStorage.removeItem('user')
-    sessionStorage.removeItem('meta')
-    sessionStorage.removeItem('institution')
-    clearAllCache()
-  },
-
-  async me() {
-    return await api.get('/auth/me')
-  },
-
-  getUser() {
-    const user = sessionStorage.getItem('user')
-    return user ? JSON.parse(user) : null
-  },
-
-  getMeta() {
-    const meta = sessionStorage.getItem('meta')
-    return meta ? JSON.parse(meta) : null
-  },
-
-  isAuthenticated() {
-    return !!sessionStorage.getItem('token')
-  },
-
-  // Obtenir le rôle de l'utilisateur
-  getUserRole() {
-    const user = this.getUser()
-    return user?.role || null
-  },
-
-  // Logique de rôle déléguée à src/constants/roles.js (#18) — rôle normalisé,
-  // plus aucune comparaison de chaîne brute ici.
-  hasRole(roles) {
-    return roleHasRole(this.getUser(), roles)
-  },
-
-  // Périmètre admin STRICT (admin | supradmin), aligné backend Role::isAdmin()
-  isAdmin() {
-    return roleIsAdmin(this.getUser())
-  },
-
-  isTeacher() {
-    return roleIsTeacher(this.getUser())
-  },
-
-  isStudent() {
-    return roleIsStudent(this.getUser())
-  },
-
-  // Obtenir le slug de l'institution depuis les métadonnées de session
-  getInstitution() {
-    const meta = this.getMeta()
-    return meta?.institution || sessionStorage.getItem('institution') || null
-  },
-
-  // Obtenir le nom de l'institution depuis les métadonnées
-  getInstitutionName() {
-    const meta = this.getMeta()
-    return meta?.institution_name || null
-  },
-
-  // Vérifier si l'utilisateur est supradmin (rôle normalisé)
-  isSupradmin() {
-    return roleIsSupradmin(this.getUser())
-  },
-
-  // Récupérer la liste des institutions actives (route publique)
-  async getActiveInstitutions() {
-    return await api.get('/institutions/active')
-  },
-
-  // Changer l'institution courante (local dev uniquement)
-  setInstitution(slug) {
-    sessionStorage.setItem('institution', slug)
-  }
+  login: (username, password) => useAuthStore().login(username, password),
+  logout: () => useAuthStore().logout(),
+  me: () => useAuthStore().me(),
+  getUser: () => useAuthStore().currentUser,
+  getMeta: () => useAuthStore().meta,
+  isAuthenticated: () => useAuthStore().isAuthenticated,
+  getUserRole: () => useAuthStore().userRole,
+  // hasRole délègue au helper normalisé (pas de réimplémentation, #18)
+  hasRole: (roles) => roleHasRole(useAuthStore().currentUser, roles),
+  isAdmin: () => useAuthStore().isAdmin,
+  isTeacher: () => useAuthStore().isTeacher,
+  isStudent: () => useAuthStore().isStudent,
+  isSupradmin: () => useAuthStore().isSupradmin,
+  getInstitution: () => useAuthStore().institutionSlug,
+  getInstitutionName: () => useAuthStore().institutionDisplayName,
+  setInstitution: (slug) => useAuthStore().setInstitution(slug),
+  getActiveInstitutions: () => useAuthStore().fetchActiveInstitutions(),
 }
 
 // Fonctions pour les leçons

--- a/src/stores/__tests__/auth.test.js
+++ b/src/stores/__tests__/auth.test.js
@@ -1,0 +1,206 @@
+/**
+ * Tests du store d'authentification (#19) — src/stores/auth.js
+ *
+ * Couvre T1-T10 du design : login/logout, persistance sessionStorage, getters
+ * dérivés de roles.js (fail-secure), régression #11 (token store == token login),
+ * non-régression bug `user` (currentUser jamais {}), hydratation, réactivité,
+ * délégation de la façade api.js.
+ *
+ * Isolation : Pinia neuf par test, sessionStorage (jsdom) réinitialisé, instance
+ * axios `api` (default export) mockée pour contrôler les réponses HTTP sans réseau.
+ */
+import { setActivePinia, createPinia } from 'pinia'
+import { computed } from 'vue'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// vi.hoisted : les mocks sont référencés par la factory vi.mock (hoistée en tête du module).
+const { mockPost, mockGet } = vi.hoisted(() => ({ mockPost: vi.fn(), mockGet: vi.fn() }))
+
+// On garde le module api.js réel (façade `auth` pour T10) mais on remplace
+// l'instance axios `default` par un double contrôlable (pas de réseau).
+vi.mock('@/services/api', async (importActual) => {
+  const actual = await importActual()
+  return { ...actual, default: { post: mockPost, get: mockGet } }
+})
+vi.mock('@/services/cache', () => ({ clearAllCache: vi.fn() }))
+
+import { useAuthStore } from '@/stores/auth'
+import { auth as authFacade } from '@/services/api'
+import { clearAllCache } from '@/services/cache'
+
+const LOGIN_RESPONSE = {
+  success: true,
+  data: { token: 'tok-123', user: { id: 1, name: 'Awa', role: 'superAdmin' } },
+  meta: { institution: 'esi', institution_name: 'ESI Ouaga' },
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  sessionStorage.clear()
+  mockPost.mockReset()
+  mockGet.mockReset()
+  clearAllCache.mockClear()
+})
+
+describe('useAuthStore — login (T1, T2)', () => {
+  it('T1 — login réussi peuple le store ET sessionStorage (4 clés)', async () => {
+    mockPost.mockResolvedValue(LOGIN_RESPONSE)
+    const store = useAuthStore()
+
+    const res = await store.login('awa', 'secret')
+
+    expect(mockPost).toHaveBeenCalledWith('/auth/login', { username: 'awa', password: 'secret' })
+    expect(res).toEqual(LOGIN_RESPONSE)
+    expect(store.token).toBe('tok-123')
+    expect(store.currentUser).toEqual(LOGIN_RESPONSE.data.user)
+    expect(store.userRole).toBe('superAdmin')
+    expect(store.institutionSlug).toBe('esi')
+    expect(store.meta).toEqual(LOGIN_RESPONSE.meta)
+
+    expect(sessionStorage.getItem('token')).toBe('tok-123')
+    expect(JSON.parse(sessionStorage.getItem('user'))).toEqual(LOGIN_RESPONSE.data.user)
+    expect(JSON.parse(sessionStorage.getItem('meta'))).toEqual(LOGIN_RESPONSE.meta)
+    expect(sessionStorage.getItem('institution')).toBe('esi')
+  })
+
+  it('T2 — login échoué (success:false) ne mute rien', async () => {
+    mockPost.mockResolvedValue({ success: false, message: 'Identifiants incorrects' })
+    const store = useAuthStore()
+
+    await store.login('x', 'y')
+
+    expect(store.isAuthenticated).toBe(false)
+    expect(store.currentUser).toBeNull()
+    expect(sessionStorage.getItem('token')).toBeNull()
+    expect(sessionStorage.getItem('user')).toBeNull()
+  })
+})
+
+describe('useAuthStore — logout (T3)', () => {
+  it('T3 — logout purge state + storage + clearAllCache', async () => {
+    mockPost.mockResolvedValue(LOGIN_RESPONSE)
+    const store = useAuthStore()
+    await store.login('awa', 'secret')
+
+    store.logout()
+
+    expect(store.isAuthenticated).toBe(false)
+    expect(store.currentUser).toBeNull()
+    expect(store.token).toBeNull()
+    expect(store.meta).toBeNull()
+    expect(sessionStorage.getItem('token')).toBeNull()
+    expect(sessionStorage.getItem('user')).toBeNull()
+    expect(sessionStorage.getItem('meta')).toBeNull()
+    expect(sessionStorage.getItem('institution')).toBeNull()
+    expect(clearAllCache).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useAuthStore — getters d\'autorisation dérivés de roles.js (T4)', () => {
+  it('T4 — alias reconnus + fail-secure + isAdmin strict', () => {
+    const store = useAuthStore()
+
+    store.setSession({ token: 't', user: { role: 'superAdmin' } })
+    expect(store.isSupradmin).toBe(true)
+    expect(store.isAdmin).toBe(true) // admin|supradmin
+
+    store.setSession({ token: 't', user: { role: 'teacher' } })
+    expect(store.isTeacher).toBe(true)
+    expect(store.isAdmin).toBe(false)
+
+    store.setSession({ token: 't', user: { role: 'student' } })
+    expect(store.isStudent).toBe(true)
+
+    store.setSession({ token: 't', user: { role: 'coordinateur' } })
+    expect(store.isAdmin).toBe(false) // coordinateur hors périmètre admin strict
+
+    store.setSession({ token: 't', user: { role: 'hacker' } })
+    expect(store.isAdmin).toBe(false)
+    expect(store.isSupradmin).toBe(false)
+    expect(store.isTeacher).toBe(false)
+    expect(store.isStudent).toBe(false)
+    expect(store.normalizedRole).toBeNull()
+  })
+})
+
+describe('useAuthStore — régression #11 token cohérent (T5)', () => {
+  it('T5 — le token du store (lu par l\'intercepteur) == token du login', async () => {
+    mockPost.mockResolvedValue(LOGIN_RESPONSE)
+    const store = useAuthStore()
+    await store.login('awa', 'secret')
+    // L'intercepteur lira useAuthStore().token ; il doit valoir le token reçu.
+    expect(store.token).toBe(LOGIN_RESPONSE.data.token)
+  })
+})
+
+describe('useAuthStore — bug `user` (T6)', () => {
+  it('T6 — currentUser est l\'utilisateur après login, null sinon (jamais {})', async () => {
+    const store = useAuthStore()
+    expect(store.currentUser).toBeNull()
+
+    mockPost.mockResolvedValue(LOGIN_RESPONSE)
+    await store.login('awa', 'secret')
+    expect(store.currentUser).toEqual(LOGIN_RESPONSE.data.user)
+    expect(store.currentUser).not.toEqual({})
+  })
+})
+
+describe('useAuthStore — hydratation au démarrage (T7)', () => {
+  it('T7 — un store neuf s\'hydrate depuis sessionStorage', () => {
+    sessionStorage.setItem('token', 'tok-xyz')
+    sessionStorage.setItem('user', JSON.stringify({ id: 9, role: 'enseignant' }))
+    sessionStorage.setItem('meta', JSON.stringify({ institution: 'iam', institution_name: 'IAM' }))
+    sessionStorage.setItem('institution', 'iam')
+
+    const store = useAuthStore() // doit s'hydrater à la création
+
+    expect(store.isAuthenticated).toBe(true)
+    expect(store.currentUser).toEqual({ id: 9, role: 'enseignant' })
+    expect(store.institutionSlug).toBe('iam')
+    expect(store.isTeacher).toBe(true)
+  })
+
+  it('T7b — JSON corrompu en storage ne casse pas le boot (state vide)', () => {
+    sessionStorage.setItem('token', 'tok')
+    sessionStorage.setItem('user', '{ broken json')
+    const store = useAuthStore()
+    // tolérant : pas d'exception ; user invalide → null
+    expect(store.currentUser).toBeNull()
+  })
+})
+
+describe('useAuthStore — setInstitution (T8)', () => {
+  it('T8 — met à jour institutionSlug + sessionStorage', () => {
+    const store = useAuthStore()
+    store.setInstitution('ujkz')
+    expect(store.institutionSlug).toBe('ujkz')
+    expect(sessionStorage.getItem('institution')).toBe('ujkz')
+  })
+})
+
+describe('useAuthStore — réactivité (T9)', () => {
+  it('T9 — isAuthenticated réagit à login puis logout', async () => {
+    mockPost.mockResolvedValue(LOGIN_RESPONSE)
+    const store = useAuthStore()
+    const authed = computed(() => store.isAuthenticated)
+
+    expect(authed.value).toBe(false)
+    await store.login('awa', 'secret')
+    expect(authed.value).toBe(true)
+    store.logout()
+    expect(authed.value).toBe(false)
+  })
+})
+
+describe('façade api.js — délégation au store (T10)', () => {
+  it('T10 — auth.getUser()/getInstitution() renvoient les valeurs du store', async () => {
+    mockPost.mockResolvedValue(LOGIN_RESPONSE)
+    const store = useAuthStore()
+    await store.login('awa', 'secret')
+
+    expect(authFacade.getUser()).toEqual(LOGIN_RESPONSE.data.user)
+    expect(authFacade.getInstitution()).toBe('esi')
+    expect(authFacade.isAuthenticated()).toBe(true)
+    expect(authFacade.isSupradmin()).toBe(true)
+  })
+})

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,0 +1,136 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import api from '../services/api'
+import { clearAllCache } from '../services/cache'
+import {
+  normalizeRole,
+  isAdmin as roleIsAdmin,
+  isSupradmin as roleIsSupradmin,
+  isTeacher as roleIsTeacher,
+  isStudent as roleIsStudent,
+} from '../constants/roles'
+
+/**
+ * Store d'authentification — source de vérité unique de l'état d'auth (#19).
+ *
+ * Remplace l'accès dispersé et incohérent au storage (localStorage vs sessionStorage)
+ * réparti sur 12 fichiers. Le bloc `auth` de api.js devient une façade fine déléguant
+ * à ce store. Les getters d'autorisation dérivent de src/constants/roles.js (#18),
+ * jamais réimplémentés.
+ *
+ * Persistance : sessionStorage (mécanisme unique, pas localStorage → atténuation XSS
+ * #2/#6). sessionStorage survit au rechargement (F5) mais est effacé à la fermeture
+ * de l'onglet et n'est pas partagé entre onglets — compromis de sécurité assumé.
+ *
+ * Anti-cycle ESM : ce module importe UNIQUEMENT l'instance axios `default` de api.js
+ * au top-level (utilisée seulement dans les actions, à l'exécution). api.js importe
+ * la définition `useAuthStore` mais ne l'appelle qu'à la volée — pas de cycle au chargement.
+ */
+
+const KEYS = Object.freeze({
+  token: 'token',
+  user: 'user',
+  meta: 'meta',
+  institution: 'institution',
+})
+
+/** Lecture tolérante d'une valeur JSON en sessionStorage (JSON corrompu → null). */
+function readJSON(key) {
+  try {
+    const raw = sessionStorage.getItem(key)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export const useAuthStore = defineStore('auth', () => {
+  // --- State (hydraté depuis sessionStorage à la création du store) ---
+  const user = ref(readJSON(KEYS.user))
+  const token = ref(sessionStorage.getItem(KEYS.token) || null)
+  const meta = ref(readJSON(KEYS.meta))
+  const institution = ref(sessionStorage.getItem(KEYS.institution) || null)
+  const institutionName = ref(meta.value?.institution_name ?? null)
+
+  // --- Getters dérivés ---
+  const isAuthenticated = computed(() => !!token.value)
+  const currentUser = computed(() => user.value ?? null) // jamais {} (R4.4)
+  const userRole = computed(() => user.value?.role ?? null) // rôle brut
+  const normalizedRole = computed(() => normalizeRole(user.value?.role))
+  // Autorisation déléguée à roles.js (fail-secure hérité), jamais réimplémentée.
+  const isAdmin = computed(() => roleIsAdmin(user.value)) // admin | supradmin (strict backend)
+  const isSupradmin = computed(() => roleIsSupradmin(user.value))
+  const isTeacher = computed(() => roleIsTeacher(user.value))
+  const isStudent = computed(() => roleIsStudent(user.value))
+  const institutionSlug = computed(() => meta.value?.institution ?? institution.value ?? null)
+  const institutionDisplayName = computed(() => meta.value?.institution_name ?? null)
+
+  // --- Actions ---
+
+  /** Peuple l'état d'auth depuis la réponse de login et persiste en sessionStorage. */
+  function setSession(data, metaPayload) {
+    user.value = data?.user ?? null
+    token.value = data?.token ?? null
+    sessionStorage.setItem(KEYS.token, token.value ?? '')
+    sessionStorage.setItem(KEYS.user, JSON.stringify(user.value))
+    if (metaPayload) {
+      meta.value = metaPayload
+      institutionName.value = metaPayload.institution_name ?? null
+      sessionStorage.setItem(KEYS.meta, JSON.stringify(metaPayload))
+      if (metaPayload.institution) {
+        institution.value = metaPayload.institution
+        sessionStorage.setItem(KEYS.institution, metaPayload.institution)
+      }
+    }
+  }
+
+  /** Authentifie l'utilisateur (POST /auth/login) et ouvre la session si succès. */
+  async function login(username, password) {
+    const response = await api.post('/auth/login', { username, password })
+    if (response.success && response.data) {
+      setSession(response.data, response.meta)
+    }
+    return response
+  }
+
+  /** Change l'institution courante (dev local) et persiste le slug. */
+  function setInstitution(slug) {
+    institution.value = slug
+    sessionStorage.setItem(KEYS.institution, slug)
+  }
+
+  /** Purge complète : state + sessionStorage + cache tenant-scopé. */
+  function logout() {
+    user.value = null
+    token.value = null
+    meta.value = null
+    institution.value = null
+    institutionName.value = null
+    sessionStorage.removeItem(KEYS.token)
+    sessionStorage.removeItem(KEYS.user)
+    sessionStorage.removeItem(KEYS.meta)
+    sessionStorage.removeItem(KEYS.institution)
+    clearAllCache()
+  }
+
+  /** Profil courant (GET /auth/me) — ne mute pas l'état. */
+  async function me() {
+    return await api.get('/auth/me')
+  }
+
+  /** Liste des institutions actives (route publique) — ne mute pas l'état. */
+  async function fetchActiveInstitutions() {
+    return await api.get('/institutions/active')
+  }
+
+  return {
+    // state
+    user, token, meta, institution, institutionName,
+    // getters
+    isAuthenticated, currentUser, userRole, normalizedRole,
+    isAdmin, isSupradmin, isTeacher, isStudent,
+    institutionSlug, institutionDisplayName,
+    // actions
+    login, setSession, setInstitution, logout, me, fetchActiveInstitutions,
+  }
+})

--- a/src/stores/visio.js
+++ b/src/stores/visio.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import lmsService from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 
 /**
  * Store Pinia global pour gérer la participation aux visioconférences
@@ -245,7 +246,7 @@ export const useVisioStore = defineStore('visio', () => {
   const sendLeaveVisioBeacon = async (seanceId) => {
     try {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/seances/${seanceId}/leave-visio`
-      const token = localStorage.getItem('token')
+      const token = useAuthStore().token
 
       if (!token) {
         console.warn('[VisioStore] Pas de token, impossible d\'envoyer Beacon')
@@ -343,9 +344,9 @@ export const useVisioStore = defineStore('visio', () => {
     // Se déconnecter d'abord
     leaveVisio()
 
-    // Si enseignant : proposer de fermer la séance pour tous
-    const user = JSON.parse(localStorage.getItem('user') || '{}')
-    if (user.role === 'enseignant' || user.role === 'teacher') {
+    // Si enseignant : proposer de fermer la séance pour tous (#19 : user via store)
+    const role = useAuthStore().currentUser?.role
+    if (role === 'enseignant' || role === 'teacher') {
       // Utiliser setTimeout pour s'assurer que leaveVisio() est terminé
       setTimeout(() => {
         const shouldEnd = confirm(

--- a/src/views/ForumTopic.vue
+++ b/src/views/ForumTopic.vue
@@ -175,6 +175,7 @@
 <script>
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import { forum } from '@/services/api'
+import { useAuthStore } from '@/stores/auth'
 
 export default {
   name: 'ForumTopic',
@@ -195,9 +196,8 @@ export default {
   },
   methods: {
     getCurrentUser() {
-      // Récupérer l'utilisateur connecté depuis le service auth
-      const user = JSON.parse(localStorage.getItem('user') || '{}')
-      this.currentUser = user
+      // Récupérer l'utilisateur connecté depuis le store (#19) — plus de localStorage('user')
+      this.currentUser = useAuthStore().currentUser
     },
 
     canMarkAsSolution(post) {

--- a/src/views/TeacherSeances.vue
+++ b/src/views/TeacherSeances.vue
@@ -341,6 +341,7 @@ import ContentLoader from '@/components/common/ContentLoader.vue'
 import { useVisioParticipation } from '@/composables/useVisioParticipation'
 import { lmsService } from '@/services/lms'
 import { klassciService } from '@/services/klassci'
+import { useAuthStore } from '@/stores/auth'
 import { readCache, writeCache, clearCache } from '@/services/cache'
 
 const seances = ref([])
@@ -353,9 +354,9 @@ const actionLoading = ref(null)
 // visioParticipation sera créé dynamiquement pour chaque séance
 const visioParticipations = reactive({})
 
-// Get current user
-const currentUser = JSON.parse(localStorage.getItem('user') || '{}')
-const isEnseignant = currentUser.role === 'enseignant'
+// Get current user (#19 : via store, plus de localStorage('user'))
+const currentUser = useAuthStore().currentUser
+const isEnseignant = currentUser?.role === 'enseignant'
 
 // Filters
 const filters = reactive({

--- a/src/views/attendance/SeanceAttendanceHistory.vue
+++ b/src/views/attendance/SeanceAttendanceHistory.vue
@@ -325,6 +325,7 @@
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import lmsService from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 
 export default {
   name: 'SeanceAttendanceHistory',
@@ -534,7 +535,7 @@ export default {
         console.log('[SeanceHistory] Export PDF de la séance', this.selectedSeance.klassci_seance_id)
 
         const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
-        const token = sessionStorage.getItem('token')
+        const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
         const url = `${API_URL}/lms/seances/${this.selectedSeance.klassci_seance_id}/export/presences/pdf`
@@ -583,7 +584,7 @@ export default {
         console.log('[SeanceHistory] Export Excel de la séance', this.selectedSeance.klassci_seance_id)
 
         const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
-        const token = sessionStorage.getItem('token')
+        const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
         const url = `${API_URL}/lms/seances/${this.selectedSeance.klassci_seance_id}/export/presences/excel`

--- a/src/views/coordinateur/SeanceManagement.vue
+++ b/src/views/coordinateur/SeanceManagement.vue
@@ -279,6 +279,7 @@ import ContentLoader from '@/components/common/ContentLoader.vue'
 import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
 import { useVisioParticipation } from '@/composables/useVisioParticipation'
 import ParticipantsModal from '@/components/visio/ParticipantsModal.vue'
+import { useAuthStore } from '@/stores/auth'
 
 import lmsService from '@/services/lms'
 import { readCache, writeCache, clearCache } from '@/services/cache'
@@ -305,8 +306,8 @@ const filters = reactive({
   classe_id: null
 })
 
-// Get current user for Jitsi
-const currentUser = JSON.parse(localStorage.getItem('user') || '{}')
+// Get current user for Jitsi (#19 : via store, plus de localStorage('user'))
+const currentUser = useAuthStore().currentUser
 
 // État de la modal Jitsi
 // visioParticipation sera créé dynamiquement pour chaque séance
@@ -526,7 +527,7 @@ async function handleCalendarAction({ type, data }) {
       // Coordinateur rejoint la visio
       {
         const roomId = data.visio?.room_id || data.visio_room_id || `seance_${data.id}`
-        const userName = encodeURIComponent(currentUser.name || 'Coordinateur')
+        const userName = encodeURIComponent(currentUser?.name || 'Coordinateur')
         const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
         window.open(jitsiLink, '_blank')
       }

--- a/src/views/student/StudentSchedule.vue
+++ b/src/views/student/StudentSchedule.vue
@@ -23,15 +23,17 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
 import { lmsService } from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 
 const router = useRouter()
 
-const currentUser = ref(JSON.parse(localStorage.getItem('user') || '{}'))
+// Utilisateur courant réactif depuis le store (#19) — plus de localStorage('user')
+const currentUser = computed(() => useAuthStore().currentUser)
 
 async function handleEventAction({ type, data }) {
   console.log('[StudentSchedule] Action:', type, data)
@@ -45,7 +47,7 @@ async function handleEventAction({ type, data }) {
         console.log('[StudentSchedule] Rejoint visio:', data.id)
         // Ouvrir Jitsi
         const roomId = data.visio?.room_id || data.visio_room_id || `seance_${data.id}`
-        const userName = encodeURIComponent(currentUser.value.name || 'Etudiant')
+        const userName = encodeURIComponent(currentUser.value?.name || 'Etudiant')
         const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
         window.open(jitsiLink, '_blank')
       } catch (error) {

--- a/src/views/teacher/TeacherSchedule.vue
+++ b/src/views/teacher/TeacherSchedule.vue
@@ -24,16 +24,18 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
 import { lmsService } from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
 
 const router = useRouter()
 const calendarRef = ref(null)
 
-const currentUser = ref(JSON.parse(localStorage.getItem('user') || '{}'))
+// Utilisateur courant réactif depuis le store (#19) — plus de localStorage('user')
+const currentUser = computed(() => useAuthStore().currentUser)
 
 async function handleEventAction({ type, data }) {
   console.log('[TeacherSchedule] Action:', type, data)
@@ -43,7 +45,7 @@ async function handleEventAction({ type, data }) {
       // Enseignant rejoint la visio active - ouvrir Jitsi directement
       {
         const roomId = data.visio?.room_id || data.visio_room_id || `seance_${data.id}`
-        const userName = encodeURIComponent(currentUser.value.name || 'Enseignant')
+        const userName = encodeURIComponent(currentUser.value?.name || 'Enseignant')
         const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
         window.open(jitsiLink, '_blank')
       }
@@ -57,7 +59,7 @@ async function handleEventAction({ type, data }) {
           console.log('[TeacherSchedule] Visio demarree:', data.id)
           // Ouvrir Jitsi
           const roomId = result.data?.visio_room_id || data.visio?.room_id || `seance_${data.id}`
-          const userName = encodeURIComponent(currentUser.value.name || 'Enseignant')
+          const userName = encodeURIComponent(currentUser.value?.name || 'Enseignant')
           const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
           window.open(jitsiLink, '_blank')
           // Rafraichir le calendrier

--- a/tests/contract/api-contract.spec.mjs
+++ b/tests/contract/api-contract.spec.mjs
@@ -12,6 +12,7 @@
  *
  * Chaque cible est confirmée par `.claude/specs/api-contract-sync/backend-contract-verified.md`.
  */
+import { setActivePinia, createPinia } from 'pinia'
 import { installCapture } from './captureAdapter.mjs'
 
 // Services réels (import = le vrai code testé, pas un double).
@@ -172,6 +173,9 @@ const DEAD_PATH_MATCHERS = [
  * @returns {Promise<{results: Array<{name, ok, detail, _req, _ek}>, failed: number}>}
  */
 export async function runContractAssertions() {
+  // Pinia actif requis : l'intercepteur axios lit le token via useAuthStore() (#19).
+  // Store vide ici → aucun header Authorization → les assertions de chemin sont intactes.
+  setActivePinia(createPinia())
   const capture = installCapture()
   const results = []
 


### PR DESCRIPTION
## Contexte

TIER 0 de l'audit (épique #16). Recoupe **#2/#6** (token en localStorage = XSS) et **#11** (token visio absent/périmé).

L'état d'auth vivait dans **13 accès directs et incohérents** au storage sur 12 fichiers : token en `sessionStorage` partout **sauf** `visio.js` (`localStorage`), et **6 vues lisaient `localStorage('user')`** que `api.js` n'écrivait jamais (il écrit `sessionStorage`) → `currentUser` y valait `{}` (**bug latent corrigé**).

## Solution — `src/stores/auth.js` (`useAuthStore`)

- State `user/token/meta/institution` + **hydratation `sessionStorage`** tolérante (try/catch).
- Getters **dérivés de `roles.js`** (#18, fail-secure) : `isAdmin/isSupradmin/isTeacher/isStudent`, `isAuthenticated`, `currentUser` (**`null` jamais `{}`**), `institutionSlug`.
- Actions `login` (POST /auth/login) / `logout` (purge + `clearAllCache`) / `setSession` / `setInstitution` / `me`.
- **Persistance unique `sessionStorage`** (jamais `localStorage` → atténuation XSS).

## Intégration sans régression

- `api.js` bloc `auth` → **façade fine** déléguant au store (16 méthodes, **88 appels / 32 fichiers intacts**) ; intercepteurs lisent le token / déclenchent `logout()` via le store **à la volée**.
- **Anti-cycle ESM** : `auth.js` n'importe que l'instance axios `default` ; `useAuthStore()` jamais au top-level (Pinia actif seulement à l'exécution).
- **12 fichiers migrés** : 6 lectures token visio + 6 lectures `user` → store (`computed` réactif pour les 2 Schedule), gardes `?.` là où `currentUser` peut être `null`.

## Vérifications

| Commande | Résultat |
|---|---|
| `npm run test` | **62 tests verts** (11 store : login/logout/persistance/getters/**régression #11**/**bug user**/hydratation/réactivité/façade) |
| `npm run test:contract` | **28/28** (non-régression #17) |
| `npm run build` | réussi |
| greps | 0 `localStorage('user')`, 0 `sessionStorage('token')` direct, 0 `localStorage('token')` |

## Dette tracée

- **#19-D1** : `sessionStorage` reste lisible par JS ; cookie `HttpOnly` (idéal #2/#6) exigerait une **modif backend** (hors scope NFR-2). Tracée, non payée.

## Spec

`.claude/specs/auth-store/` (requirements EARS, design, tasks).

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
