### PR TITLE
fix(errors): handler d'erreurs centralisé (#20)

### DIFF
--- a/.claude/specs/error-handler/design.md
+++ b/.claude/specs/error-handler/design.md
@@ -1,0 +1,462 @@
+# Design Document — Gestion centralisée des erreurs côté client (error-handler)
+
+> Issue GitHub **#20** (TIER 0 CRITICAL, épique d'audit #16). Équivalent frontend de `PRODUCTION_STANDARDS §1.2` (« Aucun `$e->getMessage()` exposé au client »). Aucune modification backend.
+
+## Overview
+
+### Objectif
+
+Garantir, de façon **vérifiable par test**, qu'aucun détail technique d'infrastructure (message SQL/SQLSTATE, stack trace, chemin de fichier, nom de classe d'exception, message d'exception axios) ne puisse atteindre l'utilisateur final, tout en offrant des messages d'erreur français cohérents, actionnables et prêts pour l'i18n.
+
+La pièce centrale est une **fonction pure de normalisation** qui transforme n'importe quelle erreur (erreur axios, réponse applicative `{success:false}`, `Error` native, `null`, chaîne, objet inattendu) en un résultat sûr `{ category, userMessage, fieldErrors }`. Cette fonction est appelée à deux endroits cohérents par construction (même fonction pure) :
+
+1. dans l'**intercepteur de réponse** de `src/services/api.js`, qui attache `error.userMessage` (et `error.fieldErrors` pour 422) avant `Promise.reject(error)` ;
+2. directement dans les **composants** qui n'ont pas reçu une erreur passée par l'intercepteur (erreur applicative `{success:false}` levée localement, `Error` native).
+
+### Scope de CE design (vs dette)
+
+| Inclus dans cette itération | Tracé en dette |
+|---|---|
+| Module pur `src/services/errorHandler.js` (`normalizeError`, `logError`) | Migration des ~80 expositions `.message` restantes (vagues 2+) → **#20-FE-1** |
+| Catalogue gelé `src/constants/errorMessages.js` | Intégration APM/Sentry (déféré TIER 2 backend) |
+| Tests Vitest exhaustifs de `normalizeError` | i18n complet (le catalogue le prépare seulement) |
+| Branchement intercepteur (`userMessage` + `fieldErrors`) | Migration comparaisons de rôle (#18-FE-2) |
+| Migration des **21 `alert()` d'erreur** (vague 1) | Refonte god components (#28) |
+
+### Briques réutilisées (lues, vérifiées le 2026-06-15)
+
+- `src/services/toast.js` : singleton `toast.success/error/warning/info(message, title)`. Cible d'affichage.
+- `src/services/api.js` : intercepteur réponse (#19) — `console.error('❌ API Error:', url, status)` puis `return Promise.reject(error)` ; logout 401 via `useAuthStore().logout()` + redirection conditionnelle.
+- `src/constants/roles.js` (#18) : pattern `logRoleDecision` (journal sans donnée sensible, `if (import.meta.env?.PROD) return`), `Object.freeze`, `normalizeRole` (fonction pure fail-soft). Modèles à reproduire.
+- Format d'erreur backend 422 confirmé : `error.response.data.errors = { champ: [messages] }` (Laravel), vérifié à `src/views/admin/AdminInstitutions.vue:427-428`.
+
+## Architecture
+
+### Diagramme d'architecture système
+
+```mermaid
+graph TB
+    subgraph Composants
+        C1[Composant Vue]
+    end
+    subgraph CoucheServices
+        API[api.js intercepteur reponse]
+        EH[errorHandler.js normalizeError logError]
+        TOAST[toast.js]
+    end
+    subgraph Donnees
+        CAT[errorMessages.js catalogue gele]
+    end
+    subgraph Backend
+        BE[API Laravel lecture seule]
+    end
+
+    C1 -->|appel methode api| API
+    API -->|requete HTTP| BE
+    BE -->|erreur HTTP| API
+    API -->|normalizeError error| EH
+    EH -->|lit messages| CAT
+    EH -->|userMessage fieldErrors| API
+    API -->|reject error enrichi| C1
+    C1 -->|toast.error error.userMessage| TOAST
+    C1 -.erreur locale non axios.->|normalizeError error| EH
+    API -->|logError error contexte| EH
+```
+
+### Diagramme de flux de données
+
+```mermaid
+graph LR
+    IN[Erreur quelconque] --> CL{Classification}
+    CL -->|response.status present| BYCODE[Categorie par code HTTP]
+    CL -->|pas de response| NET[Categorie network]
+    CL -->|success false applicatif| APP[Regles d exposition]
+    CL -->|Error null string inconnu| UNK[Categorie unknown]
+    BYCODE --> POL{Message serveur autorise}
+    APP --> POL
+    POL -->|422 champs| FIELDS[fieldErrors structure plus message agrege]
+    POL -->|categorie sure| SAFE[Message serveur controle]
+    POL -->|categorie a risque| CATMSG[Message catalogue force]
+    NET --> CATMSG
+    UNK --> CATMSG
+    FIELDS --> OUT[Resultat category userMessage fieldErrors]
+    SAFE --> OUT
+    CATMSG --> OUT
+```
+
+## Décisions tranchées
+
+Conformément à `PRODUCTION_STANDARDS §6` (« UNE seule solution, jamais A ou B »), chaque point ouvert du requirements est tranché en une option unique, justifiée par lecture de code.
+
+### (a) Forme du module → **service pur** `src/services/errorHandler.js`
+
+**Décision : module service exportant la fonction pure `normalizeError(error)`. PAS de composable.**
+
+Justification par preuve :
+- La normalisation n'a **aucun état réactif** : elle prend une erreur en entrée et retourne un objet. Un composable (`useErrorHandler`) n'apporterait de valeur que s'il exposait un `ref`/`reactive` ou un cycle de vie ; ici il n'y en a aucun.
+- Le **même code doit être appelé hors d'un composant Vue** : l'intercepteur de `api.js` n'est pas un composant et ne peut pas appeler un composable (`useXxx` exige un contexte de setup). Une fonction pure importable partout est la seule forme qui satisfait à la fois l'intercepteur (Requirement 5) et les composants (Requirement 5.5).
+- Le requirement 1.6 impose explicitement une **fonction pure sans effet de bord**, testable en isolation (Requirement 8.6, `§1.3`). C'est exactement le contrat d'une fonction de service, pas d'un composable.
+- Cohérence avec l'existant : `roles.js` est un module de fonctions pures (`normalizeRole`, `hasRole`, `canActivate`) consommé indistinctement par le router (hors composant) et par les composants. On reproduit ce pattern éprouvé.
+
+### (b) Catalogue → `src/constants/errorMessages.js`, séparé du module (SRP)
+
+**Décision : catalogue de données dans `src/constants/errorMessages.js`, gelé `Object.freeze`, distinct du module de logique.**
+
+Justification par preuve :
+- **SRP (`§1.6`)** : la donnée (messages) et la logique (classification) ont deux raisons de changer distinctes — ajouter/reformuler un message vs changer une règle de classification. Les séparer respecte la responsabilité unique exigée par Requirement 1.8 et 9 (NFR SOLID).
+- **Cohérence d'emplacement** : `src/constants/` héberge déjà `roles.js`, lui-même un catalogue gelé (`ROLES`, `ALIAS`, `DISPLAY_NAMES` via `Object.freeze`). Requirement 2.6 impose explicitement le même pattern `Object.freeze`.
+- **Préparation i18n (Requirement 2.3, NFR 6)** : un objet plat `catégorie → message` est trivialement transformable en `catégorie → clé i18n` plus tard, sans toucher aux sites appelants ni à la logique de `normalizeError` (qui lit toujours `ERROR_MESSAGES[category]`).
+
+### (c) Migration → **incrémentale priorisée**, vague 1 dans CE design
+
+**Décision : module + catalogue + branchement intercepteur + migration des 21 `alert()` d'erreur. Le reliquat (~80 expositions `.message`) est tracé en dette #20-FE-1.**
+
+Justification par preuve :
+- Un big-bang sur ~135 sites recensés (114 `alert`, 80 expositions, recoupements inclus) sur 37 emplacements serait une PR ingérable, non revue sérieusement, à fort risque de régression — l'opposé de la qualité exigée. Requirement 6.4 autorise et recommande explicitement l'incrémental priorisé avec dette tracée.
+- La vague 1 attaque les sites à la fois les **plus risqués sécurité ET les plus visibles UX** : les 21 `alert()` contenant une variable d'erreur concatènent `error.response?.data?.message || error.message` (ex. `VisioManager.vue:285`) — c'est exactement le vecteur de fuite §1.2.
+- Le branchement intercepteur fait baisser le risque résiduel **immédiatement sur tous les sites non encore migrés** : dès que `error.userMessage` est disponible, un site migré ultérieurement n'a qu'à lire ce champ.
+
+**Périmètre exact de CE design :**
+
+| Élément | Vague 1 (ce design) | Dette #20-FE-1 |
+|---|---|---|
+| `src/services/errorHandler.js` | ✅ créé + testé | — |
+| `src/constants/errorMessages.js` | ✅ créé | — |
+| Branchement `api.js` | ✅ `userMessage` + `fieldErrors` | — |
+| 21 `alert(... error ...)` | ✅ migrés en `toast.error(...)` | — |
+| ~80 expositions `.message` (`this.error =`, `error.value =`) | sites déjà touchés par les 21 alerts uniquement | reste migré par vagues |
+| Sites `*.vue.bak` | exclus (Requirement 6.5) | exclus |
+
+### (d) Branchement → intercepteur attache `error.userMessage` ; composants lisent en priorité ce champ, sinon appellent `normalizeError`
+
+**Décision : l'intercepteur attache `error.userMessage` (et `error.fieldErrors` pour 422) ; les sites consomment `error.userMessage ?? normalizeError(error).userMessage`.**
+
+Justification par preuve :
+- **Point unique de normalisation** (Requirement 5.1) : toute erreur HTTP traverse l'intercepteur, donc tout site recevant une erreur axios dispose gratuitement de `userMessage` sans dupliquer la logique.
+- **Cohérence garantie par construction** (Requirement 5.5) : les deux voies appellent **la même fonction pure** `normalizeError`. Il n'existe pas deux implémentations à maintenir synchrones.
+- **Cas non couverts par l'intercepteur** : certaines erreurs sont des `new Error(response?.message || ...)` levées **localement** dans les composants (ex. `VisioManager.vue:281`, `ParticipantsModal.vue:380`) — elles ne passent jamais par l'intercepteur. Le fallback `?? normalizeError(error)` les couvre. D'où l'opérateur de coalescence : `error.userMessage` s'il existe, sinon normalisation directe.
+
+## Composants et interfaces
+
+### `src/services/errorHandler.js`
+
+Module de fonctions pures. Responsabilité unique : **normaliser** et **journaliser** ; jamais afficher (pas d'import de `toast`), jamais naviguer, jamais muter d'état global.
+
+```js
+/**
+ * @typedef {'auth'|'forbidden'|'notFound'|'validation'|'rateLimit'|'server'|'network'|'unknown'} ErrorCategory
+ *
+ * @typedef {Object} NormalizedError
+ * @property {ErrorCategory} category   Catégorie classifiée.
+ * @property {string}        userMessage Chaîne SÛRE, non vide, issue du catalogue (jamais un détail technique brut sauf cas contrôlés 422/403/404).
+ * @property {Object.<string,string[]>|null} fieldErrors Messages par champ pour 422, sinon null.
+ */
+
+/**
+ * Transforme n'importe quelle erreur en résultat sûr. PURE, déterministe, sans effet de bord.
+ * @param {unknown} error
+ * @returns {NormalizedError}
+ */
+export function normalizeError(error) { /* ... */ }
+
+/**
+ * Journalisation sûre (catégorie, status, url) — JAMAIS token/email/mot de passe.
+ * Désactivée en production. Modèle logRoleDecision.
+ * @param {unknown} error
+ * @param {string} [context] Étiquette d'origine non sensible (ex. '[api.js]').
+ * @returns {void}
+ */
+export function logError(error, context = '') { /* ... */ }
+```
+
+#### Logique de classification de `normalizeError`
+
+Ordre de décision (premier cas vrai gagne) :
+
+1. **`error` falsy, ou typeof string, ou `Error` native sans `response`** → `category = 'unknown'`, `userMessage = ERROR_MESSAGES.unknown`, `fieldErrors = null`. (Couvre `null`, `undefined`, `'oops'`, `new Error('boom')`.)
+2. **`error.response` présent** (erreur axios avec réponse HTTP) → classer par `error.response.status` via `categoryFromStatus(status)` :
+   - `401 → 'auth'`, `403 → 'forbidden'`, `404 → 'notFound'`, `422 → 'validation'`, `429 → 'rateLimit'`, `>= 500 → 'server'`, autre → `'unknown'`.
+3. **`error.response` absent MAIS `error.request` présent OU `error.isAxiosError`/code réseau** (timeout, coupure, CORS) → `category = 'network'`.
+4. **Objet applicatif `{ success:false, message }`** sans enveloppe axios (erreur levée localement) → `category = 'unknown'` par défaut (pas de status pour qualifier le risque) ; le `message` applicatif n'est **jamais** exposé tel quel (règle d'exposition §1.2) → on retourne `ERROR_MESSAGES.unknown`.
+5. **Fallback final** → `'unknown'`.
+
+Construction de `userMessage` après classification, via `resolveMessage(category, error)` :
+
+| Catégorie | Source du message utilisateur | Message serveur autorisé ? |
+|---|---|---|
+| `validation` (422) | message agrégé des champs si exploitables, sinon `ERROR_MESSAGES.validation` | **Oui**, champs (libellés validation Laravel, non sensibles) |
+| `forbidden` (403) | `ERROR_MESSAGES.forbidden` (catalogue) | Non — message catalogue forcé (prudence : un 403 contrôlé pourrait l'autoriser, voir note) |
+| `notFound` (404) | `ERROR_MESSAGES.notFound` (catalogue) | Non — message catalogue forcé |
+| `auth` (401) | `ERROR_MESSAGES.auth` | Non |
+| `rateLimit` (429) | `ERROR_MESSAGES.rateLimit` | Non |
+| `server` (5xx) | `ERROR_MESSAGES.server` | **Jamais** (Requirement 4.1, 4.5) |
+| `network` | `ERROR_MESSAGES.network` | **Jamais** (Requirement 4.4) |
+| `unknown` | `ERROR_MESSAGES.unknown` | **Jamais** |
+
+> **Note de décision sur 403/404** : bien que Requirement 4.3 cite 403/404 comme « éventuellement contrôlés », on **force le message catalogue** pour 403/404 dans cette itération. Raison vérifiée : le backend Laravel renvoie pour ces codes des messages potentiellement variables (`Unauthenticated.`, messages d'exception de policy) dont la sûreté n'est pas garantie sans audit backend — interdit ici. Seul 422 ouvre la porte aux messages serveur, car son format `errors:{champ:[...]}` est structurellement des libellés de validation destinés à l'utilisateur. C'est le choix fail-secure (cohérent avec `roles.js` fail-secure). Évolution possible (dette potentielle) si le backend garantit des messages 403/404 sûrs.
+
+#### Traitement structuré du 422 (`extractFieldErrors`)
+
+- Lit `error.response.data.errors` (format Laravel confirmé `AdminInstitutions.vue:427`).
+- Si c'est un objet non vide `{ champ: [msg, ...] }` → `fieldErrors = ce_objet` ; `userMessage` = agrégation des messages (ex. join des premières valeurs, ou `ERROR_MESSAGES.validation` en préfixe) → satisfait Requirement 3.4 (message agrégé pour appelants non structurés).
+- Si absent / vide / forme inattendue → `fieldErrors = null`, `userMessage = ERROR_MESSAGES.validation` (Requirement 3.2).
+- `fieldErrors` ne contient **que** ce que le backend a mis dans `errors` (libellés de validation) ; aucun ajout de détail technique (Requirement 3.3).
+
+#### `logError(error, context)`
+
+- `if (import.meta.env?.PROD) return` (modèle `logRoleDecision`, Requirement 7.2 ; optional chaining identique à `roles.js`/`api.js` pour les exécutions hors Vite).
+- Construit un contexte **non sensible** : `{ category, status: error?.response?.status ?? null, url: error?.config?.url ?? null }`. Jamais `headers.Authorization`, jamais le corps de requête, jamais email/token (Requirement 7.1).
+- `console.warn(\`[errorHandler] ${context}\`, safeContext)` (cohérent `[roles]`).
+- Si aucune info exploitable → journalise au minimum `{ category: 'unknown' }` sans échouer (Requirement 7.4).
+
+### `src/services/api.js` — branchement intercepteur
+
+Modification **chirurgicale** du handler d'erreur de `interceptors.response.use`, en préservant le flux #19 (logout 401, `Promise.reject`).
+
+```js
+import { normalizeError, logError } from './errorHandler'
+// (import relatif, cohérent avec '../constants/roles' déjà importé en relatif #19)
+
+api.interceptors.response.use(
+  (response) => response.data,
+  (error) => {
+    // #19 préservé : journal d'origine remplacé par logError (sûr, désactivé en prod)
+    logError(error, '[api.js] response interceptor')
+
+    // #20 : attacher le message normalisé AVANT toute autre branche
+    const normalized = normalizeError(error)
+    error.userMessage = normalized.userMessage
+    error.fieldErrors = normalized.fieldErrors   // null hors 422
+
+    // #19 INCHANGÉ : logout 401 via le store + redirection conditionnelle
+    if (error.response?.status === 401) {
+      useAuthStore().logout()
+      if (!window.location.pathname.includes('/login')) {
+        window.location.href = '/login'
+      }
+    }
+
+    return Promise.reject(error)   // flux de rejet préservé (Requirement 5.2)
+  }
+)
+```
+
+Points garantis :
+- L'attachement se fait **avant** la branche 401 et le `reject` (Requirement 5.1).
+- La promesse reste **rejetée avec l'objet erreur** (jamais résolue/avalée — Requirement 5.2).
+- Le comportement 401 est **identique** au code #19 (Requirement 5.3).
+- `error.fieldErrors` est posé pour le 422 (Requirement 5.4).
+- `console.error('❌ API Error:', ...)` est remplacé par `logError` qui journalise les **mêmes** informations non sensibles (url, status) mais ajoute la désactivation prod ; aucune perte de diagnostic en dev.
+
+## Data Models
+
+### Définitions des structures de données
+
+```js
+// Catalogue — src/constants/errorMessages.js (gelé, cohérent roles.js)
+export const ERROR_MESSAGES = Object.freeze({
+  auth:       "Votre session a expiré. Veuillez vous reconnecter.",
+  forbidden:  "Vous n'avez pas les droits nécessaires pour cette action.",
+  notFound:   "La ressource demandée est introuvable.",
+  validation: "Certains champs sont invalides. Veuillez vérifier votre saisie.",
+  rateLimit:  "Trop de requêtes. Veuillez patienter un instant avant de réessayer.",
+  server:     "Une erreur est survenue côté serveur. Veuillez réessayer plus tard.",
+  network:    "Connexion impossible. Vérifiez votre connexion internet et réessayez.",
+  unknown:    "Une erreur inattendue est survenue. Veuillez réessayer.",
+})
+```
+
+> Les clés correspondent 1:1 aux valeurs de `ErrorCategory`. La résolution est toujours `ERROR_MESSAGES[category] ?? ERROR_MESSAGES.unknown` (Requirement 2.2 : repli sur `unknown` si clé manquante).
+
+### Forme du résultat de normalisation
+
+```js
+// Cas réseau (axios sans response)
+{ category: 'network',    userMessage: ERROR_MESSAGES.network, fieldErrors: null }
+
+// Cas 5xx avec message SQL brut côté serveur — le message brut N'EST JAMAIS exposé
+{ category: 'server',     userMessage: ERROR_MESSAGES.server,  fieldErrors: null }
+
+// Cas 422 avec erreurs de champ
+{
+  category: 'validation',
+  userMessage: "Certains champs sont invalides. Veuillez vérifier votre saisie.",
+  fieldErrors: { email: ["L'adresse e-mail est déjà utilisée."], nom: ['Le nom est requis.'] }
+}
+
+// Entrée invalide (null, undefined, string, Error native)
+{ category: 'unknown',    userMessage: ERROR_MESSAGES.unknown, fieldErrors: null }
+```
+
+### Diagramme du modèle de données
+
+```mermaid
+graph TD
+    NE[NormalizedError] --> CAT[category enum 8 valeurs]
+    NE --> UM[userMessage chaine non vide]
+    NE --> FE[fieldErrors objet champ vers messages ou null]
+    CAT --> CATALOG[ERROR_MESSAGES cle par categorie]
+    FE -->|seulement si validation| SRC[response.data.errors backend Laravel]
+```
+
+## Business Process
+
+### Processus 1 : Normalisation d'une erreur
+
+```mermaid
+flowchart TD
+    A[normalizeError error] --> B{error falsy ou string ou Error sans response}
+    B -->|oui| U[category unknown]
+    B -->|non| C{error.response present}
+    C -->|oui| D[categoryFromStatus error.response.status]
+    C -->|non| E{error.request ou code reseau}
+    E -->|oui| N[category network]
+    E -->|non| F{objet success false}
+    F -->|oui| U
+    F -->|non| U
+    D --> G{category vaut validation}
+    G -->|oui| H[extractFieldErrors response.data.errors]
+    G -->|non| I[resolveMessage category]
+    H --> J{champs exploitables}
+    J -->|oui| K[userMessage agrege plus fieldErrors]
+    J -->|non| L[userMessage ERROR_MESSAGES.validation fieldErrors null]
+    I --> M[userMessage ERROR_MESSAGES par categorie]
+    N --> M
+    U --> M
+    K --> R[retour NormalizedError]
+    L --> R
+    M --> R
+```
+
+### Processus 2 : Branchement intercepteur (point unique)
+
+```mermaid
+sequenceDiagram
+    participant C as Composant
+    participant API as api.js intercepteur
+    participant EH as errorHandler
+    participant BE as Backend
+    C->>API: appel methode api
+    API->>BE: requete HTTP
+    BE-->>API: erreur HTTP status data
+    API->>EH: logError error contexte
+    API->>EH: normalizeError error
+    EH-->>API: category userMessage fieldErrors
+    API->>API: error.userMessage et error.fieldErrors poses
+    alt status 401
+        API->>API: useAuthStore logout plus redirection conditionnelle
+    end
+    API-->>C: Promise.reject error enrichi
+```
+
+### Processus 3 : Affichage dans un site migré
+
+```mermaid
+flowchart TD
+    A[catch error] --> B{error.userMessage present}
+    B -->|oui voie intercepteur| C[message error.userMessage]
+    B -->|non erreur locale| D[normalizeError error puis userMessage]
+    C --> E[toast.error message]
+    D --> E
+    E --> F[loading false etat preserve]
+```
+
+### Pattern de migration d'un site type
+
+Exemple `VisioManager.vue:283-285` (avant) :
+
+```js
+} catch (error) {
+  console.error('[VisioManager] Erreur programmation visio:', error)
+  alert('Erreur lors de la programmation de la visio: ' + (error.response?.data?.message || error.message))
+}
+```
+
+Après (Requirement 6.1, 6.3, 6.6 — seule la source du message change, branches inchangées) :
+
+```js
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
+// ...
+} catch (error) {
+  toast.error(error.userMessage ?? normalizeError(error).userMessage)
+}
+```
+
+> Le `console.error` local part au profit du journal centralisé (`logError` dans l'intercepteur pour les erreurs HTTP ; les erreurs locales `new Error(...)` n'ont pas de détail sensible). `error.userMessage` est présent pour les erreurs axios (posé par l'intercepteur) ; le `?? normalizeError(error)` couvre les `new Error(response?.message || ...)` levées localement (`VisioManager.vue:281`). `loading`/état finally inchangés (Requirement 6.6).
+
+Exemple affectation d'état `ParticipantsModal.vue:384` (avant `this.error = error.response?.data?.message || error.message || 'Erreur inconnue'`) → après `this.error = error.userMessage ?? normalizeError(error).userMessage`.
+
+## Error Handling
+
+- **Sûreté absolue par défaut** : toute catégorie à risque (`server`, `network`, `unknown`) force le message catalogue ; il n'existe **aucun chemin** par lequel `error.message`/`error.response.data.message` d'un 5xx ou réseau atteint `userMessage` (Requirement 4.5, prouvé par test).
+- **`normalizeError` ne lève jamais** : toute branche aboutit à un `NormalizedError` valide, y compris pour `null`/`undefined`/objets exotiques (Requirement 1.5). Accès défensif (`error?.response?.status`, `?? null`).
+- **Séparation stricte affichage / journal** (Requirement 7.3) : le détail technique ne vit que dans `logError` (dev uniquement), jamais dans `userMessage`.
+- **Le flux #19 n'est pas dégradé** : logout 401 et `Promise.reject` préservés ; un éventuel throw dans `normalizeError` serait fatal pour l'intercepteur — d'où la garantie « ne lève jamais » testée.
+
+## Testing Strategy
+
+Tests Vitest (#21), TDD (`§1.3`), fichier `src/services/errorHandler.test.js`. La fonction étant pure, les tests sont déterministes et sans mock réseau.
+
+| Test | Vérifie | Requirement |
+|---|---|---|
+| 401/403/404/429 par status | `category` correcte + `userMessage === ERROR_MESSAGES[cat]` | 8.1 |
+| 5xx avec `data.message = "SQLSTATE[23000] FK constraint..."` | `userMessage === ERROR_MESSAGES.server` ET `userMessage` **ne contient pas** la sous-chaîne `SQLSTATE` | 8.2, 4.1, 9.1 |
+| 422 avec `data.errors = {email:[...], nom:[...]}` | `fieldErrors` égal à l'objet, `category === 'validation'`, `userMessage` non vide | 8.3, 3.1 |
+| 422 sans `errors` exploitable | `fieldErrors === null`, `userMessage === ERROR_MESSAGES.validation` | 3.2 |
+| Réseau (axios `{request}` sans `response`, `code:'ECONNREFUSED'`) | `category === 'network'`, `userMessage === ERROR_MESSAGES.network`, ne contient pas `ECONNREFUSED` | 8.5, 4.4 |
+| Entrées `null`, `undefined`, `'string'`, `{}`, `new Error('boom')` | retour `unknown`, **aucune exception levée** (`expect(() => normalizeError(x)).not.toThrow()`) | 8.4, 1.5 |
+| Déterminisme | deux appels sur la même entrée → résultats `toEqual` | 8.6, 1.7 |
+| Pureté | aucun spy `toast`/navigation déclenché ; entrée non mutée | 8.6, 1.6 |
+| `logError` en prod simulé (`import.meta.env.PROD = true`) | `console.warn` non appelé | 7.2 |
+| `logError` contexte | n'inclut jamais `Authorization`/token/email | 7.1 |
+
+Preuve d'équivalence sécurité (Requirement 9) : le test « 5xx SQL brut » et le test « réseau ECONNREFUSED » constituent la preuve mesurable qu'aucun détail technique ne fuit par la normalisation — l'équivalent frontend du grep backend `getMessage()` = 0.
+
+## Mapping de migration (vague 1)
+
+Les 21 `alert()` contenant une variable d'erreur, transformés en `toast.error(error.userMessage ?? normalizeError(error).userMessage)`. Sites types confirmés par lecture :
+
+| Fichier | Ligne (avant) | Forme actuelle | Action |
+|---|---|---|---|
+| `src/components/visio/VisioManager.vue` | 285 | `alert('...' + (error.response?.data?.message || error.message))` | `toast.error(...)` |
+| `src/components/visio/ParticipantsModal.vue` | 384 | `this.error = error.response?.data?.message || error.message || 'Erreur inconnue'` | `this.error = error.userMessage ?? normalizeError(error).userMessage` |
+| `src/components/modals/GenerateReportModal.vue` | 210-211 | `error.value = err.response?.data?.message || '...'` puis `toast.error(error.value)` | `error.value = err.userMessage ?? normalizeError(err).userMessage` |
+| `src/views/admin/AdminEnseignants.vue` | 455 | `error.value = err.message || '...'` | `error.value = err.userMessage ?? normalizeError(err).userMessage` |
+
+> Les autres occurrences `alert(... error ...)` (les 12 de `VisioManager.vue`, etc.) suivent strictement le même pattern. L'inventaire exhaustif des 21 sera figé au début de l'implémentation par grep (`alert\([^)]*\b(error|err|e)\b`) pour éviter toute dérive de compte.
+
+## Dette tracée
+
+**#20-FE-1 — Migration du reliquat des expositions de message brut.**
+- **Quoi** : les ~80 expositions `.message` restantes (`this.error =`, `error.value =`, `error.response?.data?.message`) hors des sites de la vague 1, sur les ~37 emplacements recensés, ainsi que les `alert()` non porteurs d'erreur (UX) non couverts ici.
+- **Pourquoi différé** : un big-bang sur ~135 sites serait non revoyable et risqué (cf. décision c). L'intercepteur réduit déjà le risque résiduel sur tous les sites (chaque erreur axios porte `error.userMessage`).
+- **Risque résiduel** : un site non migré affichant encore `error.response.data.message` peut exposer un message serveur ; mitigé car les 5xx backend conformes `§1.2` ne renvoient déjà pas de détail. Risque concentré sur les `alert()` concaténant `error.message` non encore traités hors vague 1.
+- **Quand** : par vagues successives, priorisées par fréquence d'affichage et sensibilité, après livraison de cette itération.
+- **Mesure** : compteur exact à recalculer par grep en fin de vague 1 (point de départ : 80 expositions / 37 emplacements au 2026-06-15).
+
+**Note 403/404** : message serveur non exposé pour ces codes (message catalogue forcé) faute de garantie backend auditable ici ; à rouvrir si le backend garantit des messages 403/404 sûrs.
+
+## Conformité PRODUCTION_STANDARDS
+
+| Section | Application |
+|---|---|
+| **§1.2 Sécurité Absolue** | Équivalence `getMessage()` = 0 côté client : 5xx/network/unknown forcent le message catalogue ; preuve par test (« SQL brut jamais exposé »). `logError` ne journalise jamais token/email. |
+| **§1.3 Tests Obligatoires** | `normalizeError` unit-testée en isolation, TDD, happy path + edge cases (chaque catégorie + entrées invalides) ; déterminisme et pureté prouvés. |
+| **§1.6 SOLID** | **S** : `errorHandler.js` ne fait que normaliser/journaliser ; `errorMessages.js` ne porte que la donnée ; `toast.js` n'affiche. **O** : nouvelle catégorie = nouvelle clé catalogue + nouveau cas `categoryFromStatus`, sans réécrire les sites. **L** : fonction pure substituable par un fake trivial en test. **I** : API minimale (`normalizeError`, `logError`). **D** : les sites dépendent de l'abstraction « message sûr », pas du format d'erreur axios. |
+| **§5 Standards par type** | Module et fonctions de taille maîtrisée (fonctions ≤ ~40 lignes, fichier bien < 300 lignes) ; découpage en helpers (`categoryFromStatus`, `resolveMessage`, `extractFieldErrors`). |
+| **§6 Une seule solution** | Chaque décision (a/b/c/d) tranchée en une option justifiée par lecture de code, sans « A ou B ». |
+
+## Traçabilité design → requirements
+
+| Requirement | Section(s) du design |
+|---|---|
+| 1 — Module de normalisation pur | Décision (a), Composants/`errorHandler.js`, Processus 1 |
+| 2 — Catalogue centralisé | Décision (b), Data Models/`ERROR_MESSAGES` |
+| 3 — Validation 422 structurée | `extractFieldErrors`, Data Models (forme 422), Tests 422 |
+| 4 — Non-divulgation §1.2 | Tableau d'exposition, Error Handling, Tests 5xx/réseau |
+| 5 — Branchement intercepteur | Décision (d), `api.js`, Processus 2 |
+| 6 — Migration des sites | Décision (c), Pattern de migration, Mapping, Dette |
+| 7 — Journalisation sûre | `logError`, Error Handling, Tests `logError` |
+| 8 — Couverture Vitest | Testing Strategy (toutes lignes) |
+| 9 — Équivalence sécurité backend | Conformité §1.2, preuve par test, Dette (compteur d'écart) |

--- a/.claude/specs/error-handler/requirements.md
+++ b/.claude/specs/error-handler/requirements.md
@@ -1,0 +1,163 @@
+# Requirements Document — Gestion centralisée des erreurs côté client (error-handler)
+
+## Introduction
+
+Cette fonctionnalité centralise et fiabilise la gestion des erreurs côté client du frontend Vue 3 (dépôt `lms-frontend`). Elle répond à l'issue GitHub **#20** (TIER 0 CRITICAL de l'épique d'audit #16) et constitue l'équivalent frontend de la règle backend `PRODUCTION_STANDARDS §1.2` qui interdit d'exposer `$e->getMessage()` à l'utilisateur final.
+
+### Problème vérifié (grep, 2026-06-15, dossier `src/` hors fichiers `.bak`)
+
+- **80 expositions** de `error.message` / `err.message` / `error.response?.data?.message` affichées directement à l'utilisateur (dans des `alert()`, `this.error =`, `error.value =`), réparties sur 37 emplacements.
+- **114 appels `alert(...)`** au total (29 fichiers), dont **21** contenant une variable d'erreur (`error` / `err` / `e`) — UX native incohérente **et** fuite potentielle du détail technique.
+- Message « Erreur lors du chargement » dupliqué **34 fois** (absence de catalogue centralisé / i18n).
+- Risque concret : si l'API renvoie `{ success:false, message:"SQLSTATE[23000]... FK constraint..." }` (erreur 5xx) ou un message d'infrastructure, l'utilisateur voit ce détail. Exemples vérifiés : `components/visio/VisioManager.vue:285` (`alert('Erreur...: ' + (error.response?.data?.message || error.message))`), `components/enseignants/EnseignantsListExample.vue:151` (`this.error = err.message || ...`), `views/lessons/LessonEditor.vue`, `components/modals/GenerateReportModal.vue`, `views/admin/AdminEnseignants.vue:455`, `views/admin/AdminEvaluationDetails.vue:257`.
+
+> Note d'écart par rapport au brief : les chiffres ci-dessus remplacent les estimations du brief (~51 expositions, 42 `alert` avec erreur, ~72 duplications). Recompté par grep le 2026-06-15 ; les fichiers `*.vue.bak` sont exclus du périmètre de migration.
+
+### Briques existantes à réutiliser
+
+- `src/services/toast.js` : service toast singleton (`toast.success/error/warning/info(message, title)`). Cible d'affichage standard, remplace les `alert()`.
+- `src/services/api.js` : intercepteur de réponse (refait en #19) — il fait `console.error('❌ API Error:', ...)` puis `return Promise.reject(error)` (logout sur 401 via le store). Point unique de normalisation en amont.
+- `src/constants/roles.js` (#18) : `logRoleDecision(event, context)` journalise SANS donnée sensible et se désactive en prod (`import.meta.env?.PROD`). Modèle de journalisation à reproduire.
+- `src/constants/` : emplacement candidat pour le catalogue de messages.
+- Vitest installé (#21) : la normalisation doit être testable en isolation (fonction pure).
+
+### Périmètre
+
+- **Inclus** : module de normalisation pur, catalogue de messages centralisé, branchement dans l'intercepteur, migration des `alert()` d'erreur et des affectations de message brut, journalisation sûre, tests Vitest.
+- **Exclu explicitement** : intégration APM/Sentry (déféré, roadmap TIER 2 backend) ; i18n complet (le catalogue prépare i18n mais ne l'implémente pas) ; migration des comparaisons de rôle (#18-FE-2) ; refonte des god components (#28) ; **toute modification backend** (interdite).
+
+---
+
+## Requirements
+
+### Requirement 1 — Module de normalisation pur
+
+**User Story:** En tant qu'ingénieur frontend, je veux une fonction pure unique qui transforme n'importe quelle erreur en un message utilisateur sûr, afin qu'aucun détail technique brut ne puisse atteindre l'utilisateur et que la logique soit testable en isolation.
+
+#### Acceptance Criteria
+
+1. WHEN une erreur est passée au module de normalisation THEN le système SHALL retourner un objet résultat contenant au minimum un message utilisateur sûr (chaîne non vide) et une catégorie d'erreur identifiée.
+2. WHEN l'erreur fournie est une erreur axios avec réponse HTTP THEN le système SHALL déterminer la catégorie à partir du code de statut HTTP (`error.response.status`).
+3. WHEN l'erreur fournie est une erreur axios SANS réponse (timeout, coupure réseau, CORS) THEN le système SHALL classer l'erreur en catégorie « réseau » et retourner le message réseau du catalogue.
+4. WHEN l'erreur fournie est une réponse applicative `{ success:false, message }` THEN le système SHALL traiter `message` selon les règles d'exposition (cf. Requirement 4) et non le restituer aveuglément.
+5. WHEN l'erreur fournie est une `Error` JavaScript native, `null`, `undefined`, une chaîne, ou un type non reconnu THEN le système SHALL retourner le message de repli générique (catégorie « inconnue ») sans lever d'exception.
+6. WHERE le module de normalisation est défini, le système SHALL exposer la normalisation comme une fonction PURE (sans effet de bord : pas d'appel `toast`, pas de navigation, pas de mutation d'état global à l'intérieur de la normalisation elle-même).
+7. IF la même erreur est normalisée deux fois THEN le système SHALL retourner un résultat identique (déterminisme).
+8. WHERE le module est implémenté, le système SHALL respecter `PRODUCTION_STANDARDS §5` (taille des unités) et §1.6 (SOLID — responsabilité unique : normaliser, ne pas afficher).
+
+### Requirement 2 — Catalogue de messages centralisé
+
+**User Story:** En tant que mainteneur, je veux un catalogue unique de messages utilisateur par catégorie d'erreur, afin de supprimer la duplication des 34 « Erreur lors du chargement » et de préparer une future internationalisation.
+
+#### Acceptance Criteria
+
+1. WHERE le catalogue est défini, le système SHALL fournir un message utilisateur sûr pour chacune des catégories suivantes : `401` (non authentifié), `403` (accès refusé), `404` (introuvable), `422` (validation), `429` (trop de requêtes), `5xx` (erreur serveur), `network` (réseau / pas de réponse), et `unknown` (repli générique).
+2. WHEN une catégorie d'erreur ne dispose pas d'un message dédié dans le catalogue THEN le système SHALL utiliser le message de repli générique de la catégorie `unknown`.
+3. WHERE les messages sont définis, le système SHALL les centraliser dans une source unique (le design tranche entre `src/constants/` et le module), structurée de façon à permettre l'introduction ultérieure de clés d'i18n sans changer les sites appelants.
+4. WHEN le catalogue est consulté THEN le système SHALL retourner des messages rédigés en français, orientés utilisateur (actionnables, sans jargon technique).
+5. WHERE le catalogue remplace des chaînes dupliquées, le système SHALL permettre une personnalisation contextuelle optionnelle du message (ex. « impossible de charger les enseignants ») sans réintroduire la duplication littérale ni exposer de détail technique.
+6. WHERE le catalogue est défini, le système SHALL le geler (immuable à l'exécution) de façon cohérente avec le pattern `Object.freeze` utilisé dans `src/constants/roles.js`.
+
+### Requirement 3 — Gestion structurée des erreurs de validation (422)
+
+**User Story:** En tant qu'utilisateur, je veux voir les messages de validation par champ lorsque ma saisie est invalide, afin de corriger précisément mon erreur sans voir d'information technique.
+
+#### Acceptance Criteria
+
+1. WHEN l'erreur est de catégorie `422` ET contient des messages de validation par champ THEN le système SHALL exposer ces messages de champ de façon structurée (accessibles par champ) dans le résultat de normalisation.
+2. WHEN l'erreur `422` ne contient aucun détail de champ exploitable THEN le système SHALL retourner le message générique de validation du catalogue.
+3. WHILE des messages de validation de champ sont exposés, le système SHALL ne transmettre que des libellés non sensibles destinés à l'utilisateur, et SHALL ne jamais inclure de détail technique d'infrastructure (cf. Requirement 4).
+4. WHEN le résultat de normalisation est consommé par un appelant qui n'attend qu'un message simple THEN le système SHALL fournir également un message utilisateur agrégé (chaîne unique) pour le cas `422`, de sorte que les appelants non structurés restent fonctionnels.
+
+### Requirement 4 — Non-divulgation des détails techniques (sécurité §1.2)
+
+**User Story:** En tant que responsable sécurité, je veux qu'aucun détail technique d'infrastructure ne soit jamais affiché à l'utilisateur, afin d'atteindre l'équivalence avec la règle backend `getMessage()` = 0 (`PRODUCTION_STANDARDS §1.2`).
+
+#### Acceptance Criteria
+
+1. WHEN l'erreur est de catégorie `5xx` THEN le système SHALL retourner le message serveur générique du catalogue et SHALL ne jamais retourner comme message utilisateur le contenu brut de `error.response.data.message`.
+2. IF une réponse d'erreur contient une stack trace, un message SQL/SQLSTATE, un chemin de fichier, un nom de classe d'exception ou tout autre détail d'infrastructure THEN le système SHALL ne jamais l'inclure dans le message utilisateur retourné.
+3. WHERE un message provenant du serveur pourrait être affiché, le système SHALL ne le considérer comme affichable que pour les catégories où il est sûr et utile (ex. `422` validation, `403`/`404` contrôlés), et SHALL appliquer le message du catalogue pour les catégories à risque (`5xx`, `unknown`).
+4. WHEN une erreur réseau survient (pas de réponse) THEN le système SHALL ne jamais exposer le détail technique sous-jacent (ex. `ECONNREFUSED`, message d'exception axios) dans le message utilisateur.
+5. WHERE la normalisation est appliquée, le système SHALL garantir qu'il existe zéro chemin par lequel `error.message` brut d'une erreur 5xx ou réseau parvient à l'utilisateur final (vérifiable par test, cf. Requirement 8).
+
+### Requirement 5 — Branchement dans l'intercepteur de réponse (point unique)
+
+**User Story:** En tant qu'ingénieur frontend, je veux que l'intercepteur de réponse attache un message utilisateur sûr à chaque erreur rejetée, afin que tout appelant dispose d'un message prêt à afficher sans dupliquer la logique de normalisation.
+
+#### Acceptance Criteria
+
+1. WHEN l'intercepteur de réponse de `src/services/api.js` rejette une erreur THEN le système SHALL attacher à l'objet erreur un message utilisateur sûr normalisé (ex. `error.userMessage`) avant le `return Promise.reject(error)`.
+2. WHERE l'intercepteur attache le message normalisé, le système SHALL préserver le flux de rejet existant (la promesse reste rejetée avec l'objet erreur) et SHALL ne pas avaler ni résoudre l'erreur.
+3. WHERE l'intercepteur attache le message normalisé, le système SHALL préserver le comportement existant de déconnexion sur 401 (`useAuthStore().logout()` + redirection conditionnelle vers `/login`).
+4. WHEN l'erreur est de catégorie `422` THEN le système SHALL rendre les messages de validation par champ accessibles sur l'objet erreur en plus du message agrégé.
+5. IF un appelant n'utilise pas le message attaché par l'intercepteur THEN le système SHALL permettre à cet appelant d'invoquer directement le module de normalisation pour obtenir le même résultat (cohérence entre les deux voies).
+
+### Requirement 6 — Migration des sites d'affichage d'erreur
+
+**User Story:** En tant qu'utilisateur, je veux des notifications d'erreur cohérentes (toast) plutôt que des `alert()` natifs et des messages techniques bruts, afin d'avoir une expérience homogène et sûre.
+
+#### Acceptance Criteria
+
+1. WHEN un site affiche une erreur via `alert(...)` contenant une variable d'erreur THEN le système SHALL remplacer cet appel par `toast.error(messageNormalisé)`.
+2. WHEN un site affecte un message d'erreur brut à un état (`this.error = err.message || ...` ou `error.value = error.response?.data?.message || ...`) THEN le système SHALL remplacer la valeur affectée par le message utilisateur normalisé.
+3. WHERE la migration est appliquée, le système SHALL ne plus laisser aucun site afficher directement `error.message`, `err.message` ou `error.response?.data?.message` à l'utilisateur dans les fichiers migrés.
+4. IF la migration de la totalité des sites n'est pas réalisable dans le périmètre de cette itération THEN le système SHALL appliquer une migration incrémentale priorisée (module + intercepteur + sites `alert()` d'erreur en premier) ET SHALL tracer explicitement le reliquat comme dette identifiée (fichiers et compteur restants), conformément à `PRODUCTION_STANDARDS` (déclaration de dette tracée).
+5. WHERE des fichiers `*.vue.bak` existent, le système SHALL les exclure du périmètre de migration.
+6. WHEN un site est migré THEN le système SHALL préserver le comportement fonctionnel existant (mêmes branches succès/échec, mêmes effets sur `loading`/état), en ne changeant que la source du message affiché.
+
+### Requirement 7 — Journalisation sûre des erreurs techniques
+
+**User Story:** En tant qu'ingénieur d'exploitation, je veux que les erreurs techniques soient journalisées de façon exploitable mais sans donnée sensible, afin de pouvoir diagnostiquer sans créer de fuite ni polluer la console en production.
+
+#### Acceptance Criteria
+
+1. WHEN une erreur technique est traitée THEN le système SHALL pouvoir la journaliser de façon exploitable (catégorie, code HTTP, URL de la requête) sans inclure de donnée sensible (pas de token, pas d'email, pas de mot de passe).
+2. WHERE la journalisation est implémentée, le système SHALL suivre le modèle de `logRoleDecision` (`src/constants/roles.js`) et se désactiver en production (`import.meta.env?.PROD`), cohérent avec la désactivation des `console.log` en prod (#15).
+3. WHEN la journalisation est active (hors production) THEN le système SHALL pouvoir consigner le détail technique pour le diagnostic, sans que ce détail soit jamais retourné comme message utilisateur (séparation stricte affichage / journal).
+4. IF aucune information non sensible n'est disponible THEN le système SHALL journaliser au minimum la catégorie d'erreur sans échouer.
+
+### Requirement 8 — Couverture de tests Vitest
+
+**User Story:** En tant que mainteneur, je veux des tests unitaires exhaustifs de la normalisation, afin de garantir de façon vérifiable qu'aucun détail technique ne fuit et que chaque catégorie est correctement traitée.
+
+#### Acceptance Criteria
+
+1. WHERE la suite de tests est définie, le système SHALL couvrir chaque catégorie d'erreur : `401`, `403`, `404`, `422`, `429`, `5xx`, `network` (pas de réponse) et `unknown`.
+2. WHEN un cas `5xx` portant un message technique brut (ex. SQL/SQLSTATE) est normalisé THEN le test SHALL vérifier que ce message brut N'EST JAMAIS retourné comme message utilisateur.
+3. WHEN un cas `422` avec erreurs de champ est normalisé THEN le test SHALL vérifier que les messages de validation par champ sont exposés de façon structurée.
+4. WHEN une entrée invalide (`null`, `undefined`, objet inattendu, chaîne) est normalisée THEN le test SHALL vérifier qu'un message de repli générique est retourné sans exception levée.
+5. WHEN une erreur réseau (axios sans `response`) est normalisée THEN le test SHALL vérifier que le message réseau du catalogue est retourné et qu'aucun détail technique n'apparaît.
+6. WHERE la normalisation est testée, le système SHALL démontrer son déterminisme et son absence d'effet de bord (fonction pure), conformément à `PRODUCTION_STANDARDS §1.3`.
+
+### Requirement 9 — Équivalence sécurité avec la règle backend
+
+**User Story:** En tant que responsable sécurité, je veux une preuve mesurable que le frontend n'expose aucun détail technique d'infrastructure, afin d'atteindre la parité avec la règle backend `getMessage()` = 0.
+
+#### Acceptance Criteria
+
+1. WHEN la fonctionnalité est livrée THEN le système SHALL garantir qu'aucun message d'erreur 5xx brut, stack trace ou détail SQL/infra n'est affiché à l'utilisateur dans les sites migrés (objectif d'équivalence : 0 exposition).
+2. WHERE des sites n'ont pas encore été migrés THEN le système SHALL en documenter le compte exact comme dette tracée (cf. Requirement 6.4), de sorte que l'écart par rapport à l'objectif « 0 » soit explicite et mesurable.
+3. WHEN un détail technique doit être conservé pour diagnostic THEN le système SHALL le restreindre au canal de journalisation (Requirement 7) et SHALL ne jamais le présenter dans l'UI.
+
+---
+
+## Exigences non fonctionnelles
+
+1. **Sécurité (`PRODUCTION_STANDARDS §1.2`)** : aucune fuite de détail technique d'infrastructure vers le client ; secrets et données sensibles jamais journalisés.
+2. **Testabilité (`§1.3`)** : la logique métier (normalisation) est unit-testée en isolation, tests écrits selon l'approche TDD, couvrant les cas limites.
+3. **SOLID (`§1.6`)** : séparation stricte normalisation (logique pure) / catalogue (données) / affichage (`toast`) / journalisation ; responsabilité unique par unité.
+4. **Tailles (`§5`)** : modules et fonctions de taille maîtrisée, scindés si nécessaire.
+5. **Contrainte d'intégration** : aucune modification backend ; réutilisation de `toast.js`, de l'intercepteur `api.js` et du modèle `logRoleDecision` existants.
+6. **Préparation i18n** : le catalogue est structuré pour accueillir des clés d'i18n ultérieurement, sans imposer l'implémentation i18n dans cette itération.
+
+---
+
+## Questions ouvertes laissées au document de conception (le design tranche)
+
+Ces points relèvent du **COMMENT** et seront décidés en phase de design ; ils ne modifient pas le **QUOI** ci-dessus :
+
+- (a) Forme du module : service (`src/services/errorHandler.js`) vs composable (`useErrorHandler`).
+- (b) Emplacement du catalogue : `src/constants/` vs intégré au module de normalisation.
+- (c) Stratégie de migration des ~135 sites concernés (114 `alert`, dont 21 d'erreur + 80 expositions, recoupements inclus) : big-bang vs incrémentale priorisée (probablement incrémentale : module + intercepteur + `alert()` d'erreur d'abord, reliquat tracé en dette).
+- (d) Branchement : attacher `error.userMessage` dans l'intercepteur vs faire invoquer le handler par les appelants (les deux voies devant rester cohérentes, cf. Requirement 5.5).

--- a/.claude/specs/error-handler/tasks.md
+++ b/.claude/specs/error-handler/tasks.md
@@ -1,0 +1,121 @@
+# Plan d'implémentation — Gestion centralisée des erreurs côté client (error-handler)
+
+> Issue GitHub **#20** (TIER 0 CRITICAL, épique d'audit #16). Équivalent frontend de `PRODUCTION_STANDARDS §1.2`. Aucune modification backend.
+>
+> Documents de contexte (disponibles à l'implémentation) :
+> - `.claude/specs/error-handler/requirements.md`
+> - `.claude/specs/error-handler/design.md`
+>
+> **Approche TDD (Vitest #21)** : les tests de `normalizeError` sont écrits AVANT l'implémentation (rouge → vert).
+> **ATTENTION include Vitest** (vérifié `vitest.config.js:19`) : le motif est `src/**/*.test.{js,mjs}` — il ne matche QUE `*.test.{js,mjs}`, **jamais** `.spec.`. Le fichier de test DOIT donc s'appeler `…errorHandler.test.js`.
+> **Inventaire migration figé par grep** (`alert\([^)]*\b(error|err|e)\b`, 2026-06-15, `src/**/*.vue`) : 21 lignes brutes, dont **1 commentée** à `views/lessons/TeacherLessons.vue:482` (exclue) → **20 alert() actifs à migrer**.
+
+---
+
+## Liste des tâches
+
+- [x] 1. Écrire les tests Vitest de `normalizeError` (rouge) — TDD avant implémentation
+  - Décision design : (a) service pur ; (d) fonction unique appelée par intercepteur ET composants. Tests pilotent le contrat `normalizeError(error) -> {category, userMessage, fieldErrors}`.
+  - Fichier créé : `src/services/__tests__/errorHandler.test.js` (matché par l'include `src/**/*.test.{js,mjs}` ; NE PAS utiliser `.spec.`).
+  - Importer le catalogue attendu (`ERROR_MESSAGES` depuis `../../constants/errorMessages`) pour asserter `userMessage === ERROR_MESSAGES[cat]` (les tâches 2 et 3 rendront ces imports résolvables).
+  - Couvrir une assertion par catégorie via `error.response.status` : `401 → 'auth'`, `403 → 'forbidden'`, `404 → 'notFound'`, `422 → 'validation'`, `429 → 'rateLimit'`, `500 → 'server'`, axios sans `response` (`{ request:{}, code:'ECONNREFUSED' }`) → `'network'`.
+  - Preuve sécurité §1.2 : cas `5xx` avec `response.data.message = "SQLSTATE[23000] FK constraint..."` → `category === 'server'`, `userMessage === ERROR_MESSAGES.server`, ET `expect(userMessage).not.toContain('SQLSTATE')`.
+  - Preuve réseau : cas réseau avec `code:'ECONNREFUSED'` → `userMessage === ERROR_MESSAGES.network` ET `expect(userMessage).not.toContain('ECONNREFUSED')`.
+  - Cas `422` structuré : `response.data.errors = { email:['...'], nom:['...'] }` → `category === 'validation'`, `fieldErrors` `toEqual` cet objet, `userMessage` chaîne non vide (message agrégé).
+  - Cas `422` sans détail exploitable (`errors` absent / `{}` / forme inattendue) → `fieldErrors === null`, `userMessage === ERROR_MESSAGES.validation`.
+  - Entrées invalides `null`, `undefined`, `'oops'`, `{}`, `new Error('boom')` → `category === 'unknown'`, `userMessage === ERROR_MESSAGES.unknown`, ET `expect(() => normalizeError(x)).not.toThrow()`.
+  - Déterminisme : deux appels sur la même entrée → résultats `toEqual`.
+  - Pureté : l'entrée passée n'est pas mutée (`toEqual` sur une copie figée de l'entrée après appel) ; aucun import de `toast` dans le module testé (vérifié en tâche 6).
+  - Critère de complétion : `npm run test` exécute ce fichier et il **échoue** (rouge), faute de `src/services/errorHandler.js` et `src/constants/errorMessages.js` ; aucune autre suite cassée (`test:contract` non concerné).
+  - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 1.5, 1.7, 1.6, 3.1, 3.2, 4.1, 4.4, 4.5, 9.1_
+
+- [x] 2. Créer le catalogue gelé `src/constants/errorMessages.js`
+  - Décision design : (b) catalogue de données séparé du module (SRP §1.6), gelé `Object.freeze` (cohérent `src/constants/roles.js:20`).
+  - Fichier créé : `src/constants/errorMessages.js`.
+  - Exporter `export const ERROR_MESSAGES = Object.freeze({ ... })` avec les 8 clés 1:1 des catégories : `auth`, `forbidden`, `notFound`, `validation`, `rateLimit`, `server`, `network`, `unknown` ; messages FR orientés utilisateur, actionnables, sans jargon (valeurs exactes du design, section Data Models).
+  - Structure plate `catégorie → message` (préparation i18n : transformable en `catégorie → clé i18n` sans toucher les appelants ni `normalizeError`).
+  - Critère de complétion : `grep -c "Object.freeze" src/constants/errorMessages.js` ≥ 1 et les 8 clés présentes (`grep -E "auth|forbidden|notFound|validation|rateLimit|server|network|unknown"`).
+  - _Requirements: 2.1, 2.3, 2.4, 2.6_
+
+- [x] 3. Implémenter le module pur `src/services/errorHandler.js` (vert)
+  - Décision design : (a) service pur exportant `normalizeError` (fonction pure, sans effet de bord) + `logError` (journal sûr). Aucun import de `toast`, aucune navigation, aucune mutation d'état global.
+  - Fichier créé : `src/services/errorHandler.js`. Importer `ERROR_MESSAGES` depuis `../constants/errorMessages` (chemin relatif, cohérent avec les imports relatifs de `api.js`).
+  - Helper `categoryFromStatus(status)` : `401→'auth'`, `403→'forbidden'`, `404→'notFound'`, `422→'validation'`, `429→'rateLimit'`, `>=500→'server'`, autre→`'unknown'`.
+  - Helper `extractFieldErrors(error)` : lit `error.response.data.errors` (format Laravel `{champ:[msgs]}`) ; objet non vide → renvoie cet objet ; sinon `null`.
+  - Helper `resolveMessage(category, error)` : applique le tableau d'exposition du design — seul `validation` (422) peut agréger les messages serveur (champs) ; `forbidden`/`notFound`/`auth`/`rateLimit`/`server`/`network`/`unknown` forcent `ERROR_MESSAGES[category]` (fail-secure ; **dette potentielle 403/404** notée dans le design, message catalogue forcé faute de garantie backend auditable ici). Résolution toujours `ERROR_MESSAGES[category] ?? ERROR_MESSAGES.unknown`.
+  - `normalizeError(error)` : ordre de décision du design (1. falsy/string/`Error` sans `response` → `unknown` ; 2. `error.response` présent → `categoryFromStatus` ; 3. pas de `response` mais `error.request`/code réseau → `network` ; 4. objet `{success:false}` local → `unknown` sans exposer `message` ; 5. fallback `unknown`). Accès défensifs (`error?.response?.status`, `?? null`). **Ne lève jamais** ; retourne toujours un `{category, userMessage, fieldErrors}` valide (`fieldErrors` non null seulement en 422 exploitable).
+  - `logError(error, context = '')` : modèle `logRoleDecision` (`src/constants/roles.js:178-181`) — `if (import.meta.env?.PROD) return` puis `console.warn(\`[errorHandler] ${context}\`, safeContext)` où `safeContext = { category, status: error?.response?.status ?? null, url: error?.config?.url ?? null }`. JAMAIS de token/email/mot de passe/headers/corps. Si rien d'exploitable → journalise au moins `{ category: 'unknown' }` sans échouer.
+  - Tailles §5 : fonctions ≤ ~40 lignes, fichier < 300 lignes, découpé en helpers ci-dessus.
+  - Critère de complétion : `npm run test` → la suite de la tâche 1 passe **au vert** (toutes assertions), `test:contract` toujours vert.
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 2.2, 2.5, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 4.5, 7.1, 7.2, 7.3, 7.4_
+
+- [x] 4. Brancher l'intercepteur de réponse dans `src/services/api.js`
+  - Décision design : (d) l'intercepteur attache `error.userMessage` (+ `error.fieldErrors` pour 422) via `normalizeError`, AVANT la branche 401 et le `Promise.reject` ; `console.error` brut remplacé par `logError`.
+  - Fichier modifié : `src/services/api.js` (handler d'erreur de `interceptors.response.use`, lignes 46-60 actuelles).
+  - Ajouter l'import relatif : `import { normalizeError, logError } from './errorHandler'` (cohérent avec `'../constants/roles'`).
+  - Remplacer `console.error('❌ API Error:', error.config?.url, error.response?.status)` (ligne 47) par `logError(error, '[api.js] response interceptor')` (mêmes infos non sensibles, + désactivation prod).
+  - Avant la branche 401 : `const normalized = normalizeError(error); error.userMessage = normalized.userMessage; error.fieldErrors = normalized.fieldErrors`.
+  - **Préserver INTÉGRALEMENT le flux #19** : la branche `if (error.response?.status === 401) { useAuthStore().logout(); … window.location.href = '/login' }` reste identique (lignes 50-57), et `return Promise.reject(error)` (ligne 59) inchangé — la promesse reste rejetée avec l'objet erreur enrichi (jamais résolue/avalée).
+  - Critère de complétion : `npm run test:contract` toujours vert (api.js reste chargeable hors Vite) ; `grep -n "console.error" src/services/api.js` ne renvoie plus la ligne du handler de réponse ; `grep -n "userMessage\|fieldErrors\|logError" src/services/api.js` confirme l'attachement.
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 7.2_
+
+- [x] 5. Migrer les 20 `alert()` d'erreur actifs → `toast.error(...)`
+  - Décision design : (c) migration incrémentale priorisée — vague 1 = les `alert()` d'erreur ; (d) consommation `toast.error(error.userMessage ?? normalizeError(error).userMessage)` (fallback couvrant les `new Error(...)` levées localement, hors intercepteur).
+  - Dans chaque fichier touché : ajouter `import { toast } from '@/services/toast'` et `import { normalizeError } from '@/services/errorHandler'` (toast est un export nommé, vérifié `toast.js:72`).
+  - Ne changer QUE la source du message affiché : branches succès/échec, `loading`, état `finally` inchangés (Requirement 6.6). Pour les `alert(err.response?.data?.message || 'texte')`, remplacer par `toast.error(err.userMessage ?? normalizeError(err).userMessage)` (le message catalogue remplace le littéral dupliqué et la fuite `.message`).
+  - Fichiers et lignes (inventaire grep figé 2026-06-15) :
+    - `src/components/visio/VisioManager.vue` : lignes 285, 311, 347, 384, 432
+    - `src/components/visio/ParticipantsModal.vue` : lignes 462, 511
+    - `src/components/lessons/ChapterManager.vue` : lignes 413, 442, 463, 579
+    - `src/views/coordinateur/SeanceManagement.vue` : ligne 501
+    - `src/views/TeacherSeances.vue` : ligne 603
+    - `src/views/seances/SeanceDetails.vue` : ligne 517
+    - `src/views/Quizzes.vue` : ligne 105
+    - `src/views/lessons/LessonChapters.vue` : ligne 180
+    - `src/views/lessons/LessonEditor.vue` : lignes 569, 591
+    - `src/views/lessons/StudentLessonView.vue` : ligne 496
+    - `src/views/admin/AdminInstitutions.vue` : ligne 453
+  - **EXCLU** : `src/views/lessons/TeacherLessons.vue:482` (ligne **commentée** `// alert(...)`, hors périmètre).
+  - Conflits de fichiers : ces 12 fichiers sont **disjoints** de `src/services/api.js` (tâche 4) et des fichiers des tâches 1-3 ; aucune collision. Les sites sont aussi disjoints entre eux.
+  - Critère de complétion : `grep -rnE "alert\([^)]*\b(error|err|e)\b" src/**/*.vue` ne renvoie plus que la ligne commentée de `TeacherLessons.vue`. `npm run build` réussit (imports résolus, pas de référence cassée).
+  - _Requirements: 6.1, 6.2, 6.3, 6.5, 6.6_
+
+- [x] 6. Vérification finale et traçage de la dette #20-FE-1
+  - Aucune écriture de code fonctionnel : exécution des vérifications + ajout/mise à jour de la note de dette dans le design (`## Dette tracée`) avec le compteur recalculé.
+  - Tests : `npm run test` → suite `errorHandler.test.js` entièrement verte ; `npm run test:contract` → vert ; `npm run build` → succès.
+  - Preuve sécurité (équivalence backend §1.2) : confirmer via la suite Vitest que le test « 5xx SQL brut » et le test « réseau ECONNREFUSED » passent (aucune fuite par `normalizeError`).
+  - Preuve pureté : `grep -n "toast" src/services/errorHandler.js` ne renvoie rien (le module n'affiche jamais).
+  - Preuve migration : `grep -rnE "alert\([^)]*\b(error|err|e)\b" src` ne renvoie que la ligne commentée ; `grep -rnE "(error|err)\.(response\?\.data\?\.message|message)" <12 fichiers migrés>` ne renvoie plus d'exposition directe dans une UI (les `.message` restants y sont remplacés par `userMessage ?? normalizeError(...)`).
+  - Dette #20-FE-1 : recompter par grep le reliquat d'expositions `.message` hors vague 1 (`this.error =`, `error.value =`, `error.response?.data?.message`) et le consigner dans le design comme dette tracée (point de départ : 80 expositions / 37 emplacements au 2026-06-15). NE PAS migrer ce reliquat dans cette itération.
+  - Critère de complétion : les 3 commandes ci-dessus réussissent, le compteur de dette est inscrit, et le grep prouve 0 `alert(...error...)` actif et 0 exposition `.message` directe dans les 12 fichiers migrés.
+  - _Requirements: 6.4, 9.1, 9.2, 9.3, 4.5, 1.6_
+
+---
+
+## Diagramme de dépendances des tâches
+
+```mermaid
+flowchart TD
+    T1[Tache 1: Tests Vitest normalizeError ROUGE]
+    T2[Tache 2: Catalogue errorMessages.js gele]
+    T3[Tache 3: Module errorHandler.js VERT]
+    T4[Tache 4: Branchement intercepteur api.js]
+    T5[Tache 5: Migration 20 alert vers toast.error]
+    T6[Tache 6: Verification finale + dette 20-FE-1]
+
+    T1 --> T3
+    T2 --> T3
+    T3 --> T4
+    T3 --> T5
+    T4 --> T6
+    T5 --> T6
+
+    style T1 fill:#ffcdd2
+    style T2 fill:#fff9c4
+    style T3 fill:#c8e6c9
+    style T4 fill:#e1f5fe
+    style T5 fill:#e1f5fe
+    style T6 fill:#d1c4e9
+```
+
+> Parallélisme possible : les tâches 4 et 5 sont indépendantes une fois la tâche 3 livrée (api.js vs 12 fichiers .vue disjoints) et peuvent être menées en parallèle, puis convergent en tâche 6.

--- a/src/components/lessons/ChapterManager.vue
+++ b/src/components/lessons/ChapterManager.vue
@@ -256,6 +256,8 @@
 
 <script>
 import api from '@/services/api'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import TipTapEditor from '@/components/common/TipTapEditor.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import KnowledgeCheckEditor from '@/components/lessons/KnowledgeCheckEditor.vue'
@@ -410,7 +412,7 @@ export default {
         }
       } catch (error) {
         console.error('[ChapterManager] Erreur sauvegarde:', error)
-        alert('Erreur: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.saving = false
       }
@@ -439,7 +441,7 @@ export default {
         }
       } catch (error) {
         console.error('[ChapterManager] Erreur upload:', error)
-        alert('Erreur upload: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         setTimeout(() => {
           this.uploadingFile = false
@@ -460,7 +462,7 @@ export default {
         }
       } catch (error) {
         console.error('[ChapterManager] Erreur suppression:', error)
-        alert('Erreur: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       }
     },
 
@@ -576,7 +578,7 @@ export default {
         }
       } catch (error) {
         console.error('[ChapterManager] Erreur suppression quiz:', error)
-        alert('Erreur: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       }
     },
 

--- a/src/components/visio/ParticipantsModal.vue
+++ b/src/components/visio/ParticipantsModal.vue
@@ -278,6 +278,8 @@
 <script>
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 
 export default {
   name: 'ParticipantsModal',
@@ -459,7 +461,7 @@ export default {
         console.log('[ParticipantsModal] ✅ PDF téléchargé avec succès')
       } catch (error) {
         console.error('[ParticipantsModal] Erreur export PDF:', error)
-        alert('Erreur lors de l\'export PDF : ' + error.message)
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.exporting = false
       }
@@ -508,7 +510,7 @@ export default {
         console.log('[ParticipantsModal] ✅ Excel téléchargé avec succès')
       } catch (error) {
         console.error('[ParticipantsModal] Erreur export Excel:', error)
-        alert('Erreur lors de l\'export Excel : ' + error.message)
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.exporting = false
       }

--- a/src/components/visio/VisioManager.vue
+++ b/src/components/visio/VisioManager.vue
@@ -139,6 +139,8 @@
 import { auth } from '@/services/api'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import jitsiService from '@/services/jitsi'
 import ParticipantsModal from './ParticipantsModal.vue'
 import { useVisioStore } from '@/stores/visio'
@@ -282,7 +284,7 @@ export default {
         }
       } catch (error) {
         console.error('[VisioManager] Erreur programmation visio:', error)
-        alert('Erreur lors de la programmation de la visio: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.loading = false
       }
@@ -308,7 +310,7 @@ export default {
         }
       } catch (error) {
         console.error('[VisioManager] Erreur désactivation visio:', error)
-        alert('Erreur lors de la désactivation de la visio: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.loading = false
       }
@@ -344,7 +346,7 @@ export default {
 
       } catch (error) {
         console.error('[VisioManager] Erreur démarrage visio:', error)
-        alert('Erreur lors du démarrage de la visio: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.loading = false
       }
@@ -381,7 +383,7 @@ export default {
         }
       } catch (error) {
         console.error('[VisioManager] Erreur fermeture séance:', error)
-        alert('Erreur lors de la fermeture: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.loading = false
       }
@@ -429,7 +431,7 @@ export default {
         console.log('[VisioManager] ✅ PDF téléchargé avec succès')
       } catch (error) {
         console.error('[VisioManager] Erreur téléchargement PDF:', error)
-        alert('Erreur lors du téléchargement : ' + error.message)
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.loading = false
       }

--- a/src/constants/errorMessages.js
+++ b/src/constants/errorMessages.js
@@ -1,0 +1,20 @@
+/**
+ * Catalogue centralisé des messages d'erreur utilisateur (#20).
+ *
+ * Source unique, gelée (cohérent avec src/constants/roles.js), orientée utilisateur
+ * (français, actionnable, sans jargon technique). Supprime la duplication des
+ * « Erreur lors du chargement » et prépare l'i18n (structure plate catégorie → message,
+ * transformable en catégorie → clé i18n sans toucher les appelants).
+ *
+ * Aucun de ces messages ne contient de détail technique d'infrastructure (§1.2).
+ */
+export const ERROR_MESSAGES = Object.freeze({
+  auth: 'Votre session a expiré. Veuillez vous reconnecter.',
+  forbidden: "Vous n'avez pas les droits nécessaires pour effectuer cette action.",
+  notFound: 'La ressource demandée est introuvable.',
+  validation: 'Certaines informations sont invalides. Veuillez vérifier votre saisie.',
+  rateLimit: 'Trop de requêtes en peu de temps. Veuillez patienter quelques instants.',
+  server: 'Une erreur est survenue côté serveur. Veuillez réessayer plus tard.',
+  network: 'Connexion impossible. Vérifiez votre connexion internet et réessayez.',
+  unknown: 'Une erreur inattendue est survenue. Veuillez réessayer.',
+})

--- a/src/services/__tests__/errorHandler.test.js
+++ b/src/services/__tests__/errorHandler.test.js
@@ -1,0 +1,101 @@
+/**
+ * Tests de normalizeError (#20) — src/services/errorHandler.js
+ *
+ * Vérifie la classification par catégorie, la NON-fuite de détail technique
+ * (équivalence backend §1.2 : aucun message 5xx/réseau brut affiché), la
+ * structuration des erreurs de validation 422, le fail-secure sur entrée
+ * invalide, le déterminisme et la pureté (pas de mutation de l'entrée).
+ */
+import { describe, it, expect } from 'vitest'
+import { normalizeError } from '@/services/errorHandler'
+import { ERROR_MESSAGES } from '@/constants/errorMessages'
+
+/** Fabrique une erreur axios avec réponse HTTP. */
+function httpError(status, data = {}) {
+  return { isAxiosError: true, response: { status, data }, config: { url: '/x' } }
+}
+
+describe('normalizeError — classification par code HTTP', () => {
+  it.each([
+    [401, 'auth'],
+    [403, 'forbidden'],
+    [404, 'notFound'],
+    [422, 'validation'],
+    [429, 'rateLimit'],
+    [500, 'server'],
+    [503, 'server'],
+  ])('status %i → catégorie %s + message catalogue', (status, category) => {
+    const r = normalizeError(httpError(status))
+    expect(r.category).toBe(category)
+    expect(r.userMessage).toBe(ERROR_MESSAGES[category])
+    expect(typeof r.userMessage).toBe('string')
+    expect(r.userMessage.length).toBeGreaterThan(0)
+  })
+})
+
+describe('normalizeError — non-fuite de détail technique (§1.2)', () => {
+  it('5xx avec message SQL brut → message serveur catalogue, jamais le détail', () => {
+    const r = normalizeError(httpError(500, { message: 'SQLSTATE[23000] FK constraint violated on table users' }))
+    expect(r.category).toBe('server')
+    expect(r.userMessage).toBe(ERROR_MESSAGES.server)
+    expect(r.userMessage).not.toContain('SQLSTATE')
+    expect(r.userMessage).not.toContain('constraint')
+  })
+
+  it('erreur réseau (pas de response) → message réseau, jamais ECONNREFUSED', () => {
+    const r = normalizeError({ isAxiosError: true, request: {}, code: 'ECONNREFUSED', message: 'connect ECONNREFUSED 127.0.0.1:8000' })
+    expect(r.category).toBe('network')
+    expect(r.userMessage).toBe(ERROR_MESSAGES.network)
+    expect(r.userMessage).not.toContain('ECONNREFUSED')
+  })
+})
+
+describe('normalizeError — validation 422 structurée', () => {
+  it('422 avec errors par champ → fieldErrors structuré + message agrégé', () => {
+    const errors = { email: ['L\'email est requis'], nom: ['Le nom est trop court'] }
+    const r = normalizeError(httpError(422, { errors }))
+    expect(r.category).toBe('validation')
+    expect(r.fieldErrors).toEqual(errors)
+    expect(typeof r.userMessage).toBe('string')
+    expect(r.userMessage.length).toBeGreaterThan(0)
+  })
+
+  it('422 sans détail exploitable → fieldErrors null + message validation catalogue', () => {
+    expect(normalizeError(httpError(422, {})).fieldErrors).toBeNull()
+    expect(normalizeError(httpError(422, {})).userMessage).toBe(ERROR_MESSAGES.validation)
+    expect(normalizeError(httpError(422, { errors: {} })).fieldErrors).toBeNull()
+  })
+})
+
+describe('normalizeError — fail-secure sur entrée invalide', () => {
+  it.each([null, undefined, 'oops', 42, {}, new Error('boom')])(
+    'entrée %s → catégorie unknown, message générique, aucune exception',
+    (input) => {
+      let r
+      expect(() => { r = normalizeError(input) }).not.toThrow()
+      expect(r.category).toBe('unknown')
+      expect(r.userMessage).toBe(ERROR_MESSAGES.unknown)
+      expect(r.fieldErrors).toBeNull()
+    },
+  )
+
+  it('réponse applicative {success:false, message} 5xx-like → unknown sans exposer message', () => {
+    const r = normalizeError({ success: false, message: 'Internal detail leak' })
+    expect(r.category).toBe('unknown')
+    expect(r.userMessage).not.toContain('Internal detail leak')
+  })
+})
+
+describe('normalizeError — déterminisme et pureté', () => {
+  it('deux appels sur la même entrée → résultats égaux', () => {
+    const e = httpError(404)
+    expect(normalizeError(e)).toEqual(normalizeError(e))
+  })
+
+  it('ne mute pas l\'entrée', () => {
+    const e = httpError(422, { errors: { x: ['y'] } })
+    const snapshot = JSON.parse(JSON.stringify(e))
+    normalizeError(e)
+    expect(e).toEqual(snapshot)
+  })
+})

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -3,6 +3,7 @@ import notificationsService from './notifications'
 // Imports relatifs (pas l'alias @) : le runner natif des tests de contrat (#17) ne
 // résout que les chemins relatifs.
 import { hasRole as roleHasRole } from '../constants/roles'
+import { normalizeError, logError } from './errorHandler'
 // useAuthStore : on importe la DÉFINITION au top-level (sûr) ; on n'APPELLE
 // useAuthStore() qu'à la volée dans les méthodes (Pinia actif à l'exécution).
 // Cycle api.js <-> auth.js sans danger : aucune des deux références n'est utilisée
@@ -44,7 +45,14 @@ api.interceptors.response.use(
     return response.data
   },
   (error) => {
-    console.error('❌ API Error:', error.config?.url, error.response?.status)
+    // Journalisation sûre (sans donnée sensible, désactivée en prod) — #20
+    logError(error, '[api.js] response interceptor')
+
+    // Attacher un message utilisateur SÛR normalisé pour que tout appelant l'ait
+    // prêt à afficher (et les erreurs de champ 422), sans changer le flux de rejet.
+    const normalized = normalizeError(error)
+    error.userMessage = normalized.userMessage
+    error.fieldErrors = normalized.fieldErrors
 
     // Si erreur 401, déconnecter l'utilisateur via le store (purge state + storage + cache)
     if (error.response?.status === 401) {

--- a/src/services/errorHandler.js
+++ b/src/services/errorHandler.js
@@ -1,0 +1,91 @@
+/**
+ * Gestion centralisée des erreurs côté client (#20).
+ *
+ * `normalizeError` : fonction PURE qui transforme n'importe quelle erreur (axios,
+ * réseau, Error JS, valeur invalide) en un message utilisateur SÛR + une catégorie,
+ * sans jamais exposer de détail technique d'infrastructure (équivalence backend
+ * PRODUCTION_STANDARDS §1.2). `logError` : journalisation sûre (sans donnée sensible),
+ * désactivée en production (modèle logRoleDecision de roles.js).
+ *
+ * SRP : ce module NORMALISE et JOURNALISE — il N'AFFICHE rien (aucune dépendance d'affichage).
+ */
+import { ERROR_MESSAGES } from '../constants/errorMessages'
+
+/** Catégorie d'erreur depuis le code HTTP. */
+function categoryFromStatus(status) {
+  switch (status) {
+    case 401: return 'auth'
+    case 403: return 'forbidden'
+    case 404: return 'notFound'
+    case 422: return 'validation'
+    case 429: return 'rateLimit'
+    default: return status >= 500 ? 'server' : 'unknown'
+  }
+}
+
+/**
+ * Extrait les erreurs de validation par champ (format Laravel `{champ: [messages]}`).
+ * @returns {object|null} l'objet d'erreurs si non vide, sinon null.
+ */
+function extractFieldErrors(error) {
+  const errs = error?.response?.data?.errors
+  if (errs && typeof errs === 'object' && !Array.isArray(errs) && Object.keys(errs).length > 0) {
+    return errs
+  }
+  return null
+}
+
+/** Message agrégé sûr pour 422 : concatène les libellés de champ (non sensibles). */
+function aggregateValidation(fieldErrors) {
+  const msgs = Object.values(fieldErrors).flat().filter((m) => typeof m === 'string')
+  return msgs.length ? msgs.join(' ') : ERROR_MESSAGES.validation
+}
+
+/**
+ * Normalise une erreur en message utilisateur sûr. Ne lève JAMAIS.
+ * Seule la catégorie `validation` (422) peut agréger des messages serveur (champs) ;
+ * toutes les autres forcent le message du catalogue (fail-secure, pas de fuite).
+ * @param {unknown} error
+ * @returns {{category: string, userMessage: string, fieldErrors: object|null}}
+ */
+export function normalizeError(error) {
+  const fallback = { category: 'unknown', userMessage: ERROR_MESSAGES.unknown, fieldErrors: null }
+  if (!error || typeof error !== 'object') return fallback
+
+  const status = error.response?.status
+  if (status != null) {
+    const category = categoryFromStatus(status)
+    if (category === 'validation') {
+      const fieldErrors = extractFieldErrors(error)
+      return {
+        category,
+        fieldErrors,
+        userMessage: fieldErrors ? aggregateValidation(fieldErrors) : ERROR_MESSAGES.validation,
+      }
+    }
+    return { category, userMessage: ERROR_MESSAGES[category] ?? ERROR_MESSAGES.unknown, fieldErrors: null }
+  }
+
+  // Pas de réponse HTTP : erreur réseau si axios (request/code), sinon inconnue.
+  if (error.request || error.code || error.isAxiosError) {
+    return { category: 'network', userMessage: ERROR_MESSAGES.network, fieldErrors: null }
+  }
+
+  return fallback
+}
+
+/**
+ * Journalise une erreur de façon SÛRE (catégorie, status, url) — jamais de token,
+ * email ni corps de requête. Désactivée en production (#15).
+ * @param {unknown} error
+ * @param {string} context - libellé de contexte (ex. nom de l'appelant).
+ */
+export function logError(error, context = '') {
+  if (import.meta.env?.PROD) return
+  const safe = {
+    category: normalizeError(error).category,
+    status: error?.response?.status ?? null,
+    url: error?.config?.url ?? null,
+  }
+  console.warn(`[errorHandler] ${context}`, safe)
+}

--- a/src/views/Quizzes.vue
+++ b/src/views/Quizzes.vue
@@ -67,6 +67,8 @@
 <script>
 import Navbar from '@/components/Navbar.vue'
 import { quizzes } from '@/services/api'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 
 export default {
   name: 'Quizzes',
@@ -102,7 +104,7 @@ export default {
         await quizzes.startAttempt(quizId)
         this.$router.push(`/quizzes/${quizId}/take`)
       } catch (error) {
-        alert(error.response?.data?.message || 'Erreur lors du démarrage du quiz')
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       }
     }
   }

--- a/src/views/TeacherSeances.vue
+++ b/src/views/TeacherSeances.vue
@@ -342,6 +342,8 @@ import { useVisioParticipation } from '@/composables/useVisioParticipation'
 import { lmsService } from '@/services/lms'
 import { klassciService } from '@/services/klassci'
 import { useAuthStore } from '@/stores/auth'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import { readCache, writeCache, clearCache } from '@/services/cache'
 
 const seances = ref([])
@@ -600,7 +602,7 @@ async function handleJoinVisio(seance) {
     loadSeances()
   } catch (error) {
     console.error('[ERREUR] Join visio:', error)
-    alert('Erreur lors de la connexion à la visio: ' + error.message)
+    toast.error(error.userMessage ?? normalizeError(error).userMessage)
   }
 }
 

--- a/src/views/coordinateur/SeanceManagement.vue
+++ b/src/views/coordinateur/SeanceManagement.vue
@@ -280,6 +280,8 @@ import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
 import { useVisioParticipation } from '@/composables/useVisioParticipation'
 import ParticipantsModal from '@/components/visio/ParticipantsModal.vue'
 import { useAuthStore } from '@/stores/auth'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 
 import lmsService from '@/services/lms'
 import { readCache, writeCache, clearCache } from '@/services/cache'
@@ -498,7 +500,7 @@ const handleJoinVisio = async (seance) => {
     await loadSeances()
   } catch (error) {
     console.error('[ERREUR] Join visio coordinateur:', error)
-    alert('Erreur lors de la connexion à la visio: ' + error.message)
+    toast.error(error.userMessage ?? normalizeError(error).userMessage)
   }
 }
 

--- a/src/views/lessons/LessonChapters.vue
+++ b/src/views/lessons/LessonChapters.vue
@@ -94,6 +94,8 @@
 <script>
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ChapterManager from '@/components/lessons/ChapterManager.vue'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import lessonService from '@/services/lesson'
 
 export default {
@@ -177,7 +179,7 @@ export default {
         }
       } catch (error) {
         console.error('[LessonChapters] Erreur publication:', error)
-        alert('Erreur: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       } finally {
         this.publishing = false
       }

--- a/src/views/lessons/LessonEditor.vue
+++ b/src/views/lessons/LessonEditor.vue
@@ -436,6 +436,8 @@ Exemples:
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import lessonService from '@/services/lesson'
 import chapterService from '@/services/chapter'
@@ -566,7 +568,7 @@ const saveLesson = async () => {
   } catch (error) {
     console.error('[LessonEditor] Erreur saveLesson:', error)
     console.error('[LessonEditor] error.response:', error.response)
-    alert('Erreur: ' + (error.response?.data?.message || error.message))
+    toast.error(error.userMessage ?? normalizeError(error).userMessage)
   } finally {
     saving.value = false
     console.log('[LessonEditor] saving = false')
@@ -588,7 +590,7 @@ const deleteLesson = async () => {
     }
   } catch (error) {
     console.error('[LessonEditor] Erreur deleteLesson:', error)
-    alert('Erreur lors de la suppression: ' + (error.response?.data?.message || error.message))
+    toast.error(error.userMessage ?? normalizeError(error).userMessage)
   } finally {
     saving.value = false
   }

--- a/src/views/lessons/StudentLessonView.vue
+++ b/src/views/lessons/StudentLessonView.vue
@@ -310,6 +310,8 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
 import lessonService from '@/services/lesson'
@@ -493,7 +495,7 @@ const markChapterAsCompleted = async (chapterId) => {
     }
   } catch (err) {
     console.error('[StudentLessonView] Erreur marquage chapitre:', err)
-    alert(err.response?.data?.message || 'Erreur lors du marquage du chapitre')
+    toast.error(err.userMessage ?? normalizeError(err).userMessage)
   } finally {
     markingChapter.value = null
   }

--- a/src/views/seances/SeanceDetails.vue
+++ b/src/views/seances/SeanceDetails.vue
@@ -250,6 +250,8 @@
 import lmsService from '@/services/lms'
 import { auth } from '@/services/api'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import { useVisioParticipation } from '@/composables/useVisioParticipation'
 
@@ -514,7 +516,7 @@ export default {
         }
       } catch (error) {
         console.error('[SeanceDetails] Erreur masquage séance:', error)
-        alert('Erreur lors du masquage: ' + (error.response?.data?.message || error.message))
+        toast.error(error.userMessage ?? normalizeError(error).userMessage)
       }
     },
 


### PR DESCRIPTION
## Contexte

TIER 0 de l'audit (épique #16). Équivalent frontend de `PRODUCTION_STANDARDS §1.2` (`getMessage()` = 0) : le **détail technique brut** des erreurs (`error.message`, `error.response.data.message`, y compris messages SQL/infra 5xx) était exposé à l'utilisateur via **80 sites** et **20 `alert()`** natifs, avec « Erreur lors du chargement » dupliqué.

## Solution

- **`src/constants/errorMessages.js`** (nouveau) : catalogue **gelé** FR par catégorie (`auth/forbidden/notFound/validation/rateLimit/server/network/unknown`), prêt i18n.
- **`src/services/errorHandler.js`** (nouveau) : `normalizeError(error)` **pur** → `{ category, userMessage, fieldErrors }`. **5xx/réseau/unknown forcent le message catalogue** (jamais le détail brut) ; **422** expose les erreurs de champ (format Laravel) ; **403/404 fail-secure**. `logError()` journalise sans donnée sensible, off en prod (modèle `logRoleDecision`).
- **`api.js`** : l'intercepteur attache `error.userMessage` / `error.fieldErrors` via `normalizeError`, remplace le `console.error` brut par `logError` ; flux reject + logout 401 (#19) préservés.
- **19 `alert()` d'erreur migrés** → `toast.error(...)` dans 11 fichiers.

## Vérifications

| Commande | Résultat |
|---|---|
| `npm run test` | **82 tests verts** (20 errorHandler : chaque catégorie, **preuve qu'un 5xx SQL brut ne fuit jamais**, 422 champs, fail-secure, pureté) |
| `npm run test:contract` | **28/28** |
| `npm run build` | réussi |

## Dette tracée (honnêteté)

- **#20-FE-1** : 32 expositions `.message` résiduelles (assignations d'état dans les vues) = vague 2 (migration incrémentale décidée au design), non migrées ici.
- **`AdminInstitutions.vue:toggleStatus`** : migration faite en local mais **non committée ici** car le fichier porte une WIP non liée (feature `deleteInstitution`) qui ne doit pas entrer dans #20 → 19/20 alertes migrées dans cette PR.
- **403/404** : message catalogue forcé (non auditable sans backend, fail-secure assumé).

## Spec

`.claude/specs/error-handler/` (requirements EARS, design, tasks).

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
