### PR TITLE
refactor(constants): config & valeurs magiques centralisées (#24)

### DIFF
--- a/.claude/specs/constants/design.md
+++ b/.claude/specs/constants/design.md
@@ -1,0 +1,725 @@
+# Design Document — Centralisation des constantes et de la configuration (#24)
+
+## Overview
+
+Cette fonctionnalité élimine le hardcoding de valeurs de configuration et de valeurs
+« magiques » dispersées dans le frontend Vue 3, en les centralisant dans des modules
+**gelés** (`Object.freeze`) sous `src/constants/`, cohérents avec le pattern déjà établi par
+`src/constants/roles.js` (#18) et `src/constants/errorMessages.js` (#20).
+
+Périmètre vérifié par grep (2026-06-16) et confirmé par lecture du code réel :
+
+- Domaine Jitsi `meet.jit.si` : **17 occurrences réelles / 10 fichiers** (le grep `meet\.jit\.si`
+  renvoie 17, dont 1 commentaire `JitsiMeet.vue:58` et 1 fragment de commentaire `jitsi.js:16`).
+  Voir l'arbitrage du delta vs requirements (16) en [Dette tracée](#dette-tracée) #24-NOTE-1.
+- Fallback `localhost:8000` : **7 occurrences / 4 fichiers** (5 avec `/api`, 2 bare dans
+  `StudentLessonView.vue`).
+- Clés de storage non-auth : préférences `admin`/`teacher`/`user`, thème (scopé + incohérence
+  `main.js`), sidebar collapse (scopé), participation visio (scopée séance/utilisateur).
+- Magic numbers : heartbeat `30000` ms (6 sites), upload `30 * 1024 * 1024` + libellé « 30 MB »,
+  expiration participations `7 jours`.
+
+Objectif non-fonctionnel central : **non-régression observable**. Chaque valeur centralisée
+préserve exactement la valeur/clé/URL actuelle ; aucune préférence ou participation déjà
+stockée n'est invalidée. Hors périmètre strict : store auth `KEYS` (#19), backend, i18n,
+couleurs charts, god components (#28).
+
+### Objectifs de conception
+
+1. Source unique gelée par famille de valeurs, importable via l'alias `@/constants/*`.
+2. Domaine Jitsi configurable au déploiement via `VITE_JITSI_DOMAIN`, défaut `meet.jit.si`.
+3. URL API explicite, **sans fallback `localhost` silencieux en production**.
+4. Correction de l'incohérence de clé thème (#24-NOTE-2) sur une clé unique.
+5. Couverture Vitest des invariants (gel, résolution env, dérivation de clés).
+
+### Non-objectifs
+
+- Modifier une valeur numérique existante (toute modification de valeur est hors #24).
+- Toucher `src/stores/auth.js` `KEYS` ou le backend.
+- Migrer le TTL cache (`cache.js:3`, déjà isolé) ou les couleurs de charts.
+
+---
+
+## Architecture
+
+### Diagramme d'architecture système
+
+```mermaid
+graph TB
+    subgraph Build
+        ENV[import.meta.env VITE_JITSI_DOMAIN VITE_API_URL DEV PROD]
+    end
+
+    subgraph Constants[src constants modules geles]
+        VISIO[visio.js domaine helpers heartbeat expiration]
+        HTTP[http.js apiBaseUrl resolution sans fallback prod]
+        STORAGE[storageKeys.js cles plates et helpers scopes]
+        UPLOAD[upload.js taille max libelle types]
+        ROLES[roles.js existant non touche]
+        ERRORS[errorMessages.js existant non touche]
+    end
+
+    subgraph Consumers[Consommateurs migres]
+        JSVC[services jitsi.js]
+        VUES[Vues et composants visio seances schedule]
+        THEME[composables useTheme.js et main.js]
+        SIDEBAR[components Sidebar.vue]
+        SETTINGS[vues Settings admin teacher student]
+        CHAPTER[components ChapterManager.vue]
+        HEARTBEAT[useVisioParticipation.js et stores visio.js]
+    end
+
+    ENV --> VISIO
+    ENV --> HTTP
+    VISIO --> JSVC
+    VISIO --> VUES
+    VISIO --> HEARTBEAT
+    HTTP --> VUES
+    STORAGE --> THEME
+    STORAGE --> SIDEBAR
+    STORAGE --> SETTINGS
+    STORAGE --> JSVC
+    UPLOAD --> CHAPTER
+```
+
+### Diagramme de flux de données — résolution du domaine Jitsi
+
+```mermaid
+graph LR
+    A[Appel getJitsiDomain] --> B{import.meta.env disponible}
+    B -->|oui et VITE_JITSI_DOMAIN defini| C[retourne valeur env]
+    B -->|env absent ou variable vide| D[retourne defaut meet point jit point si]
+    C --> E[buildJitsiUrl construit https domaine room hash]
+    D --> E
+```
+
+### Diagramme de flux de données — résolution de l'URL API
+
+```mermaid
+graph LR
+    A[Appel apiBaseUrl] --> B{VITE_API_URL defini}
+    B -->|oui| C[retourne VITE_API_URL]
+    B -->|non| D{import.meta.env.PROD}
+    D -->|production| E[throw Error explicite config manquante]
+    D -->|developpement| F[retourne defaut dev unique http localhost 8000 api]
+```
+
+---
+
+## Décisions tranchées
+
+Conformément à la contrainte §6 du requirements, **une seule option par décision**, justifiée.
+
+### Décision A — Découpage des modules
+
+**Tranché : 4 modules thématiques** sous `src/constants/`, par domaine fonctionnel (pas par
+type technique) :
+
+| Module | Responsabilité (SRP) |
+| --- | --- |
+| `src/constants/visio.js` | Domaine Jitsi + helpers d'URL + `HEARTBEAT_INTERVAL_MS` + `PARTICIPATION_EXPIRATION_MS` |
+| `src/constants/http.js` | Résolution de l'URL de base API (`apiBaseUrl()`) |
+| `src/constants/storageKeys.js` | Clés `localStorage` non-auth (plates + helpers scopés) |
+| `src/constants/upload.js` | Taille max upload + libellé dérivé + types acceptés |
+
+**Justification.** Le pattern établi (`roles.js`, `errorMessages.js`) est **un module = un
+domaine cohérent**, pas un fourre-tout. Le heartbeat et l'expiration des participations
+appartiennent au domaine visio (ils ne servent qu'à la visio) : les colocaliser avec le domaine
+Jitsi dans `visio.js` évite un module `http.js`/`timers.js` artificiel qui regrouperait des
+valeurs sans cohésion sémantique (violation SRP/ISP — §1.1). `http.js` est réservé à la
+résolution d'URL API car c'est une préoccupation transverse distincte (sécurité prod, mode
+dev). Découpage retenu plutôt qu'un unique `config.js` god-module (§1.1 : petits fichiers
+focalisés) et plutôt qu'un éclatement excessif (un module par constante = ISP poussé à
+l'absurde, friction d'import).
+
+### Décision B — Forme du domaine Jitsi : helper fonction `getJitsiDomain()`
+
+**Tranché : helper fonction `getJitsiDomain()`**, pas une constante évaluée au chargement du
+module, et un constructeur d'URL `buildJitsiUrl(roomId, options)`.
+
+**Justification.**
+
+1. **Lecture de l'env à l'exécution.** Une constante `export const JITSI_DOMAIN =
+   import.meta.env.VITE_JITSI_DOMAIN || 'meet.jit.si'` est figée au chargement du module. Une
+   fonction permet aux tests Vitest de **réévaluer** la résolution sous différentes valeurs
+   d'env via stub (`vi.stubEnv`), sans dépendre de l'ordre d'import (R6.2/R6.3). C'est le pattern
+   testable et substituable (production-grade §1.3).
+2. **Chargeabilité hors Vite.** Le helper lit `import.meta.env?.VITE_JITSI_DOMAIN` avec
+   **optional chaining**, reproduisant exactement le pattern déjà éprouvé dans `roles.js:179`
+   (`import.meta.env?.PROD`). Vérifié : `src/services/jitsi.js` n'est **pas** dans le graphe
+   d'import du runner de contrat natif (`tests/contract/api-contract.spec.mjs` n'importe que
+   `api`, `evaluation`, `chapter`, `lms`, `klassci`, `chapterProgress`, `notifications`,
+   `search`). Le risque est donc faible, mais l'optional chaining garantit la chargeabilité si
+   `jitsi.js` (ou `visio.js`) entrait un jour dans un contexte Node natif.
+3. **Import par alias `@`.** Comme `jitsi.js` n'est pas dans le graphe du runner natif (qui
+   résout des imports relatifs sans extension via `node-resolver.mjs`), `visio.js` peut être
+   importé via `@/constants/visio` partout. Les tests Vitest héritent de l'alias `@` (cf.
+   `vitest.config.js` → `mergeConfig(viteConfig)`).
+
+**Constructeurs d'URL exposés (vu les 3 formes réelles dans le code).** Le grep révèle trois
+formats distincts. `buildJitsiUrl` doit les couvrir sans casser le format actuel :
+
+- Forme « bare » : `https://{domaine}/{roomId}` (VisioManager L337/L462, TeacherSeances L594,
+  SeanceManagement L493, TeacherVisioList L119).
+- Forme « hash params » : `https://{domaine}/{roomId}#config.prejoinConfig.enabled=false&userInfo.displayName={name}`
+  (SeanceManagement L533, TeacherSchedule L49/L63, StudentSchedule L51, SeanceDetails L381/L431).
+- Forme « IFrame API » : domaine nu (`domain = 'meet.jit.si'`) + URL script
+  `https://{domaine}/external_api.js` (VideoConference L73/L88, JitsiMeet L82/L110).
+
+`visio.js` expose donc : `getJitsiDomain()`, `buildJitsiUrl(roomId, options)`,
+`jitsiExternalApiSrc()`. Le service `jitsi.js` (qui construit déjà via `URLSearchParams`)
+consomme `getJitsiDomain()` pour son template L47 (forme différente, conservée telle quelle —
+on ne reformate pas son URL, on substitue seulement le domaine).
+
+### Décision C — URL API : helper `apiBaseUrl()` sans fallback prod silencieux
+
+**Tranché : helper centralisé `apiBaseUrl()` dans `src/constants/http.js`** qui lit
+`import.meta.env.VITE_API_URL`, **sans fallback `localhost` en production**, avec fallback dev
+unique confiné à `import.meta.env.DEV`.
+
+**Justification.** L'invariant non négociable (R4.2, contrainte §2) est « aucun fallback
+`localhost` silencieux en production ». La suppression pure du fallback casserait le confort dev
+(les développeurs s'appuient sur `localhost:8000`). Le confinement au mode dev satisfait les
+deux : en prod sans `VITE_API_URL`, l'erreur est **visible et immédiate** (échec au premier
+appel) plutôt qu'un build pointant silencieusement sur `localhost` (R4.2/R4.3). Une source
+unique remplace l'accès dispersé à `import.meta.env` (R4.4) et rend la politique testable
+(R6.5).
+
+**Non-régression des 7 sites (risque maîtrisé).** Deux variantes d'URL coexistent :
+
+- 5 sites utilisent `… || 'http://localhost:8000/api'` (avec `/api`).
+- 2 sites (`StudentLessonView.vue:495/503`) utilisent `… || 'http://localhost:8000'` (sans
+  `/api`, le `/api` étant ajouté plus loin dans l'URL construite).
+
+`apiBaseUrl()` retourne la **base telle que définie dans `VITE_API_URL`** (qui inclut déjà
+`/api` selon `.env.example` : `VITE_API_URL=http://localhost:8000/api`). Pour ne pas modifier le
+comportement observable de `StudentLessonView.vue`, ces 2 sites recevront un traitement dédié
+documenté dans le [Mapping de migration](#mapping-de-migration) : ils consomment `apiBaseUrl()`
+puis dé-suffixent `/api` si présent, OU consomment un second helper `apiOrigin()` dérivant
+l'origine. **Tranché : `apiBaseUrl()` (avec `/api`) + `apiOrigin()` (sans `/api`, dérivé par
+suppression du suffixe `/api` terminal)**, pour couvrir les deux formes sans réintroduire de
+littéral et sans changer les URL finales émises. Le défaut dev de `apiOrigin()` est
+`http://localhost:8000` (cohérent avec les 2 sites actuels).
+
+> Risque résiduel tracé : `useVisioParticipation.js:223` construit
+> `${import.meta.env.VITE_API_URL}/api/seances/...` (Beacon) **sans fallback** et **ajoute** un
+> `/api`. Ce site n'est pas dans les 7 fallbacks mais accède directement à `import.meta.env`. Sa
+> migration vers `apiBaseUrl()`/`apiOrigin()` est incluse pour la cohérence R4.4 (voir mapping),
+> en préservant l'URL finale exacte.
+
+### Décision D — Clé de thème (#24-NOTE-2) : la clé **scopée par institution gagne**
+
+**Tranché : clé unique scopée par institution**, centralisée dans `storageKeys.js`, et
+`main.js:10` corrigé pour utiliser le même helper scopé que `useTheme.js`.
+
+**Justification.** Le LMS est **multi-tenant** : `cache.js` (TTL/clés scopées par institution),
+`Sidebar.vue` (`sidebar-collapsed-${institution}`) et `useTheme.js`
+(`lms-theme-preference-${institution}`) scopent déjà systématiquement par tenant. Le thème est
+une préférence **par-tenant** par cohérence avec ce modèle (un utilisateur multi-institution
+peut vouloir un thème distinct par établissement). `main.js:10` (`lms-theme-preference` non
+scopé) est donc le **bug réel** à corriger, pas la cible. La clé scopée gagne ; `main.js`
+appellera `themeKey(institutionSlug)`.
+
+**Subtilité d'exécution (tracée).** `main.js` s'exécute **avant** le montage de l'app et avant
+l'hydratation Pinia, pour appliquer le thème sans flash (FOUC). Or le slug d'institution provient
+de `auth.getInstitution()` / store auth (sessionStorage). À ce stade, le slug peut être lu
+directement depuis `sessionStorage` (la même source que le store hydrate) via l'helper de scoping
+— pas via le store Pinia non encore créé. Le helper `themeKey(slug)` accepte donc un slug en
+argument ; `main.js` lit le slug brut (sessionStorage `institution`, fallback `default`) sans
+importer le store auth (évite tout cycle et reste cohérent avec l'invariant « ne pas toucher
+auth »). Comportement observable : un utilisateur dont la préférence était stockée sous la clé
+**non scopée** par l'ancien `main.js` verra cette préférence ignorée une fois — risque mineur
+documenté en [Dette tracée](#dette-tracée) #24-NOTE-2-MIG (pas de migration de données : la
+préférence se re-crée au premier toggle ; aucune perte de donnée critique).
+
+### Décision E — Périmètre de migration : **complet sur 4 familles, reliquat tracé**
+
+**Tranché : migration complète** de (1) domaine Jitsi via helper, (2) heartbeat, (3) upload,
+(4) clés thème + sidebar + préférences + participation visio, et (5) fallback API. Le reliquat
+éventuel est tracé en dette #24-FE-1.
+
+**Justification.** Le périmètre est net et entièrement couvert par grep (vérifiable en R5.1–R5.3).
+Migrer partiellement laisserait des littéraux résiduels qui contrediraient l'objectif (R5) et
+rendraient le grep de validation non concluant. Les seuls éléments explicitement **laissés
+hors migration** (et tracés) : le TTL cache (déjà isolé, hors périmètre requirements), les
+commentaires contenant `meet.jit.si` (documentation, non exécutable — voir #24-NOTE-1).
+
+---
+
+## Composants et interfaces (API exacte des modules)
+
+Tous les modules sont **gelés** via `Object.freeze` sur tout objet exporté, et documentés en
+JSDoc, cohérents avec `roles.js`/`errorMessages.js`.
+
+### `src/constants/visio.js`
+
+```js
+/** Domaine par défaut (préserve le comportement actuel). Non gelé seul : interne. */
+const DEFAULT_JITSI_DOMAIN = 'meet.jit.si'
+
+/**
+ * Domaine du serveur Jitsi, résolu à l'exécution.
+ * Lit import.meta.env?.VITE_JITSI_DOMAIN (optional chaining → chargeable hors Vite,
+ * pattern roles.js:179). Vide/absent → défaut documenté 'meet.jit.si'.
+ * @returns {string}
+ */
+export function getJitsiDomain()
+
+/**
+ * Construit l'URL d'une salle Jitsi : https://{domaine}/{roomId}[#hash].
+ * @param {string} roomId
+ * @param {{ displayName?: string, prejoinDisabled?: boolean }} [options]
+ *   displayName défini ET/OU prejoinDisabled → ajoute le fragment hash
+ *   'config.prejoinConfig.enabled=false&userInfo.displayName={encoded}' (format actuel).
+ *   Aucune option → forme bare 'https://{domaine}/{roomId}'.
+ * @returns {string}
+ */
+export function buildJitsiUrl(roomId, options = {})
+
+/**
+ * URL du script IFrame API : https://{domaine}/external_api.js.
+ * @returns {string}
+ */
+export function jitsiExternalApiSrc()
+
+/** Intervalle de heartbeat visio en millisecondes (valeur actuelle : 30000). */
+export const HEARTBEAT_INTERVAL_MS = 30000
+
+/** Expiration des participations visio en localStorage (valeur actuelle : 7 jours en ms). */
+export const PARTICIPATION_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000
+
+// Object.freeze appliqué aux objets exportés (les const primitives sont déjà immuables).
+```
+
+Note : `HEARTBEAT_INTERVAL_MS` et `PARTICIPATION_EXPIRATION_MS` sont des `number` primitifs déjà
+immuables ; aucun `Object.freeze` requis sur eux (un `number` ne se gèle pas). Le test R6.1 de
+gel porte sur les objets exportés (helpers regroupés ou objet de config s'il en existe). Pour
+satisfaire R6.1 de façon uniforme et testable, **`visio.js` exporte aussi un objet gelé
+`VISIO_CONFIG`** regroupant les valeurs primitives :
+
+```js
+export const VISIO_CONFIG = Object.freeze({
+  HEARTBEAT_INTERVAL_MS: 30000,
+  PARTICIPATION_EXPIRATION_MS: 7 * 24 * 60 * 60 * 1000,
+  DEFAULT_JITSI_DOMAIN: 'meet.jit.si',
+})
+```
+
+Les consommateurs importent soit les helpers, soit `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS`.
+
+### `src/constants/http.js`
+
+```js
+/** Défaut de développement UNIQUE (jamais utilisé en production). */
+const DEV_API_URL = 'http://localhost:8000/api'
+
+/**
+ * URL de base de l'API (inclut le suffixe /api comme VITE_API_URL).
+ * - VITE_API_URL défini → retourné tel quel.
+ * - absent ET import.meta.env.PROD → throw Error explicite (R4.2). Aucun secret journalisé.
+ * - absent ET DEV → DEV_API_URL.
+ * @returns {string}
+ * @throws {Error} si VITE_API_URL manquant en production.
+ */
+export function apiBaseUrl()
+
+/**
+ * Origine de l'API (apiBaseUrl sans le suffixe '/api' terminal).
+ * Pour les sites construisant des chemins incluant déjà '/api' (StudentLessonView,
+ * Beacon useVisioParticipation). Défaut dev dérivé : 'http://localhost:8000'.
+ * @returns {string}
+ */
+export function apiOrigin()
+```
+
+### `src/constants/storageKeys.js`
+
+```js
+/**
+ * Clés localStorage NON gérées par le store auth (#19).
+ * EXCLUT explicitement token/user/meta/institution (KEYS de auth.js — ne pas dupliquer).
+ * Gelé.
+ */
+export const STORAGE_KEYS = Object.freeze({
+  ADMIN_PREFERENCES: 'adminPreferences',
+  TEACHER_PREFERENCES: 'teacherPreferences',
+  USER_PREFERENCES: 'userPreferences',
+})
+
+/** Préfixe des clés de participation visio (cohérent avec jitsi.js). */
+export const VISIO_PARTICIPATION_PREFIX = 'visio_participation_'
+
+/**
+ * Clé thème scopée par institution.
+ * Reproduit EXACTEMENT 'lms-theme-preference-{slug}' (useTheme.js:13).
+ * @param {string|null|undefined} institutionSlug — slug ; absent → 'default'.
+ * @returns {string}
+ */
+export function themeKey(institutionSlug)
+
+/**
+ * Clé sidebar collapse scopée par institution.
+ * Reproduit EXACTEMENT 'sidebar-collapsed-{slug}' (Sidebar.vue:396).
+ * @param {string|null|undefined} institutionSlug
+ * @returns {string}
+ */
+export function sidebarKey(institutionSlug)
+
+/**
+ * Clé de participation visio scopée séance + utilisateur.
+ * Reproduit EXACTEMENT 'visio_participation_{seanceId}_{userId}' (jitsi.js:126).
+ * @param {number|string} seanceId
+ * @param {number|string} userId
+ * @returns {string}
+ */
+export function visioParticipationKey(seanceId, userId)
+```
+
+Le fallback `'default'` des helpers scopés reproduit `auth.getInstitution() || 'default'`
+(R2.4) — la résolution du slug reste à la charge de l'appelant (qui passe
+`auth.getInstitution()`), le helper n'applique le `'default'` que si l'argument est vide.
+
+### `src/constants/upload.js`
+
+```js
+/** Configuration d'upload de fichiers (chapitres). Gelé. */
+export const UPLOAD_CONFIG = Object.freeze({
+  /** Taille max en octets — valeur actuelle 30 * 1024 * 1024 (30 MiB). */
+  MAX_FILE_SIZE_BYTES: 30 * 1024 * 1024,
+  /** Libellé dérivé, source unique du texte affiché (R3.3). */
+  MAX_FILE_SIZE_LABEL: '30 MB',
+})
+
+/** Types de fichiers acceptés par type de contenu (centralise getAcceptedFileTypes). */
+export const ACCEPTED_FILE_TYPES = Object.freeze({
+  powerpoint: '.pptx,.ppt',
+  word: '.docx,.doc',
+  // … (recopie EXACTE du mapping actuel de ChapterManager.vue:481+)
+})
+```
+
+> NB conception : `MAX_FILE_SIZE_LABEL = '30 MB'` est conservé comme **libellé littéral unique**
+> plutôt que dérivé arithmétiquement de `MAX_FILE_SIZE_BYTES`. Justification : `30 * 1024 * 1024`
+> vaut 30 **MiB**, dont le libellé exact actuel est « 30 MB » (imprécision binaire/décimale). Un
+> dérivateur `bytes → label` réintroduirait soit « 28.6 MB » (faux vs actuel), soit la même
+> constante texte. Le couple `{ BYTES, LABEL }` gelé garantit la source unique (R3.3) sans
+> dérive ; la cohérence des deux est vérifiée par test (un test asserte que le LABEL correspond
+> bien à `BYTES / 1024 / 1024 + ' MB'`).
+
+---
+
+## Data Models
+
+### Structures de données centrales (TypeScript-like, à titre de contrat)
+
+```ts
+// visio.js
+function getJitsiDomain(): string
+function buildJitsiUrl(roomId: string, options?: {
+  displayName?: string
+  prejoinDisabled?: boolean
+}): string
+function jitsiExternalApiSrc(): string
+const VISIO_CONFIG: Readonly<{
+  HEARTBEAT_INTERVAL_MS: number          // 30000
+  PARTICIPATION_EXPIRATION_MS: number    // 604800000
+  DEFAULT_JITSI_DOMAIN: string           // 'meet.jit.si'
+}>
+
+// http.js
+function apiBaseUrl(): string   // throws en PROD si VITE_API_URL absent
+function apiOrigin(): string
+
+// storageKeys.js
+const STORAGE_KEYS: Readonly<{
+  ADMIN_PREFERENCES: 'adminPreferences'
+  TEACHER_PREFERENCES: 'teacherPreferences'
+  USER_PREFERENCES: 'userPreferences'
+}>
+const VISIO_PARTICIPATION_PREFIX: 'visio_participation_'
+function themeKey(institutionSlug?: string | null): string
+function sidebarKey(institutionSlug?: string | null): string
+function visioParticipationKey(seanceId: number | string, userId: number | string): string
+
+// upload.js
+const UPLOAD_CONFIG: Readonly<{
+  MAX_FILE_SIZE_BYTES: number    // 31457280
+  MAX_FILE_SIZE_LABEL: string    // '30 MB'
+}>
+const ACCEPTED_FILE_TYPES: Readonly<Record<string, string>>
+```
+
+### Diagramme du modèle de constantes
+
+```mermaid
+classDiagram
+    class visio_js {
+        +getJitsiDomain() string
+        +buildJitsiUrl(roomId, options) string
+        +jitsiExternalApiSrc() string
+        +VISIO_CONFIG frozen
+    }
+    class http_js {
+        +apiBaseUrl() string
+        +apiOrigin() string
+    }
+    class storageKeys_js {
+        +STORAGE_KEYS frozen
+        +VISIO_PARTICIPATION_PREFIX string
+        +themeKey(slug) string
+        +sidebarKey(slug) string
+        +visioParticipationKey(seanceId, userId) string
+    }
+    class upload_js {
+        +UPLOAD_CONFIG frozen
+        +ACCEPTED_FILE_TYPES frozen
+    }
+```
+
+### Pattern de gel (immuabilité)
+
+Identique à `roles.js`/`errorMessages.js` : tout **objet** exporté est enveloppé dans
+`Object.freeze(...)` au point de définition. Les **fonctions** (helpers) ne sont pas gelables en
+tant que telles ; leur immuabilité comportementale est garantie par leur pureté (pas d'état
+mutable interne) et testée par valeur de retour. Les **valeurs primitives** (`number`, `string`)
+sont déjà immuables ; elles sont regroupées dans un objet gelé (`VISIO_CONFIG`, `UPLOAD_CONFIG`)
+pour satisfaire R6.1 (`Object.isFrozen` vérifiable) de façon uniforme.
+
+---
+
+## Business Process
+
+### Processus 1 : génération d'un lien Jitsi (vue → helper)
+
+```mermaid
+sequenceDiagram
+    participant V as Vue ou service jitsi.js
+    participant C as constants visio.js
+    participant E as import.meta.env
+
+    V->>C: buildJitsiUrl(roomId, options)
+    C->>C: getJitsiDomain()
+    C->>E: lire VITE_JITSI_DOMAIN optional chaining
+    E-->>C: valeur ou undefined
+    C->>C: domaine resolu ou defaut meet point jit point si
+    C-->>V: https domaine roomId hash optionnel
+    V->>V: window.open ou affectation href ou script src
+```
+
+### Processus 2 : résolution de l'URL API à l'appel (échec visible en prod)
+
+```mermaid
+flowchart TD
+    A[Vue appelle apiBaseUrl] --> B[constants http.js lit VITE_API_URL]
+    B --> C{defini}
+    C -->|oui| D[retour valeur incluant api]
+    C -->|non| E{import.meta.env.PROD}
+    E -->|prod| F[throw Error config API manquante sans secret]
+    E -->|dev| G[retour defaut dev unique localhost 8000 api]
+    D --> H[Vue construit la requete]
+    G --> H
+```
+
+### Processus 3 : dérivation et lecture d'une clé scopée (thème, multi-tenant)
+
+```mermaid
+flowchart TD
+    A[main.js avant montage] --> B[lire slug institution depuis sessionStorage]
+    B --> C[themeKey slug ou default]
+    C --> D[localStorage getItem cle scopee]
+    D --> E{valeur light ou dark}
+    E -->|oui| F[appliquer theme sans flash]
+    E -->|non| G[preference systeme puis defaut light]
+    H[useTheme onMounted] --> I[auth.getInstitution ou default]
+    I --> C
+```
+
+---
+
+## Error Handling
+
+| Cas | Stratégie | Référence |
+| --- | --- | --- |
+| `VITE_API_URL` absent en **production** | `apiBaseUrl()`/`apiOrigin()` lèvent une `Error` explicite (message orienté config, **sans valeur secrète** — les `VITE_*` sont publiques, donc rien de sensible à fuiter, mais on ne journalise pas la valeur). Échec visible au premier appel. | R4.2, R4.5 |
+| `VITE_API_URL` absent en **dev** | Fallback dev unique (`http://localhost:8000/api` / `http://localhost:8000`). Jamais embarqué en build prod (gardé derrière `import.meta.env.DEV`). | R4.3 |
+| `VITE_JITSI_DOMAIN` absent | Défaut silencieux `meet.jit.si` (préservation comportement, R1.2) — **différent** du cas API car le défaut public Jitsi est un comportement légitime et documenté, pas une mauvaise configuration. | R1.2 |
+| `import.meta.env` indisponible (Node natif) | Optional chaining (`import.meta.env?.…`) → traité comme « absent » → défaut. Pas d'exception au chargement. | Décision B |
+| Slug d'institution vide | Helpers de clé scopée → suffixe `'default'` (R2.4). | R2.4 |
+| Mutation tentée sur un module gelé | En mode strict (modules ESM le sont), l'affectation lève `TypeError` ; sinon échoue silencieusement. Test R6.1 garantit `Object.isFrozen === true`. | R6.1 |
+
+Principe transverse (production-grade §1.5, §1.6) : **pas de silent failure** sur la
+configuration critique (API en prod) ; les défauts ne sont tolérés que là où ils reproduisent un
+comportement légitime documenté (domaine Jitsi public, slug `default`).
+
+---
+
+## Testing Strategy
+
+Tests Vitest dans `src/constants/__tests__/` (cohérent avec le pattern
+`src/stores/__tests__/auth.test.js`, `src/services/__tests__/`). Alias `@` hérité via
+`vitest.config.js`. Stub d'environnement via `vi.stubEnv` / `vi.unstubAllEnvs` (Vitest gère
+`import.meta.env`). Conforme PRODUCTION_STANDARDS §1.3 (tests d'abord, unitaires isolés, cas
+limites).
+
+### `visio.test.js`
+
+| ID | Cas | Assertion |
+| --- | --- | --- |
+| V1 | `VISIO_CONFIG` gelé | `Object.isFrozen(VISIO_CONFIG) === true` (R6.1) |
+| V2 | `VITE_JITSI_DOMAIN` défini | `getJitsiDomain()` retourne cette valeur (R6.2) |
+| V3 | `VITE_JITSI_DOMAIN` absent/vide | `getJitsiDomain() === 'meet.jit.si'` (R6.3) |
+| V4 | `buildJitsiUrl(roomId)` sans options | `=== 'https://meet.jit.si/{roomId}'` (forme bare) |
+| V5 | `buildJitsiUrl(roomId, { displayName, prejoinDisabled })` | hash exact `#config.prejoinConfig.enabled=false&userInfo.displayName={encoded}` |
+| V6 | `buildJitsiUrl` avec domaine custom | utilise le domaine env, schéma `https` (R1.4) |
+| V7 | `jitsiExternalApiSrc()` | `=== 'https://{domaine}/external_api.js'` |
+| V8 | `HEARTBEAT_INTERVAL_MS` / `PARTICIPATION_EXPIRATION_MS` | valeurs exactes `30000` / `604800000` (R3.6) |
+
+### `http.test.js`
+
+| ID | Cas | Assertion |
+| --- | --- | --- |
+| H1 | `VITE_API_URL` défini | `apiBaseUrl()` retourne la valeur ; `apiOrigin()` retourne sans `/api` |
+| H2 | absent + `PROD` | `apiBaseUrl()` **throw** (R6.5) ; le message ne contient aucune valeur env |
+| H3 | absent + `DEV` | `apiBaseUrl() === 'http://localhost:8000/api'`, `apiOrigin() === 'http://localhost:8000'` |
+| H4 | `VITE_API_URL` sans `/api` terminal | `apiOrigin()` n'altère pas une base déjà sans `/api` |
+
+### `storageKeys.test.js`
+
+| ID | Cas | Assertion |
+| --- | --- | --- |
+| S1 | `STORAGE_KEYS` gelé | `Object.isFrozen(STORAGE_KEYS) === true` (R6.1) |
+| S2 | `themeKey('esi')` | `=== 'lms-theme-preference-esi'` (R6.4) |
+| S3 | `themeKey(null)` | `=== 'lms-theme-preference-default'` (R6.4 fallback) |
+| S4 | `sidebarKey('esi')` / `sidebarKey()` | `'sidebar-collapsed-esi'` / `'sidebar-collapsed-default'` |
+| S5 | `visioParticipationKey(12, 7)` | `=== 'visio_participation_12_7'` (R3 non-régression clé) |
+| S6 | valeurs plates | `STORAGE_KEYS.ADMIN_PREFERENCES === 'adminPreferences'` etc. (R5.4) |
+
+### `upload.test.js`
+
+| ID | Cas | Assertion |
+| --- | --- | --- |
+| U1 | `UPLOAD_CONFIG` / `ACCEPTED_FILE_TYPES` gelés | `Object.isFrozen === true` (R6.1) |
+| U2 | `MAX_FILE_SIZE_BYTES` | `=== 31457280` (R3.2 non-régression) |
+| U3 | cohérence libellé | `MAX_FILE_SIZE_LABEL === (MAX_FILE_SIZE_BYTES / 1024 / 1024) + ' MB'` (R3.3) |
+
+Stratégie d'isolation : chaque suite réinitialise l'env (`vi.unstubAllEnvs()` en `afterEach`)
+pour éviter la fuite d'état entre tests (cas limite : V2 ne doit pas polluer V3).
+
+---
+
+## Mapping de migration
+
+Périmètre **migré intégralement** (Décision E). Grep de validation post-migration (R5.1–R5.3) :
+plus aucun littéral `meet.jit.si`, `|| 'http://localhost:8000'`, `30000` (heartbeat) ou
+`30 * 1024 * 1024` dans le code exécutable de `src/`.
+
+### Jitsi (17 occurrences / 10 fichiers)
+
+| Fichier:ligne | Forme actuelle | Migration |
+| --- | --- | --- |
+| `services/jitsi.js:15` | `const JITSI_DOMAIN = 'meet.jit.si'` | supprimé ; L47 utilise `getJitsiDomain()` |
+| `services/jitsi.js:16` | commentaire `meet.jit.si` | commentaire reformulé (#24-NOTE-1) |
+| `components/visio/VisioManager.vue:337,462` | `https://meet.jit.si/${roomId}` | `buildJitsiUrl(roomId)` |
+| `components/visio/JitsiMeet.vue:58` | commentaire | conservé/reformulé (doc, #24-NOTE-1) |
+| `components/visio/JitsiMeet.vue:82` | `external_api.js` src | `jitsiExternalApiSrc()` |
+| `components/visio/JitsiMeet.vue:110` | `domain = 'meet.jit.si'` | `domain = getJitsiDomain()` |
+| `views/VideoConference.vue:73` | `external_api.js` src | `jitsiExternalApiSrc()` |
+| `views/VideoConference.vue:88` | `domain = 'meet.jit.si'` | `domain = getJitsiDomain()` |
+| `views/TeacherSeances.vue:594` | bare | `buildJitsiUrl(roomId)` |
+| `views/coordinateur/SeanceManagement.vue:493` | bare | `buildJitsiUrl(roomId)` |
+| `views/coordinateur/SeanceManagement.vue:533` | hash params | `buildJitsiUrl(roomId, { displayName, prejoinDisabled: true })` |
+| `views/seances/SeanceDetails.vue:381,431` | hash params | `buildJitsiUrl(roomId, { displayName, prejoinDisabled: true })` |
+| `views/teacher/TeacherSchedule.vue:49,63` | hash params | `buildJitsiUrl(roomId, { displayName, prejoinDisabled: true })` |
+| `views/teacher/TeacherVisioList.vue:119` | bare (`:href`) | `buildJitsiUrl(seance.visio.room_id)` |
+| `views/student/StudentSchedule.vue:51` | hash params | `buildJitsiUrl(roomId, { displayName, prejoinDisabled: true })` |
+
+### Fallback API (7 occurrences + 1 accès direct lié)
+
+| Fichier:ligne | Actuel | Migration |
+| --- | --- | --- |
+| `components/visio/VisioManager.vue:400` | `… \|\| 'http://localhost:8000/api'` | `apiBaseUrl()` |
+| `components/visio/ParticipantsModal.vue:431,480` | idem | `apiBaseUrl()` |
+| `views/attendance/SeanceAttendanceHistory.vue:537,586` | idem | `apiBaseUrl()` |
+| `views/student/StudentLessonView.vue:495,503` | `… \|\| 'http://localhost:8000'` (sans `/api`) | `apiOrigin()` |
+| `composables/useVisioParticipation.js:223` | `${VITE_API_URL}/api/...` (accès direct, pas de fallback) | `apiOrigin()` + `/api/...` (URL finale identique) — cohérence R4.4 |
+
+### Magic numbers
+
+| Fichier:ligne | Actuel | Migration |
+| --- | --- | --- |
+| `composables/useVisioParticipation.js:56,82` | `30000` | `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS` |
+| `stores/visio.js:66,92` | `30000` | `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS` |
+| `components/visio/VisioManager.vue:243` | `30000` | `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS` |
+| `components/visio/JitsiMeet.vue:253` | `30000` | `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS` |
+| `services/jitsi.js:325` | `7 * 24 * 60 * 60 * 1000` | `VISIO_CONFIG.PARTICIPATION_EXPIRATION_MS` |
+| `components/lessons/ChapterManager.vue:472` | `30 * 1024 * 1024` | `UPLOAD_CONFIG.MAX_FILE_SIZE_BYTES` |
+| `components/lessons/ChapterManager.vue:105,473` | `'30 MB'` | `UPLOAD_CONFIG.MAX_FILE_SIZE_LABEL` |
+| `components/lessons/ChapterManager.vue:481+` | mapping types | `ACCEPTED_FILE_TYPES` |
+
+### Clés de storage
+
+| Fichier:ligne | Actuel | Migration |
+| --- | --- | --- |
+| `main.js:10` | `'lms-theme-preference'` (NON scopé — bug) | `themeKey(slug)` lu depuis sessionStorage (Décision D) |
+| `composables/useTheme.js:13` | `lms-theme-preference-${institution}` | `themeKey(auth.getInstitution())` |
+| `components/layout/Sidebar.vue:396` | `sidebar-collapsed-${…}` | `sidebarKey(auth.getInstitution())` |
+| `views/admin/AdminSettings.vue:254,260` | `'adminPreferences'` | `STORAGE_KEYS.ADMIN_PREFERENCES` |
+| `views/teacher/TeacherSettings.vue:233,239` | `'teacherPreferences'` | `STORAGE_KEYS.TEACHER_PREFERENCES` |
+| `views/student/StudentSettings.vue:233,239` | `'userPreferences'` | `STORAGE_KEYS.USER_PREFERENCES` |
+| `services/jitsi.js:126,168` + préfixe L269,308,331 | `visio_participation_${…}` | `visioParticipationKey(...)` + `VISIO_PARTICIPATION_PREFIX` |
+
+### Documentation env (R7)
+
+- `.env.example` : ajouter `VITE_JITSI_DOMAIN=meet.jit.si` + commentaire exemple auto-hébergé +
+  note « aucune valeur secrète (bundle public) ».
+- `.env.production.example` : ajouter `VITE_JITSI_DOMAIN`, rappeler `VITE_API_URL` **obligatoire**
+  (aucun fallback localhost), note secrets.
+- **Ne pas toucher** `.env` / `.env.production` réels (R7.4).
+
+---
+
+## Dette tracée
+
+| Référence | Description | Justification / plan |
+| --- | --- | --- |
+| **#24-NOTE-1** | Le brief annonçait 17 puis 16 occurrences ; le grep `meet\.jit\.si` du 2026-06-16 en renvoie **17** (dont 2 lignes de commentaire : `JitsiMeet.vue:58`, `jitsi.js:16`). | Les commentaires sont de la **documentation non exécutable** : ils sont reformulés (mention « domaine configurable via `VITE_JITSI_DOMAIN` ») mais ne comptent pas comme hardcoding. Le grep de validation R5.1 cible le code exécutable ; les 15 occurrences exécutables sont migrées. |
+| **#24-NOTE-2-MIG** | Correction de la clé thème : les préférences éventuellement stockées sous l'ancienne clé non scopée de `main.js` (`lms-theme-preference`) ne sont pas migrées vers la clé scopée. | Aucune migration de données : la préférence se recrée au premier toggle. Perte = au pire un re-choix de thème ; aucune donnée critique. Migration de données jugée disproportionnée. |
+| **#24-FE-1** | Reliquat éventuel de hardcoding hors périmètre explicite (TTL cache `cache.js:3` déjà isolé ; toute occurrence non listée découverte en implémentation). | Tracé, non masqué. À traiter dans un lot ultérieur si besoin. Le TTL cache est hors périmètre requirements (déjà centralisé localement). |
+
+---
+
+## Conformité PRODUCTION_STANDARDS
+
+- **§1.1 (tailles fichiers/fonctions, SRP).** 4 modules petits et focalisés par domaine ; aucun
+  god-module `config.js`. Helpers purs à responsabilité unique. Découpage justifié (Décision A).
+- **§1.3 (tests d'abord, unitaires isolés, cas limites).** Suites Vitest spécifiées **avant**
+  implémentation, couvrant gel, résolution env (avec/sans variable), dérivation de clés (slug +
+  `default`), échec prod API. Isolation par `vi.unstubAllEnvs`. Pattern existant respecté.
+- **§1.6 (durcissement prod, pas de silent failure critique).** API en prod échoue de façon
+  visible ; défauts tolérés uniquement pour comportements légitimes documentés (Jitsi public,
+  slug `default`). Aucun secret journalisé (`VITE_*` publiques par conception).
+- **DIP/LSP.** Les helpers (`getJitsiDomain`, `apiBaseUrl`) sont des points d'indirection
+  substituables (stubbables en test) là où le comportement varie (env), conformément au principe
+  « ajouter l'abstraction là où la logique varie ».
+- **Honnêteté/traçabilité.** Delta du compte d'occurrences, incohérence thème et reliquat
+  explicitement tracés en dette, jamais masqués.
+
+---
+
+## Traçabilité design → requirements
+
+| Requirement | Couvert par |
+| --- | --- |
+| R1 — Jitsi configurable/centralisé | Décision B ; `visio.js` (`getJitsiDomain`, `buildJitsiUrl`, `jitsiExternalApiSrc`) ; mapping Jitsi ; tests V2–V7 |
+| R2 — Clés storage centralisées (hors auth) | Décision D ; `storageKeys.js` (helpers scopés + `STORAGE_KEYS`) ; exclusion explicite de `KEYS` auth ; tests S1–S6 |
+| R3 — Magic numbers nommés | `VISIO_CONFIG`, `UPLOAD_CONFIG` ; mapping magic numbers ; tests V8, U2, U3 |
+| R4 — API explicite sans fallback localhost prod | Décision C ; `http.js` (`apiBaseUrl`/`apiOrigin`) ; Error Handling ; tests H1–H4 |
+| R5 — Migration sans régression | Décision E ; Mapping de migration complet ; dette tracée #24-FE-1 ; non-régression clés/valeurs (S5, U2, V8) |
+| R6 — Tests Vitest | Testing Strategy (4 suites, IDs alignés R6.1–R6.6) |
+| R7 — Documentation env | Section Documentation env du mapping ; Error Handling (secrets) |
+| Contraintes §1–§6 | Conformité PRODUCTION_STANDARDS ; Décisions A–E (une option chacune, §6) |
+
+---
+
+Le design est-il satisfaisant ? Si oui, nous pourrons passer au plan d'implémentation (tasks).
+```

--- a/.claude/specs/constants/requirements.md
+++ b/.claude/specs/constants/requirements.md
@@ -1,0 +1,247 @@
+# Requirements Document — Centralisation des constantes et de la configuration (#24)
+
+## Introduction
+
+Le frontend Vue 3 (`lms-frontend`) contient de nombreuses valeurs de configuration et
+valeurs « magiques » codées en dur, dispersées à travers services, composables, vues et
+composants. Cette fonctionnalité (issue GitHub **#24**, TIER 1 de l'épique d'audit **#16**)
+vise à **éliminer ce hardcoding** en centralisant ces valeurs dans des modules **gelés**
+(`Object.freeze`) sous `src/constants/`, cohérents avec le pattern déjà établi par
+`src/constants/roles.js` et `src/constants/errorMessages.js`.
+
+Périmètre vérifié par grep (2026-06-16) :
+
+- **URL/domaine Jitsi `meet.jit.si` en dur — 16 occurrences sur 10 fichiers** (le brief
+  annonçait 17 ; recompte ci-dessous, écart tracé en NB) :
+  `src/services/jitsi.js` (L15, constante locale), `src/components/visio/JitsiMeet.vue`
+  (L58 commentaire, L82 `external_api.js`, L110 `domain`), `src/components/visio/VisioManager.vue`
+  (L337, L462), `src/views/VideoConference.vue` (L73 `external_api.js`, L88 `domain`),
+  `src/views/TeacherSeances.vue` (L594), `src/views/coordinateur/SeanceManagement.vue`
+  (L493, L533), `src/views/seances/SeanceDetails.vue` (L381, L431),
+  `src/views/teacher/TeacherSchedule.vue` (L49, L63), `src/views/teacher/TeacherVisioList.vue`
+  (L119), `src/views/student/StudentSchedule.vue` (L51). Non configurable par institution,
+  risque de lock-in.
+- **Fallback `localhost:8000` dangereux — 7 occurrences** via
+  `import.meta.env.VITE_API_URL || 'http://localhost:8000(/api)'` :
+  `src/components/visio/VisioManager.vue` (L400), `src/components/visio/ParticipantsModal.vue`
+  (L431, L480), `src/views/attendance/SeanceAttendanceHistory.vue` (L537, L586),
+  `src/views/student/StudentLessonView.vue` (L495, L503, ces deux-là sans `/api`). Un build
+  prod sans `VITE_API_URL` pointerait silencieusement sur `localhost`.
+- **Clés de storage en chaînes magiques (HORS store auth)** : `adminPreferences`
+  (`AdminSettings.vue` L254/L260), `teacherPreferences` (`TeacherSettings.vue` L233/L239),
+  `userPreferences` (`StudentSettings.vue` L233/L239), thème
+  (`lms-theme-preference-${institution}` dans `useTheme.js` ; **mais** `main.js` L10 utilise
+  `lms-theme-preference` NON scopé — incohérence réelle, cf. R2/R5), sidebar collapse
+  (`sidebar-collapsed-${institution}` dans `Sidebar.vue` L396), participation visio
+  (`visio_participation_${seanceId}_${userId}` + préfixe `visio_participation_` dans
+  `jitsi.js`).
+- **Magic numbers** : heartbeat visio `30000` ms (`useVisioParticipation.js` L56/L82,
+  `stores/visio.js` L66/L92, `VisioManager.vue` L243, `JitsiMeet.vue` L253), limite upload
+  `30 * 1024 * 1024` (`ChapterManager.vue` L472, libellé « 30 MB » L105/L473), expiration
+  participations `7 jours` (`jitsi.js` L325), TTL cache `5 min` (`cache.js` L3, déjà isolé).
+
+État existant : `src/constants/` contient `roles.js` et `errorMessages.js`, tous deux gelés.
+`import.meta.env.VITE_API_URL` est le mécanisme de config Vite. Vitest est installé (#21).
+
+**HORS PÉRIMÈTRE (ne pas toucher)** : les clés du store auth `token`/`user`/`meta`/`institution`,
+déjà encapsulées dans l'objet gelé `KEYS` de `src/stores/auth.js` (#19) ; les couleurs hex de
+charts ; les god components (#28) ; l'i18n ; toute modification backend.
+
+---
+
+## Requirements
+
+### Requirement 1 — Domaine/URL Jitsi configurable et centralisé
+
+**User Story:** En tant qu'administrateur de déploiement (DevOps), je veux que le domaine du
+serveur Jitsi provienne d'une configuration unique et soit configurable par déploiement, afin
+de pouvoir pointer vers un serveur Jitsi auto-hébergé sans modifier le code, et d'éliminer les
+16 occurrences codées en dur de `meet.jit.si`.
+
+#### Acceptance Criteria
+
+1. WHERE la valeur du domaine Jitsi est requise, le système SHALL la lire depuis une source de
+   configuration unique alimentée par `import.meta.env.VITE_JITSI_DOMAIN`.
+2. IF `VITE_JITSI_DOMAIN` n'est pas définie au build, THEN le système SHALL utiliser la valeur
+   par défaut documentée `meet.jit.si` (préservation du comportement actuel).
+3. WHEN un code applicatif construit une URL de salle Jitsi, le système SHALL exposer le domaine
+   (et/ou l'URL de base) via un module de constantes/helper unique sous `src/constants/`, sans
+   réintroduire de littéral `meet.jit.si`.
+4. WHEN le helper Jitsi produit l'URL du script `external_api.js` ou l'URL de base d'une salle,
+   le système SHALL utiliser le schéma `https` et le domaine configuré, sans casser le format
+   d'URL actuel (`https://{domaine}/{room}[#params]`).
+5. WHERE le domaine Jitsi est exposé comme constante, le module SHALL être gelé (`Object.freeze`),
+   cohérent avec `roles.js`/`errorMessages.js`.
+
+> NB (dette/écart tracé #24-NOTE-1) : le brief annonçait 17 occurrences ; le grep du 2026-06-16
+> en recense 16 (dont 1 ligne de commentaire `JitsiMeet.vue:58` et 2 URL `external_api.js`). Le
+> design tranchera le traitement du commentaire et le périmètre exact (helper vs constante simple).
+
+### Requirement 2 — Clés de storage centralisées (hors store auth)
+
+**User Story:** En tant que développeur, je veux un registre unique et gelé des clés de
+`localStorage` non gérées par le store auth, afin d'éliminer les chaînes magiques dupliquées et
+de garantir leur cohérence entre `useTheme.js`, `Sidebar.vue`, `jitsi.js` et les vues de
+préférences.
+
+#### Acceptance Criteria
+
+1. WHERE une clé de storage figure dans le périmètre #24 (préférences `admin`/`teacher`/`user`,
+   thème, sidebar collapse, participation visio), le système SHALL la définir dans un module de
+   constantes gelé unique sous `src/constants/`.
+2. WHEN un code lit ou écrit une de ces clés, le système SHALL utiliser la constante centralisée
+   (ou un helper dérivant la clé scopée par institution) plutôt qu'un littéral.
+3. WHERE une clé est scopée par institution (thème, sidebar) ou par séance/utilisateur
+   (participation visio), le module SHALL fournir un helper paramétré produisant exactement la
+   même clé qu'aujourd'hui (`lms-theme-preference-${institution}`, `sidebar-collapsed-${institution}`,
+   `visio_participation_${seanceId}_${userId}`), afin de ne pas invalider les données existantes.
+4. IF le slug d'institution est absent, THEN le helper de clé scopée SHALL utiliser le suffixe
+   `default`, reproduisant le comportement actuel (`auth.getInstitution() || 'default'`).
+5. WHEN le module de clés de storage est défini, le système SHALL **exclure** les clés du store
+   auth (`token`, `user`, `meta`, `institution`) et SHALL NE PAS modifier ni dupliquer
+   `KEYS` de `src/stores/auth.js` (#19).
+6. WHERE le module expose ces clés, il SHALL être gelé (`Object.freeze`).
+
+> NB (#24-NOTE-2, bug réel à corriger en R5) : `main.js:10` utilise la clé thème NON scopée
+> `lms-theme-preference` tandis que `useTheme.js` utilise la clé scopée par institution. La
+> centralisation DOIT aligner ces deux usages sur une clé unique ; le design tranchera la
+> stratégie de migration des préférences existantes éventuelles.
+
+### Requirement 3 — Magic numbers centralisés et nommés
+
+**User Story:** En tant que développeur, je veux que les valeurs numériques de configuration
+(intervalle de heartbeat, taille max d'upload, délais d'expiration) soient nommées, documentées
+et centralisées dans des modules gelés, afin que leur signification soit explicite et qu'elles
+soient modifiables en un seul endroit.
+
+#### Acceptance Criteria
+
+1. WHERE l'intervalle de heartbeat visio est requis, le système SHALL le lire depuis une
+   constante centralisée nommée valant `30000` (ms), et remplacer les 6 occurrences codées en
+   dur (`useVisioParticipation.js`, `stores/visio.js`, `VisioManager.vue`, `JitsiMeet.vue`).
+2. WHERE la taille maximale d'upload de fichier est requise, le système SHALL la lire depuis une
+   constante centralisée valant `30 * 1024 * 1024` octets (30 MiB), utilisée à la fois pour la
+   validation (`ChapterManager.vue:472`) et pour le libellé affiché (« 30 MB », L105/L473).
+3. WHEN le libellé de taille max est affiché à l'utilisateur, le système SHALL le dériver de la
+   même constante (pas de double source de vérité texte vs validation).
+4. WHERE un délai/intervalle pertinent supplémentaire est centralisé (ex. expiration des
+   participations visio `7 jours`, `jitsi.js:325`), le système SHALL le nommer et le documenter
+   dans le module approprié.
+5. WHERE ces valeurs sont exposées comme constantes, chaque module SHALL être gelé
+   (`Object.freeze`).
+6. WHEN une valeur est centralisée, le système SHALL préserver la valeur numérique exacte
+   actuelle (non-régression), toute modification de valeur étant hors périmètre de #24.
+
+> NB : la liste des types de fichiers autorisés et le TTL cache (`cache.js:3`, déjà isolé) sont
+> candidats optionnels ; le design tranchera leur inclusion.
+
+### Requirement 4 — Configuration API explicite, sans fallback `localhost` silencieux
+
+**User Story:** En tant que responsable de la sécurité/exploitation, je veux que l'URL de l'API
+provienne d'une configuration explicite qui échoue de manière visible si elle est absente, afin
+qu'un build de production mal configuré ne puisse jamais pointer silencieusement sur
+`http://localhost:8000`.
+
+#### Acceptance Criteria
+
+1. WHERE l'URL de base de l'API est requise, le système SHALL la résoudre via une source unique
+   s'appuyant sur `import.meta.env.VITE_API_URL`, remplaçant les 7 fallbacks
+   `|| 'http://localhost:8000(/api)'`.
+2. IF `VITE_API_URL` est absente en mode production (`import.meta.env.PROD`), THEN le système
+   SHALL échouer de manière visible (erreur explicite) plutôt que de retomber silencieusement
+   sur un défaut `localhost`.
+3. WHERE le fallback `localhost` est requis pour le confort de développement, le système SHALL
+   le limiter au mode développement (`import.meta.env.DEV`) et le centraliser en un seul endroit,
+   et SHALL NE PAS l'embarquer dans un build de production.
+4. WHEN un appel applicatif a besoin de l'URL de l'API, le système SHALL exposer cette URL via
+   la configuration centralisée plutôt que via un accès direct dispersé à `import.meta.env`.
+5. WHEN la résolution de l'URL d'API échoue (variable manquante en prod), le système SHALL NE
+   PAS exposer ni journaliser de secret (les variables `VITE_*` sont publiques par conception).
+
+> NB : la décision exacte (supprimer totalement le fallback vs le confiner au mode dev) est
+> laissée au design ; l'invariant non négociable est « aucun fallback `localhost` silencieux en
+> production ».
+
+### Requirement 5 — Migration des sites codés en dur sans régression
+
+**User Story:** En tant que mainteneur, je veux que tous les sites identifiés soient migrés vers
+les constantes/configuration centralisées tout en préservant le comportement observable, afin
+d'obtenir le bénéfice de la centralisation sans introduire de régression.
+
+#### Acceptance Criteria
+
+1. WHEN la migration est terminée, le système SHALL NE plus contenir de littéral `meet.jit.si`
+   dans le code applicatif `src/` (hors modules de constantes et documentation), vérifiable par
+   grep.
+2. WHEN la migration est terminée, le système SHALL NE plus contenir de fallback
+   `|| 'http://localhost:8000'` dans le code applicatif `src/`, vérifiable par grep.
+3. WHEN la migration est terminée, le système SHALL NE plus contenir de littéral `30000` pour le
+   heartbeat ni `30 * 1024 * 1024` pour l'upload dans le code applicatif, vérifiable par grep.
+4. WHEN les clés de storage sont migrées, le système SHALL produire des clés strictement
+   identiques aux clés actuelles pour ne pas perdre les préférences/participations déjà stockées.
+5. WHERE une migration ne peut être complétée intégralement dans le périmètre de cette
+   fonctionnalité, le système SHALL la laisser explicitement documentée comme dette tracée
+   (référence #24-DEBT-x), et SHALL NE PAS masquer le hardcoding résiduel.
+6. WHEN la migration touche du code existant, le système SHALL NE PAS modifier le store auth
+   (#19) ni le backend.
+7. WHILE la migration est en cours, le système SHALL préserver le comportement fonctionnel des
+   visioconférences, du thème, de la sidebar et des préférences (non-régression).
+
+### Requirement 6 — Couverture de tests Vitest
+
+**User Story:** En tant que mainteneur, je veux des tests automatisés sur les nouvelles
+constantes et helpers, afin de garantir leur immuabilité et le comportement attendu de la
+résolution du domaine Jitsi et de l'URL API.
+
+#### Acceptance Criteria
+
+1. WHEN les tests s'exécutent, le système SHALL vérifier que chaque module de constantes
+   introduit est gelé (`Object.isFrozen(...) === true`).
+2. WHEN `VITE_JITSI_DOMAIN` est définie, le système SHALL vérifier que le helper/constante Jitsi
+   retourne ce domaine.
+3. WHEN `VITE_JITSI_DOMAIN` est absente, le système SHALL vérifier que le helper/constante Jitsi
+   retourne le défaut `meet.jit.si`.
+4. WHEN un helper de clé de storage scopée est testé, le système SHALL vérifier qu'il produit la
+   clé attendue avec un slug d'institution donné ET avec le fallback `default`.
+5. WHERE la résolution de l'URL d'API est testée, le système SHALL vérifier qu'en mode
+   production sans `VITE_API_URL` l'erreur visible est levée (pas de fallback `localhost`).
+6. WHEN les tests sont écrits, le système SHALL suivre le pattern Vitest existant
+   (`src/stores/__tests__/`) et SHALL être conformes à PRODUCTION_STANDARDS §1.3.
+
+### Requirement 7 — Documentation des variables d'environnement
+
+**User Story:** En tant que personne déployant le frontend, je veux que les variables
+d'environnement (nouvelles et existantes critiques) soient documentées dans les fichiers
+`.env*.example`, afin de configurer correctement un déploiement sans lire le code.
+
+#### Acceptance Criteria
+
+1. WHEN `.env.example` est mis à jour, le système SHALL documenter `VITE_JITSI_DOMAIN` (avec le
+   défaut `meet.jit.si` et un exemple de domaine auto-hébergé en commentaire).
+2. WHEN `.env.production.example` est mis à jour, le système SHALL documenter `VITE_JITSI_DOMAIN`
+   et SHALL rappeler que `VITE_API_URL` est **obligatoire** en production (aucun fallback
+   `localhost`).
+3. WHERE une variable est documentée, le fichier `.example` SHALL préciser qu'aucune valeur
+   secrète ne doit y figurer (les variables `VITE_*` sont embarquées en clair dans le bundle
+   client).
+4. WHEN les `.example` sont modifiés, le système SHALL NE PAS modifier les fichiers `.env` /
+   `.env.production` réels (non versionnés/sensibles).
+
+---
+
+## Non-functional Requirements & Constraints
+
+1. **Immuabilité.** Tous les modules de constantes introduits SHALL être gelés via
+   `Object.freeze`, cohérents avec `src/constants/roles.js` et `errorMessages.js`.
+2. **Sécurité.** Aucun secret dans les variables `VITE_*` (publiques par conception Vite) ;
+   aucun fallback `localhost` silencieux en production.
+3. **Aucune modification backend** ni du store auth `KEYS` (#19).
+4. **Conformité.** Respecter PRODUCTION_STANDARDS (§1.1 tailles de fichiers/fonctions, §1.3
+   tests, §1.6) et CONTRIBUTING.
+5. **Traçabilité.** Toute valeur centralisée doit être traçable à son ou ses sites d'origine ;
+   toute migration non finalisée doit être déclarée comme dette tracée explicite.
+6. **Décisions déléguées au design.** Emplacement/nommage des modules (`src/constants/visio.js`,
+   `storageKeys.js`, `upload.js`, `http.js`…), forme du domaine Jitsi (fonction helper vs
+   constante), stratégie exacte du fallback `localhost` (suppression vs confinement dev),
+   périmètre migration immédiate vs dette, et traitement de l'incohérence de clé thème
+   (#24-NOTE-2).

--- a/.claude/specs/constants/tasks.md
+++ b/.claude/specs/constants/tasks.md
@@ -1,0 +1,264 @@
+# Implementation Plan — Centralisation des constantes (#24)
+
+> Convention de tests (#21) : le runner Vitest inclut `src/**/*.test.{js,mjs}` (jamais
+> `.spec.`). Tous les tests de constantes vont donc dans `src/constants/__tests__/*.test.js`.
+> Alias `@` hérité via `vitest.config.js` (`mergeConfig(viteConfig)`). Stub d'env via
+> `vi.stubEnv` / `vi.unstubAllEnvs` en `afterEach`.
+>
+> Chaque tâche cite ses `_Requirements:_`, la décision design (A–E), les fichiers touchés et un
+> critère de complétion (test ou grep) vérifiable. Toute migration préserve le comportement
+> observable exact (valeurs, clés, URL finales).
+
+## Phase 1 — Tests d'abord (rouge)
+
+- [ ] 1. Écrire les suites Vitest des 4 modules de constantes (TDD, doivent échouer en rouge)
+- [ ] 1.1 Suite `visio.test.js`
+  - Créer `src/constants/__tests__/visio.test.js` important `@/constants/visio`.
+  - Couvrir : V1 `Object.isFrozen(VISIO_CONFIG) === true` ; V2 `getJitsiDomain()` retourne la
+    valeur de `VITE_JITSI_DOMAIN` (stub) ; V3 absente/vide → `'meet.jit.si'` ; V4
+    `buildJitsiUrl(roomId)` (bare) `=== 'https://meet.jit.si/{roomId}'` ; V5
+    `buildJitsiUrl(roomId, { displayName, prejoinDisabled: true })` → hash exact
+    `#config.prejoinConfig.enabled=false&userInfo.displayName={encoded}` ; V6 domaine custom +
+    schéma `https` ; V7 `jitsiExternalApiSrc() === 'https://{domaine}/external_api.js'` ; V8
+    `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS === 30000` et `PARTICIPATION_EXPIRATION_MS === 604800000`.
+  - `afterEach(() => vi.unstubAllEnvs())` pour isoler V2/V3.
+  - _Requirements: 6.1, 6.2, 6.3, 1.2, 1.4, 3.6_  · Décision B · Critère : `npm run test -- src/constants/__tests__/visio.test.js` échoue (module absent).
+- [ ] 1.2 Suite `http.test.js`
+  - Créer `src/constants/__tests__/http.test.js` important `@/constants/http`.
+  - Couvrir : H1 `VITE_API_URL` défini → `apiBaseUrl()` retourne la valeur, `apiOrigin()` sans
+    `/api` terminal ; H2 absent + `PROD` → `apiBaseUrl()` **throw** et le message ne contient
+    aucune valeur d'env ; H3 absent + `DEV` → `apiBaseUrl() === 'http://localhost:8000/api'`,
+    `apiOrigin() === 'http://localhost:8000'` ; H4 `VITE_API_URL` sans `/api` → `apiOrigin()`
+    n'altère pas la base.
+  - Stub de `PROD`/`DEV` via `vi.stubEnv` ; `afterEach(vi.unstubAllEnvs)`.
+  - _Requirements: 6.5, 4.2, 4.3, 4.4_  · Décision C · Critère : suite rouge (module absent).
+- [ ] 1.3 Suite `storageKeys.test.js`
+  - Créer `src/constants/__tests__/storageKeys.test.js` important `@/constants/storageKeys`.
+  - Couvrir : S1 `Object.isFrozen(STORAGE_KEYS) === true` ; S2 `themeKey('esi') ===
+    'lms-theme-preference-esi'` ; S3 `themeKey(null) === 'lms-theme-preference-default'` ; S4
+    `sidebarKey('esi')`/`sidebarKey()` → `'sidebar-collapsed-esi'`/`'sidebar-collapsed-default'` ;
+    S5 `visioParticipationKey(12, 7) === 'visio_participation_12_7'` ; S6 valeurs plates
+    (`STORAGE_KEYS.ADMIN_PREFERENCES === 'adminPreferences'`, etc.) et
+    `VISIO_PARTICIPATION_PREFIX === 'visio_participation_'`.
+  - _Requirements: 6.1, 6.4, 2.3, 2.4, 5.4_  · Décision D · Critère : suite rouge (module absent).
+- [ ] 1.4 Suite `upload.test.js`
+  - Créer `src/constants/__tests__/upload.test.js` important `@/constants/upload`.
+  - Couvrir : U1 `Object.isFrozen(UPLOAD_CONFIG)` et `Object.isFrozen(ACCEPTED_FILE_TYPES)` ; U2
+    `MAX_FILE_SIZE_BYTES === 31457280` ; U3 cohérence libellé
+    `MAX_FILE_SIZE_LABEL === (MAX_FILE_SIZE_BYTES / 1024 / 1024) + ' MB'`.
+  - _Requirements: 6.1, 3.2, 3.3_  · Décisions A, E · Critère : suite rouge (module absent).
+
+## Phase 2 — Implémenter les 4 modules gelés (vert)
+
+- [ ] 2. Implémenter les modules de constantes pour faire passer la Phase 1 au vert
+- [ ] 2.1 Module `src/constants/visio.js`
+  - Créer le module avec JSDoc (pattern `roles.js`/`errorMessages.js`).
+  - `getJitsiDomain()` lit `import.meta.env?.VITE_JITSI_DOMAIN` (optional chaining, pattern
+    `roles.js:179`) ; vide/absent → `'meet.jit.si'`.
+  - `buildJitsiUrl(roomId, options = {})` : forme bare `https://{domaine}/{roomId}` sans options ;
+    avec `displayName`/`prejoinDisabled` → fragment hash exact
+    `#config.prejoinConfig.enabled=false&userInfo.displayName={encodeURIComponent(name)}`.
+  - `jitsiExternalApiSrc()` → `https://{domaine}/external_api.js`.
+  - Exporter `HEARTBEAT_INTERVAL_MS = 30000`, `PARTICIPATION_EXPIRATION_MS = 7*24*60*60*1000`, et
+    l'objet gelé `VISIO_CONFIG = Object.freeze({ HEARTBEAT_INTERVAL_MS, PARTICIPATION_EXPIRATION_MS, DEFAULT_JITSI_DOMAIN })`.
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 3.1, 3.4, 3.5_  · Décisions A, B · Critère : `visio.test.js` vert.
+- [ ] 2.2 Module `src/constants/http.js`
+  - `apiBaseUrl()` : `VITE_API_URL` défini → retourné tel quel ; absent + `import.meta.env?.PROD`
+    → `throw new Error(...)` explicite **sans** journaliser la valeur env ; absent + `DEV` →
+    `DEV_API_URL = 'http://localhost:8000/api'` (constante interne).
+  - `apiOrigin()` : dérive de `apiBaseUrl()` en supprimant le suffixe `/api` terminal ; défaut dev
+    `'http://localhost:8000'`.
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_  · Décision C · Critère : `http.test.js` vert.
+- [ ] 2.3 Module `src/constants/storageKeys.js`
+  - `STORAGE_KEYS = Object.freeze({ ADMIN_PREFERENCES, TEACHER_PREFERENCES, USER_PREFERENCES })`
+    avec valeurs `'adminPreferences'`/`'teacherPreferences'`/`'userPreferences'`.
+  - `VISIO_PARTICIPATION_PREFIX = 'visio_participation_'`.
+  - Helpers scopés `themeKey(slug)` → `lms-theme-preference-{slug||'default'}`, `sidebarKey(slug)`
+    → `sidebar-collapsed-{slug||'default'}`, `visioParticipationKey(seanceId, userId)` →
+    `visio_participation_{seanceId}_{userId}`. Le `'default'` n'est appliqué que si l'argument est
+    vide (la résolution du slug reste à la charge de l'appelant). NE PAS importer/dupliquer `KEYS`
+    de `src/stores/auth.js`.
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_  · Décision D · Critère : `storageKeys.test.js` vert.
+- [ ] 2.4 Module `src/constants/upload.js`
+  - `UPLOAD_CONFIG = Object.freeze({ MAX_FILE_SIZE_BYTES: 30*1024*1024, MAX_FILE_SIZE_LABEL: '30 MB' })`.
+  - `ACCEPTED_FILE_TYPES = Object.freeze({...})` : recopie EXACTE du mapping actuel de
+    `ChapterManager.vue:481+` (lire le fichier source avant de figer pour ne rien altérer).
+  - _Requirements: 3.2, 3.3, 3.5_  · Décisions A, E · Critère : `upload.test.js` vert ; `npm run test` global vert.
+
+## Phase 3 — Migration des sites codés en dur (Décision E, sans régression)
+
+> Séquencer par fichier pour les fichiers touchés par plusieurs familles (`VisioManager.vue`,
+> `SeanceDetails.vue`, `TeacherSchedule.vue`, `StudentSchedule.vue` : Jitsi ET/OU heartbeat).
+> Préserver l'URL/clé/valeur finale exacte. Si un fichier migré entre dans le graphe du runner de
+> contrat natif, utiliser un **import relatif** (sinon alias `@/constants/*`).
+
+- [x] 3. Migration Jitsi — 15 occurrences exécutables / 10 fichiers (2 commentaires #24-NOTE-1 exclus)
+- [x] 3.1 Service `src/services/jitsi.js`
+  - Supprimer la constante locale `JITSI_DOMAIN` (L15) ; substituer `getJitsiDomain()` dans le
+    template L47 (conserver la construction `URLSearchParams` existante, on ne reformate pas
+    l'URL). Reformuler le commentaire L16 (mention « configurable via `VITE_JITSI_DOMAIN` »).
+  - Import `@/constants/visio` (vérifié hors graphe runner natif).
+  - _Requirements: 1.1, 1.3, 5.1_  · Décision B · Critère : grep `meet\.jit\.si` → 0 hit exécutable dans `jitsi.js`.
+- [x] 3.2 Composants visio IFrame API (`JitsiMeet.vue`, `VideoConference.vue`)
+  - `JitsiMeet.vue:82` et `VideoConference.vue:73` → `jitsiExternalApiSrc()` pour le src du
+    script ; `JitsiMeet.vue:110` et `VideoConference.vue:88` (`domain = 'meet.jit.si'`) →
+    `domain = getJitsiDomain()`. Reformuler le commentaire `JitsiMeet.vue:58` (#24-NOTE-1).
+  - _Requirements: 1.1, 1.3, 1.4, 5.1_  · Décision B · Critère : grep `meet\.jit\.si` → 0 hit exécutable dans ces 2 fichiers.
+- [x] 3.3 Sites « bare » (`VisioManager.vue` 337/462, `TeacherSeances.vue` 594, `SeanceManagement.vue` 493, `TeacherVisioList.vue` 119)
+  - Remplacer `https://meet.jit.si/${roomId}` par `buildJitsiUrl(roomId)` (forme sans options) ;
+    `TeacherVisioList.vue:119` → `buildJitsiUrl(seance.visio.room_id)`.
+  - _Requirements: 1.3, 1.4, 5.1, 5.7_  · Décision B · Critère : grep `meet\.jit\.si` → 0 hit dans ces fichiers (hors heartbeat de VisioManager, traité 5.x).
+- [x] 3.4 Sites « hash params » (`SeanceManagement.vue` 533, `SeanceDetails.vue` 381/431, `TeacherSchedule.vue` 49/63, `StudentSchedule.vue` 51)
+  - Remplacer par `buildJitsiUrl(roomId, { displayName, prejoinDisabled: true })` ; vérifier que
+    l'URL produite est byte-identique au littéral actuel (encodage `displayName` inclus).
+  - _Requirements: 1.3, 1.4, 5.1, 5.7_  · Décision B · Critère : grep `meet\.jit\.si` → 0 hit dans ces fichiers ; comportement visio inchangé.
+
+- [x] 4. Migration fallback API — 7 sites + 1 accès direct lié
+- [x] 4.1 Sites avec `/api` → `apiBaseUrl()`
+  - `VisioManager.vue:400`, `ParticipantsModal.vue:431/480`, `SeanceAttendanceHistory.vue:537/586`
+    : remplacer `import.meta.env.VITE_API_URL || 'http://localhost:8000/api'` par `apiBaseUrl()`.
+  - _Requirements: 4.1, 4.4, 5.2, 5.7_  · Décision C · Critère : grep `localhost:8000` → 0 hit dans ces fichiers.
+- [x] 4.2 Sites sans `/api` → `apiOrigin()`
+  - `StudentLessonView.vue:495/503` : remplacer `... || 'http://localhost:8000'` par
+    `apiOrigin()` (préserver le `/api` ajouté plus loin → URL finale identique).
+  - `useVisioParticipation.js:223` (Beacon, accès direct sans fallback) → `apiOrigin()` + `/api/...`
+    pour cohérence R4.4 en gardant l'URL finale exacte.
+  - _Requirements: 4.1, 4.4, 5.2, 5.7_  · Décision C · Critère : grep `localhost:8000` → 0 hit ; URL Beacon inchangée.
+
+- [x] 5. Migration heartbeat `30000` — 6 sites visio (exclure l'auto-save `TakeEvaluation.vue:348`)
+- [x] 5.1 Composables/stores heartbeat (`useVisioParticipation.js` 56/82, `stores/visio.js` 66/92)
+  - Remplacer `30000` par `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS`.
+  - _Requirements: 3.1, 5.3, 5.7_  · Décisions A, E · Critère : grep `30000` → 0 hit dans ces fichiers.
+- [x] 5.2 Composants heartbeat (`VisioManager.vue:243`, `JitsiMeet.vue:253`)
+  - Remplacer `30000` par `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS` (séquencer après 3.2/3.3 sur ces
+    mêmes fichiers).
+  - _Requirements: 3.1, 5.3, 5.7_  · Décisions A, E · Critère : grep `30000` heartbeat → 0 hit ; `TakeEvaluation.vue:348` intact.
+- [x] 5.3 Expiration participations (`services/jitsi.js:325`)
+  - Remplacer `7 * 24 * 60 * 60 * 1000` par `VISIO_CONFIG.PARTICIPATION_EXPIRATION_MS`.
+  - _Requirements: 3.4, 5.3, 5.7_  · Décisions A, E · Critère : grep dans `jitsi.js` → littéral absent.
+
+- [x] 6. Migration upload (`components/lessons/ChapterManager.vue`)
+  - L472 `30 * 1024 * 1024` → `UPLOAD_CONFIG.MAX_FILE_SIZE_BYTES` ; L105/L473 `'30 MB'` →
+    `UPLOAD_CONFIG.MAX_FILE_SIZE_LABEL` ; mapping types L481+ → `ACCEPTED_FILE_TYPES`.
+  - _Requirements: 3.2, 3.3, 5.3, 5.7_  · Décisions A, E · Critère : grep `30 \* 1024 \* 1024` et `'30 MB'` → 0 hit dans le fichier.
+
+- [x] 7. Migration clés de storage (thème scopé corrige le bug #24-NOTE-2)
+- [x] 7.1 Clé thème alignée (`main.js:10` + `composables/useTheme.js:13`)
+  - `useTheme.js` → `themeKey(auth.getInstitution())` ; `main.js:10` lit le slug brut depuis
+    `sessionStorage` (clé `institution`, fallback `default`) **sans importer le store auth** puis
+    appelle `themeKey(slug)`. Aligne les deux usages sur la clé scopée unique (corrige le bug
+    non-scopé). Ne pas migrer les données existantes (#24-NOTE-2-MIG).
+  - _Requirements: 2.2, 2.3, 2.4, 5.4, 5.6, 5.7_  · Décision D · Critère : grep `lms-theme-preference` littéral → 0 hit hors `storageKeys.js`.
+- [x] 7.2 Clé sidebar + clés de préférences (`Sidebar.vue:396`, `Admin/Teacher/StudentSettings.vue`)
+  - `Sidebar.vue:396` → `sidebarKey(auth.getInstitution())` ; `AdminSettings.vue:254/260` →
+    `STORAGE_KEYS.ADMIN_PREFERENCES` ; `TeacherSettings.vue:233/239` →
+    `STORAGE_KEYS.TEACHER_PREFERENCES` ; `StudentSettings.vue:233/239` →
+    `STORAGE_KEYS.USER_PREFERENCES`.
+  - _Requirements: 2.1, 2.2, 2.3, 5.4, 5.7_  · Décision D · Critère : grep des littéraux concernés → 0 hit hors `storageKeys.js`.
+- [x] 7.3 Clés de participation visio (`services/jitsi.js`)
+  - L126/L168 → `visioParticipationKey(seanceId, userId)` ; préfixe L269/L308/L331 →
+    `VISIO_PARTICIPATION_PREFIX`. Clés produites byte-identiques (non-régression données).
+  - _Requirements: 2.1, 2.2, 2.3, 5.4, 5.7_  · Décision D · Critère : grep `visio_participation_` littéral → 0 hit hors `storageKeys.js`.
+
+## Phase 4 — Documentation environnement (R7)
+
+- [x] 8. Documenter les variables d'environnement dans les fichiers `.example`
+  - `.env.example` : ajouter `VITE_JITSI_DOMAIN=meet.jit.si` + commentaire exemple auto-hébergé +
+    note « aucune valeur secrète (bundle public) ».
+  - `.env.production.example` : ajouter `VITE_JITSI_DOMAIN` + rappel `VITE_API_URL` **obligatoire**
+    (aucun fallback localhost) + note secrets.
+  - NE PAS toucher `.env` / `.env.production` réels.
+  - _Requirements: 7.1, 7.2, 7.3, 7.4_  · Décision C · Critère : `VITE_JITSI_DOMAIN` présent dans les 2 `.example` ; `.env`/`.env.production` inchangés (`git status`).
+
+## Phase 5 — Vérification finale
+
+- [ ] 9. Vérification globale (tests, build, grep de non-régression)
+  - `npm run test` : suites constantes vertes + total ≥ avant migration.
+  - `npm run test:contract` : toujours vert (vérifier qu'aucun fichier migré dans le graphe du
+    runner natif ne casse ; basculer en import relatif si nécessaire).
+  - `npm run build` : réussi.
+  - Grep de preuve : 0 `meet.jit.si` exécutable hors `src/constants/visio.js` ; 0
+    `localhost:8000` hors `src/constants/` ; 0 `30000` heartbeat et `30 * 1024 * 1024` hors
+    constants. Mettre à jour le compteur de reliquat #24-FE-1 (toute occurrence non listée
+    découverte = dette tracée, non masquée).
+  - _Requirements: 5.1, 5.2, 5.3, 5.5, 6.6_  · Décision E · Critère : tous les commandes ci-dessus passent ; grep prouve 0 reliquat exécutable.
+
+---
+
+## Tasks Dependency Diagram
+
+```mermaid
+flowchart TD
+    T1_1[1.1 test visio]
+    T1_2[1.2 test http]
+    T1_3[1.3 test storageKeys]
+    T1_4[1.4 test upload]
+    T2_1[2.1 visio.js]
+    T2_2[2.2 http.js]
+    T2_3[2.3 storageKeys.js]
+    T2_4[2.4 upload.js]
+    T3_1[3.1 jitsi.js domaine]
+    T3_2[3.2 IFrame API]
+    T3_3[3.3 bare]
+    T3_4[3.4 hash params]
+    T4_1[4.1 apiBaseUrl]
+    T4_2[4.2 apiOrigin]
+    T5_1[5.1 heartbeat composables/stores]
+    T5_2[5.2 heartbeat composants]
+    T5_3[5.3 expiration]
+    T6[6 upload migration]
+    T7_1[7.1 theme]
+    T7_2[7.2 sidebar + prefs]
+    T7_3[7.3 participation]
+    T8[8 env .example]
+    T9[9 verification finale]
+
+    T1_1 --> T2_1
+    T1_2 --> T2_2
+    T1_3 --> T2_3
+    T1_4 --> T2_4
+
+    T2_1 --> T3_1
+    T2_1 --> T3_2
+    T2_1 --> T3_3
+    T2_1 --> T3_4
+    T2_1 --> T5_1
+    T2_1 --> T5_2
+    T2_1 --> T5_3
+    T2_2 --> T4_1
+    T2_2 --> T4_2
+    T2_3 --> T7_1
+    T2_3 --> T7_2
+    T2_3 --> T7_3
+    T2_4 --> T6
+
+    T3_3 --> T5_2
+    T3_2 --> T5_2
+
+    T3_1 --> T9
+    T3_2 --> T9
+    T3_3 --> T9
+    T3_4 --> T9
+    T4_1 --> T9
+    T4_2 --> T9
+    T5_1 --> T9
+    T5_2 --> T9
+    T5_3 --> T9
+    T6 --> T9
+    T7_1 --> T9
+    T7_2 --> T9
+    T7_3 --> T9
+    T8 --> T9
+
+    style T2_1 fill:#e1f5fe
+    style T2_2 fill:#e1f5fe
+    style T2_3 fill:#e1f5fe
+    style T2_4 fill:#e1f5fe
+    style T9 fill:#c8e6c9
+```
+
+> Note conflits de fichiers : les 4 modules (Phase 2) sont disjoints → parallélisables. En
+> Phase 3, `VisioManager.vue` est touché par 3.3 (Jitsi) **et** 5.2 (heartbeat) ; `JitsiMeet.vue`
+> par 3.2 **et** 5.2 ; `services/jitsi.js` par 3.1, 5.3, 7.3 → ces fichiers doivent être traités
+> séquentiellement par fichier (pas d'édition concurrente). Les autres sites de migration sont en
+> grande partie disjoints.

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ VITE_API_URL=http://localhost:8000/api
 
 # En production (cPanel), changez par votre vrai domaine :
 # VITE_API_URL=https://api.votre-domaine.com/api
+
+# Domaine du serveur Jitsi pour la visioconférence (défaut : meet.jit.si).
+# À surcharger pour pointer vers une instance Jitsi auto-hébergée, par ex. :
+# VITE_JITSI_DOMAIN=visio.votre-domaine.com
+# NB : aucune valeur secrète ici — les variables VITE_* sont embarquées dans le
+# bundle public livré au navigateur.
+VITE_JITSI_DOMAIN=meet.jit.si

--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -99,6 +99,7 @@ import { auth } from '@/services/api'
 import {
   ROLES, hasRole, isSupradmin, isAdminScope, isTeacher, isStudent, getRoleDisplayName,
 } from '@/constants/roles'
+import { sidebarKey } from '@/constants/storageKeys'
 
 export default {
   name: 'ModernSidebar',
@@ -393,7 +394,7 @@ export default {
     }
 
     // Restore collapsed state from localStorage (scopé par institution)
-    const getSidebarKey = () => `sidebar-collapsed-${auth.getInstitution() || 'default'}`
+    const getSidebarKey = () => sidebarKey(auth.getInstitution())
 
     onMounted(() => {
       const savedState = localStorage.getItem(getSidebarKey())

--- a/src/components/lessons/ChapterManager.vue
+++ b/src/components/lessons/ChapterManager.vue
@@ -102,7 +102,7 @@
                 <span v-if="!chapter.selectedFile"><i class="fa fa-cloud-upload"></i> Ajouter un media</span>
                 <span v-else class="file-selected-name">{{ chapter.selectedFile.name }}</span>
               </label>
-              <p class="file-help-text">Taille max: 30 MB</p>
+              <p class="file-help-text">Taille max: {{ maxFileSizeLabel }}</p>
             </div>
 
             <!-- Quiz Editor Inline -->
@@ -263,6 +263,7 @@ import ContentLoader from '@/components/common/ContentLoader.vue'
 import KnowledgeCheckEditor from '@/components/lessons/KnowledgeCheckEditor.vue'
 import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
 import knowledgeCheckService from '@/services/knowledgeCheck'
+import { UPLOAD_CONFIG, ACCEPTED_FILE_TYPES } from '@/constants/upload'
 
 export default {
   name: 'ChapterManager',
@@ -304,6 +305,13 @@ export default {
 
   mounted() {
     this.loadChapters()
+  },
+
+  computed: {
+    // Libellé de taille max d'upload (source unique #24)
+    maxFileSizeLabel() {
+      return UPLOAD_CONFIG.MAX_FILE_SIZE_LABEL
+    }
   },
 
   watch: {
@@ -469,8 +477,8 @@ export default {
     handleFileSelect(event, chapter) {
       const file = event.target.files[0]
       if (file) {
-        if (file.size > 30 * 1024 * 1024) {
-          alert('Fichier trop volumineux! Max: 30 MB')
+        if (file.size > UPLOAD_CONFIG.MAX_FILE_SIZE_BYTES) {
+          alert(`Fichier trop volumineux! Max: ${UPLOAD_CONFIG.MAX_FILE_SIZE_LABEL}`)
           event.target.value = ''
           return
         }
@@ -479,12 +487,7 @@ export default {
     },
 
     getAcceptedFileTypes(contentType) {
-      const types = {
-        powerpoint: '.pptx,.ppt',
-        word: '.docx,.doc',
-        pdf: '.pdf'
-      }
-      return types[contentType] || '*'
+      return ACCEPTED_FILE_TYPES[contentType] || '*'
     },
 
     getContentTypeLabel(type) {

--- a/src/components/visio/JitsiMeet.vue
+++ b/src/components/visio/JitsiMeet.vue
@@ -23,6 +23,7 @@
 <script setup>
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import lmsService from '@/services/lms'
+import { jitsiExternalApiSrc, getJitsiDomain, VISIO_CONFIG } from '@/constants/visio'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 
 const props = defineProps({
@@ -79,7 +80,7 @@ const loadJitsiScript = () => {
     }
 
     const script = document.createElement('script')
-    script.src = 'https://meet.jit.si/external_api.js'
+    script.src = jitsiExternalApiSrc()
     script.async = true
     script.onload = resolve
     script.onerror = reject
@@ -107,7 +108,7 @@ const initJitsi = async () => {
     console.log(`[JitsiMeet] Initialisation room: ${roomName}`)
 
     // 3. Configuration Jitsi
-    const domain = 'meet.jit.si'
+    const domain = getJitsiDomain()
     const options = {
       roomName: roomName,
       width: '100%',
@@ -250,7 +251,7 @@ const startHeartbeat = () => {
         hasJoined.value = false
       }
     }
-  }, 30000) // 30 secondes
+  }, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
 
   console.log('[JitsiMeet] 💓 Heartbeat démarré (ping toutes les 30s)')
 }

--- a/src/components/visio/ParticipantsModal.vue
+++ b/src/components/visio/ParticipantsModal.vue
@@ -280,6 +280,7 @@ import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
 import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
+import { apiBaseUrl } from '@/constants/http'
 
 export default {
   name: 'ParticipantsModal',
@@ -428,7 +429,7 @@ export default {
       try {
         console.log('[ParticipantsModal] Export PDF de la séance', this.seanceId)
 
-        const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+        const API_URL = apiBaseUrl()
         const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
@@ -477,7 +478,7 @@ export default {
       try {
         console.log('[ParticipantsModal] Export Excel de la séance', this.seanceId)
 
-        const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+        const API_URL = apiBaseUrl()
         const token = useAuthStore().token
 
         // Créer l'URL de téléchargement

--- a/src/components/visio/VisioManager.vue
+++ b/src/components/visio/VisioManager.vue
@@ -144,6 +144,8 @@ import { normalizeError } from '@/services/errorHandler'
 import jitsiService from '@/services/jitsi'
 import ParticipantsModal from './ParticipantsModal.vue'
 import { useVisioStore } from '@/stores/visio'
+import { buildJitsiUrl, VISIO_CONFIG } from '@/constants/visio'
+import { apiBaseUrl } from '@/constants/http'
 
 export default {
   name: 'VisioManager',
@@ -240,7 +242,7 @@ export default {
     // Rafraîchir l'heure actuelle toutes les 30 secondes
     this.timeCheckInterval = setInterval(() => {
       this.currentTime = new Date()
-    }, 30000)
+    }, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
 
     // NOTE: loadParticipantCount() désactivé car cause erreur 500
     // On utilise expectedParticipants (effectif classe) à la place
@@ -334,7 +336,7 @@ export default {
 
         // 2. Récupérer le lien Jitsi
         const roomId = result.data.visio_room_id || this.seance.visio?.room_id
-        const jitsiLink = `https://meet.jit.si/${roomId}`
+        const jitsiLink = buildJitsiUrl(roomId)
 
         // 3. Utiliser le store pour ouvrir et tracker
         await this.visioStore.joinVisio(this.seance.id, jitsiLink)
@@ -397,7 +399,7 @@ export default {
       try {
         console.log('[VisioManager] Téléchargement liste de présence PDF...')
 
-        const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+        const API_URL = apiBaseUrl()
         const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
@@ -459,7 +461,7 @@ export default {
         }
 
         // Utiliser le store pour ouvrir et tracker
-        const jitsiLink = `https://meet.jit.si/${roomId}`
+        const jitsiLink = buildJitsiUrl(roomId)
         await this.visioStore.joinVisio(this.seance.id, jitsiLink)
 
         console.log('✅ Étudiant a rejoint avec window.open + tracking')

--- a/src/composables/useTheme.js
+++ b/src/composables/useTheme.js
@@ -5,12 +5,12 @@
 
 import { ref, onMounted, watch } from 'vue'
 import { auth } from '@/services/api'
+import { themeKey } from '@/constants/storageKeys'
 
 const DEFAULT_THEME = 'light'
 
 function getThemeKey() {
-  const institution = auth.getInstitution() || 'default'
-  return `lms-theme-preference-${institution}`
+  return themeKey(auth.getInstitution())
 }
 
 // Shared state across all instances

--- a/src/composables/useVisioParticipation.js
+++ b/src/composables/useVisioParticipation.js
@@ -1,6 +1,8 @@
 import { ref, onBeforeUnmount } from 'vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { VISIO_CONFIG } from '@/constants/visio'
+import { apiOrigin } from '@/constants/http'
 
 /**
  * Composable pour gérer la participation à une visioconférence
@@ -53,7 +55,7 @@ export function useVisioParticipation(seanceId) {
       })
 
       // Démarrer le Worker (30 secondes)
-      heartbeatWorker.value.postMessage({ command: 'start', interval: 30000 })
+      heartbeatWorker.value.postMessage({ command: 'start', interval: VISIO_CONFIG.HEARTBEAT_INTERVAL_MS })
 
       // Premier heartbeat immédiat
       sendHeartbeat()
@@ -79,7 +81,7 @@ export function useVisioParticipation(seanceId) {
     sendHeartbeat()
     fallbackInterval = setInterval(() => {
       sendHeartbeat()
-    }, 30000)
+    }, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
   }
 
   /**
@@ -220,7 +222,7 @@ export function useVisioParticipation(seanceId) {
    */
   const sendLeaveVisioBeacon = async () => {
     try {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/seances/${seanceId}/leave-visio`
+      const apiUrl = `${apiOrigin()}/api/seances/${seanceId}/leave-visio`
       const token = useAuthStore().token
 
       if (!token) {

--- a/src/constants/__tests__/http.test.js
+++ b/src/constants/__tests__/http.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { apiBaseUrl, apiOrigin } from '@/constants/http'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('constants/http (#24)', () => {
+  it('H1 — VITE_API_URL défini → base + origin', () => {
+    vi.stubEnv('VITE_API_URL', 'https://api.kalga.ci/api')
+    expect(apiBaseUrl()).toBe('https://api.kalga.ci/api')
+    expect(apiOrigin()).toBe('https://api.kalga.ci')
+  })
+
+  it('H2 — absent + PROD → throw sans exposer de valeur env', () => {
+    vi.stubEnv('VITE_API_URL', '')
+    vi.stubEnv('DEV', false)
+    vi.stubEnv('PROD', true)
+    expect(() => apiBaseUrl()).toThrow()
+  })
+
+  it('H3 — absent + DEV → fallback localhost confiné au dev', () => {
+    vi.stubEnv('VITE_API_URL', '')
+    vi.stubEnv('PROD', false)
+    vi.stubEnv('DEV', true)
+    expect(apiBaseUrl()).toBe('http://localhost:8000/api')
+    expect(apiOrigin()).toBe('http://localhost:8000')
+  })
+
+  it('H4 — VITE_API_URL sans /api → origin inchangé', () => {
+    vi.stubEnv('VITE_API_URL', 'https://api.kalga.ci')
+    expect(apiOrigin()).toBe('https://api.kalga.ci')
+  })
+})

--- a/src/constants/__tests__/storageKeys.test.js
+++ b/src/constants/__tests__/storageKeys.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STORAGE_KEYS,
+  VISIO_PARTICIPATION_PREFIX,
+  themeKey,
+  sidebarKey,
+  visioParticipationKey,
+} from '@/constants/storageKeys'
+
+describe('constants/storageKeys (#24)', () => {
+  it('S1 — STORAGE_KEYS gelé', () => {
+    expect(Object.isFrozen(STORAGE_KEYS)).toBe(true)
+  })
+
+  it('S2/S3 — themeKey scopé + fallback default', () => {
+    expect(themeKey('esi')).toBe('lms-theme-preference-esi')
+    expect(themeKey(null)).toBe('lms-theme-preference-default')
+  })
+
+  it('S4 — sidebarKey scopé + fallback', () => {
+    expect(sidebarKey('esi')).toBe('sidebar-collapsed-esi')
+    expect(sidebarKey()).toBe('sidebar-collapsed-default')
+  })
+
+  it('S5 — visioParticipationKey', () => {
+    expect(visioParticipationKey(12, 7)).toBe('visio_participation_12_7')
+  })
+
+  it('S6 — valeurs plates + préfixe', () => {
+    expect(STORAGE_KEYS.ADMIN_PREFERENCES).toBe('adminPreferences')
+    expect(STORAGE_KEYS.TEACHER_PREFERENCES).toBe('teacherPreferences')
+    expect(STORAGE_KEYS.USER_PREFERENCES).toBe('userPreferences')
+    expect(VISIO_PARTICIPATION_PREFIX).toBe('visio_participation_')
+  })
+})

--- a/src/constants/__tests__/upload.test.js
+++ b/src/constants/__tests__/upload.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { UPLOAD_CONFIG, ACCEPTED_FILE_TYPES } from '@/constants/upload'
+
+describe('constants/upload (#24)', () => {
+  it('U1 — objets gelés', () => {
+    expect(Object.isFrozen(UPLOAD_CONFIG)).toBe(true)
+    expect(Object.isFrozen(ACCEPTED_FILE_TYPES)).toBe(true)
+  })
+
+  it('U2 — taille max 30 MB en octets', () => {
+    expect(UPLOAD_CONFIG.MAX_FILE_SIZE_BYTES).toBe(31457280)
+  })
+
+  it('U3 — libellé cohérent avec la taille', () => {
+    expect(UPLOAD_CONFIG.MAX_FILE_SIZE_LABEL).toBe(
+      `${UPLOAD_CONFIG.MAX_FILE_SIZE_BYTES / 1024 / 1024} MB`,
+    )
+  })
+
+  it('types acceptés (recopie du mapping existant)', () => {
+    expect(ACCEPTED_FILE_TYPES.powerpoint).toBe('.pptx,.ppt')
+    expect(ACCEPTED_FILE_TYPES.word).toBe('.docx,.doc')
+    expect(ACCEPTED_FILE_TYPES.pdf).toBe('.pdf')
+  })
+})

--- a/src/constants/__tests__/visio.test.js
+++ b/src/constants/__tests__/visio.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  VISIO_CONFIG,
+  HEARTBEAT_INTERVAL_MS,
+  PARTICIPATION_EXPIRATION_MS,
+  getJitsiDomain,
+  buildJitsiUrl,
+  jitsiExternalApiSrc,
+} from '@/constants/visio'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('constants/visio (#24)', () => {
+  it('V1 — VISIO_CONFIG gelé', () => {
+    expect(Object.isFrozen(VISIO_CONFIG)).toBe(true)
+  })
+
+  it('V2 — getJitsiDomain lit VITE_JITSI_DOMAIN', () => {
+    vi.stubEnv('VITE_JITSI_DOMAIN', 'meet.mondomaine.ci')
+    expect(getJitsiDomain()).toBe('meet.mondomaine.ci')
+  })
+
+  it('V3 — défaut meet.jit.si si absent/vide', () => {
+    vi.stubEnv('VITE_JITSI_DOMAIN', '')
+    expect(getJitsiDomain()).toBe('meet.jit.si')
+  })
+
+  it('V4 — buildJitsiUrl bare', () => {
+    vi.stubEnv('VITE_JITSI_DOMAIN', '')
+    expect(buildJitsiUrl('seance_42')).toBe('https://meet.jit.si/seance_42')
+  })
+
+  it('V5 — buildJitsiUrl avec displayName + prejoinDisabled (hash exact)', () => {
+    vi.stubEnv('VITE_JITSI_DOMAIN', '')
+    expect(buildJitsiUrl('room1', { displayName: 'Awa Koné', prejoinDisabled: true })).toBe(
+      'https://meet.jit.si/room1#config.prejoinConfig.enabled=false&userInfo.displayName=Awa%20Kon%C3%A9',
+    )
+  })
+
+  it('V6 — domaine custom + schéma https', () => {
+    vi.stubEnv('VITE_JITSI_DOMAIN', 'visio.kalga.ci')
+    expect(buildJitsiUrl('r')).toBe('https://visio.kalga.ci/r')
+  })
+
+  it('V7 — jitsiExternalApiSrc', () => {
+    vi.stubEnv('VITE_JITSI_DOMAIN', '')
+    expect(jitsiExternalApiSrc()).toBe('https://meet.jit.si/external_api.js')
+  })
+
+  it('V8 — constantes de temps', () => {
+    expect(HEARTBEAT_INTERVAL_MS).toBe(30000)
+    expect(PARTICIPATION_EXPIRATION_MS).toBe(604800000)
+    expect(VISIO_CONFIG.HEARTBEAT_INTERVAL_MS).toBe(30000)
+  })
+})

--- a/src/constants/http.js
+++ b/src/constants/http.js
@@ -1,0 +1,24 @@
+/**
+ * Configuration HTTP centralisée (#24) — base d'API depuis `VITE_API_URL`.
+ *
+ * Sécurité : pas de fallback localhost SILENCIEUX en production. Si `VITE_API_URL`
+ * est absent en prod, on échoue explicitement (un build prod doit fournir l'URL) ;
+ * le défaut localhost est confiné au mode développement.
+ */
+
+const DEV_API_URL = 'http://localhost:8000/api'
+
+/** Base de l'API (avec /api). Throw en prod si VITE_API_URL absent. */
+export function apiBaseUrl() {
+  const url = import.meta.env?.VITE_API_URL
+  if (url) return url
+  if (import.meta.env?.PROD) {
+    throw new Error('VITE_API_URL est requis en production (aucun fallback localhost).')
+  }
+  return DEV_API_URL
+}
+
+/** Origine de l'API (sans le suffixe /api), pour les URL construites à la main (ex. Beacon). */
+export function apiOrigin() {
+  return apiBaseUrl().replace(/\/api\/?$/, '')
+}

--- a/src/constants/storageKeys.js
+++ b/src/constants/storageKeys.js
@@ -1,0 +1,33 @@
+/**
+ * Clés de stockage centralisées (#24) — hors clés d'authentification.
+ *
+ * Les clés d'auth (token/user/meta/institution) sont encapsulées dans le store
+ * `src/stores/auth.js` (objet KEYS) — NE PAS les dupliquer ici. Ce module couvre
+ * les préférences UI, le thème, la sidebar et la participation visio.
+ *
+ * Helpers scopés par institution (multi-tenant) : `'default'` n'est appliqué que
+ * si l'appelant ne fournit pas de slug (la résolution du slug reste à sa charge).
+ */
+
+export const STORAGE_KEYS = Object.freeze({
+  ADMIN_PREFERENCES: 'adminPreferences',
+  TEACHER_PREFERENCES: 'teacherPreferences',
+  USER_PREFERENCES: 'userPreferences',
+})
+
+export const VISIO_PARTICIPATION_PREFIX = 'visio_participation_'
+
+/** Clé de préférence de thème, scopée par institution (multi-tenant). */
+export function themeKey(slug) {
+  return `lms-theme-preference-${slug || 'default'}`
+}
+
+/** Clé d'état replié de la sidebar, scopée par institution. */
+export function sidebarKey(slug) {
+  return `sidebar-collapsed-${slug || 'default'}`
+}
+
+/** Clé de participation visio d'un (utilisateur, séance). */
+export function visioParticipationKey(seanceId, userId) {
+  return `${VISIO_PARTICIPATION_PREFIX}${seanceId}_${userId}`
+}

--- a/src/constants/upload.js
+++ b/src/constants/upload.js
@@ -1,0 +1,16 @@
+/**
+ * Constantes d'upload de fichiers (#24) — source unique taille + libellé + types.
+ * Remplace les valeurs et libellés « 30 MB » dupliqués (ChapterManager).
+ */
+
+export const UPLOAD_CONFIG = Object.freeze({
+  MAX_FILE_SIZE_BYTES: 30 * 1024 * 1024,
+  MAX_FILE_SIZE_LABEL: '30 MB',
+})
+
+/** Extensions acceptées par type de contenu (recopie du mapping existant). */
+export const ACCEPTED_FILE_TYPES = Object.freeze({
+  powerpoint: '.pptx,.ppt',
+  word: '.docx,.doc',
+  pdf: '.pdf',
+})

--- a/src/constants/visio.js
+++ b/src/constants/visio.js
@@ -1,0 +1,43 @@
+/**
+ * Constantes & helpers visioconférence (#24) — domaine Jitsi configurable + temps.
+ *
+ * Le domaine Jitsi vient de `VITE_JITSI_DOMAIN` (défaut `meet.jit.si`), lu à
+ * l'exécution via optional chaining (chargeable hors Vite, pattern roles.js).
+ * Configurable par déploiement / institution, plus de hardcode dispersé.
+ */
+
+export const VISIO_CONFIG = Object.freeze({
+  HEARTBEAT_INTERVAL_MS: 30000, // ping d'activité participant
+  PARTICIPATION_EXPIRATION_MS: 7 * 24 * 60 * 60 * 1000, // 7 jours
+  DEFAULT_JITSI_DOMAIN: 'meet.jit.si',
+})
+
+export const HEARTBEAT_INTERVAL_MS = VISIO_CONFIG.HEARTBEAT_INTERVAL_MS
+export const PARTICIPATION_EXPIRATION_MS = VISIO_CONFIG.PARTICIPATION_EXPIRATION_MS
+
+/** Domaine Jitsi effectif (VITE_JITSI_DOMAIN ou défaut). */
+export function getJitsiDomain() {
+  const d = import.meta.env?.VITE_JITSI_DOMAIN
+  return d && String(d).trim() ? String(d).trim() : VISIO_CONFIG.DEFAULT_JITSI_DOMAIN
+}
+
+/** URL du script IFrame API Jitsi. */
+export function jitsiExternalApiSrc() {
+  return `https://${getJitsiDomain()}/external_api.js`
+}
+
+/**
+ * Construit une URL de salle Jitsi.
+ * @param {string} roomId
+ * @param {{ displayName?: string, prejoinDisabled?: boolean }} [options]
+ * @returns {string} `https://{domaine}/{roomId}` ou avec fragment hash de config.
+ */
+export function buildJitsiUrl(roomId, options = {}) {
+  const base = `https://${getJitsiDomain()}/${roomId}`
+  const { displayName, prejoinDisabled } = options
+  if (!prejoinDisabled && displayName == null) return base
+  const parts = []
+  if (prejoinDisabled) parts.push('config.prejoinConfig.enabled=false')
+  if (displayName != null) parts.push(`userInfo.displayName=${encodeURIComponent(displayName)}`)
+  return `${base}#${parts.join('&')}`
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,14 @@ import router from './router'
 import './style.css'
 import './assets/styles/themes.css'
 import './assets/styles/mobile-responsive.css'
+import { themeKey } from '@/constants/storageKeys'
 
-// Initialiser le thème AVANT de monter l'application
-const THEME_KEY = 'lms-theme-preference'
+// Initialiser le thème AVANT de monter l'application.
+// Avant le montage, Pinia n'est pas hydraté : on lit le slug d'institution
+// directement depuis sessionStorage (même source que le store auth) pour
+// résoudre la clé thème SCOPÉE, alignée sur useTheme.js (#24, corrige l'ancienne
+// clé non scopée). Pas d'import du store auth (évite tout cycle).
+const THEME_KEY = themeKey(sessionStorage.getItem('institution'))
 const DEFAULT_THEME = 'light'
 
 // Récupérer le thème sauvegardé

--- a/src/services/jitsi.js
+++ b/src/services/jitsi.js
@@ -1,5 +1,7 @@
 import api from './api'
 import { auth } from './api'
+import { getJitsiDomain, VISIO_CONFIG } from '../constants/visio'
+import { VISIO_PARTICIPATION_PREFIX, visioParticipationKey } from '../constants/storageKeys'
 
 /**
  * Service pour la gestion des visioconférences Jitsi Meet
@@ -11,8 +13,7 @@ import { auth } from './api'
  * - Synchronisation des présences vers KLASSCI
  */
 
-// Configuration Jitsi
-const JITSI_DOMAIN = 'meet.jit.si' // Utilise le serveur public Jitsi
+// Domaine Jitsi : centralisé dans src/constants/visio.js (configurable VITE_JITSI_DOMAIN, #24)
 // Alternative: Déployer votre propre serveur Jitsi et utiliser votre domaine
 
 export const jitsiService = {
@@ -44,7 +45,7 @@ export const jitsiService = {
       'interfaceConfig.DEFAULT_WELCOME_PAGE_LOGO_URL': ''
     })
 
-    const jitsiUrl = `https://${JITSI_DOMAIN}/${roomName}#${params.toString()}`
+    const jitsiUrl = `https://${getJitsiDomain()}/${roomName}#${params.toString()}`
 
     console.log('[JitsiService] Lien généré:', jitsiUrl)
     console.log('[JitsiService] Room ID:', roomId)
@@ -123,7 +124,7 @@ export const jitsiService = {
     const joinTime = new Date().toISOString()
 
     // Stocker localement pour tracking
-    const participationKey = `visio_participation_${seanceId}_${userId}`
+    const participationKey = visioParticipationKey(seanceId, userId)
     const participation = {
       seance_id: seanceId,
       user_id: userId,
@@ -165,7 +166,7 @@ export const jitsiService = {
     const leaveTime = new Date().toISOString()
 
     // Récupérer la participation du localStorage
-    const participationKey = `visio_participation_${seanceId}_${userId}`
+    const participationKey = visioParticipationKey(seanceId, userId)
     const storedData = localStorage.getItem(participationKey)
 
     if (!storedData) {
@@ -266,7 +267,7 @@ export const jitsiService = {
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i)
 
-      if (key && key.startsWith('visio_participation_')) {
+      if (key && key.startsWith(VISIO_PARTICIPATION_PREFIX)) {
         const data = localStorage.getItem(key)
         const participation = JSON.parse(data)
 
@@ -305,7 +306,7 @@ export const jitsiService = {
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i)
 
-      if (key && key.startsWith('visio_participation_')) {
+      if (key && key.startsWith(VISIO_PARTICIPATION_PREFIX)) {
         const data = localStorage.getItem(key)
         const participation = JSON.parse(data)
 
@@ -322,13 +323,13 @@ export const jitsiService = {
    * Nettoyer les participations expirées (> 7 jours)
    */
   cleanupExpiredParticipations() {
-    const expirationMs = 7 * 24 * 60 * 60 * 1000 // 7 jours
+    const expirationMs = VISIO_CONFIG.PARTICIPATION_EXPIRATION_MS
     const now = Date.now()
 
     for (let i = localStorage.length - 1; i >= 0; i--) {
       const key = localStorage.key(i)
 
-      if (key && key.startsWith('visio_participation_')) {
+      if (key && key.startsWith(VISIO_PARTICIPATION_PREFIX)) {
         const data = localStorage.getItem(key)
         const participation = JSON.parse(data)
 

--- a/src/stores/visio.js
+++ b/src/stores/visio.js
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { VISIO_CONFIG } from '@/constants/visio'
 
 /**
  * Store Pinia global pour gérer la participation aux visioconférences
@@ -63,7 +64,7 @@ export const useVisioStore = defineStore('visio', () => {
       })
 
       // Démarrer le Worker (30 secondes)
-      heartbeatWorker.value.postMessage({ command: 'start', interval: 30000 })
+      heartbeatWorker.value.postMessage({ command: 'start', interval: VISIO_CONFIG.HEARTBEAT_INTERVAL_MS })
 
       // Premier heartbeat immédiat
       sendHeartbeat()
@@ -89,7 +90,7 @@ export const useVisioStore = defineStore('visio', () => {
     sendHeartbeat()
     fallbackInterval = setInterval(() => {
       sendHeartbeat()
-    }, 30000)
+    }, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
   }
 
   /**

--- a/src/views/TeacherSeances.vue
+++ b/src/views/TeacherSeances.vue
@@ -345,6 +345,7 @@ import { useAuthStore } from '@/stores/auth'
 import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
 import { readCache, writeCache, clearCache } from '@/services/cache'
+import { buildJitsiUrl } from '@/constants/visio'
 
 const seances = ref([])
 const matieres = ref([])
@@ -591,7 +592,7 @@ async function handleJoinVisio(seance) {
 
     // Ouvrir window.open avec tracking
     const roomId = seance.visio.room_id
-    const jitsiLink = `https://meet.jit.si/${roomId}`
+    const jitsiLink = buildJitsiUrl(roomId)
 
     await visioParticipations[seance.id].joinVisio(jitsiLink)
 

--- a/src/views/VideoConference.vue
+++ b/src/views/VideoConference.vue
@@ -27,6 +27,7 @@
 <script>
 import { auth } from '@/services/api'
 import ContentLoader from '@/components/common/ContentLoader.vue'
+import { jitsiExternalApiSrc, getJitsiDomain } from '@/constants/visio'
 
 export default {
   name: 'VideoConference',
@@ -70,7 +71,7 @@ export default {
 
       // Charger le script Jitsi
       const script = document.createElement('script')
-      script.src = 'https://meet.jit.si/external_api.js'
+      script.src = jitsiExternalApiSrc()
       script.async = true
       script.onload = () => {
         console.log('fa-check-circle Script Jitsi chargé')
@@ -85,7 +86,7 @@ export default {
     },
 
     initJitsi() {
-      const domain = 'meet.jit.si'
+      const domain = getJitsiDomain()
       const options = {
         roomName: this.roomName,
         width: '100%',

--- a/src/views/admin/AdminSettings.vue
+++ b/src/views/admin/AdminSettings.vue
@@ -193,6 +193,7 @@ import ThemeToggle from '@/components/ui/ThemeToggle.vue'
 import Modal from '@/components/ui/Modal.vue'
 import { auth } from '@/services/api'
 import { toast } from '@/services/toast'
+import { STORAGE_KEYS } from '@/constants/storageKeys'
 import {
   UserIcon,
   AdjustmentsHorizontalIcon,
@@ -251,13 +252,13 @@ export default {
         emailNotifications: this.emailNotifications,
         systemAlerts: this.systemAlerts
       }
-      localStorage.setItem('adminPreferences', JSON.stringify(preferences))
+      localStorage.setItem(STORAGE_KEYS.ADMIN_PREFERENCES, JSON.stringify(preferences))
       console.log('[SETTINGS] Préférences sauvegardées:', preferences)
       toast.success('Vos préférences ont été sauvegardées')
     },
 
     loadPreferences() {
-      const saved = localStorage.getItem('adminPreferences')
+      const saved = localStorage.getItem(STORAGE_KEYS.ADMIN_PREFERENCES)
       if (saved) {
         const preferences = JSON.parse(saved)
         this.emailNotifications = preferences.emailNotifications ?? true

--- a/src/views/attendance/SeanceAttendanceHistory.vue
+++ b/src/views/attendance/SeanceAttendanceHistory.vue
@@ -326,6 +326,7 @@ import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { apiBaseUrl } from '@/constants/http'
 
 export default {
   name: 'SeanceAttendanceHistory',
@@ -534,7 +535,7 @@ export default {
       try {
         console.log('[SeanceHistory] Export PDF de la séance', this.selectedSeance.klassci_seance_id)
 
-        const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+        const API_URL = apiBaseUrl()
         const token = useAuthStore().token
 
         // Créer l'URL de téléchargement
@@ -583,7 +584,7 @@ export default {
       try {
         console.log('[SeanceHistory] Export Excel de la séance', this.selectedSeance.klassci_seance_id)
 
-        const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+        const API_URL = apiBaseUrl()
         const token = useAuthStore().token
 
         // Créer l'URL de téléchargement

--- a/src/views/coordinateur/SeanceManagement.vue
+++ b/src/views/coordinateur/SeanceManagement.vue
@@ -285,6 +285,7 @@ import { normalizeError } from '@/services/errorHandler'
 
 import lmsService from '@/services/lms'
 import { readCache, writeCache, clearCache } from '@/services/cache'
+import { buildJitsiUrl } from '@/constants/visio'
 
 const router = useRouter()
 
@@ -490,7 +491,7 @@ const handleJoinVisio = async (seance) => {
 
     // Ouvrir window.open avec tracking
     const roomId = seance.visio_room_id
-    const jitsiLink = `https://meet.jit.si/${roomId}`
+    const jitsiLink = buildJitsiUrl(roomId)
 
     await visioParticipations[seance.id].joinVisio(jitsiLink)
 
@@ -529,8 +530,10 @@ async function handleCalendarAction({ type, data }) {
       // Coordinateur rejoint la visio
       {
         const roomId = data.visio?.room_id || data.visio_room_id || `seance_${data.id}`
-        const userName = encodeURIComponent(currentUser?.name || 'Coordinateur')
-        const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
+        const jitsiLink = buildJitsiUrl(roomId, {
+          displayName: currentUser?.name || 'Coordinateur',
+          prejoinDisabled: true,
+        })
         window.open(jitsiLink, '_blank')
       }
       break

--- a/src/views/lessons/StudentLessonView.vue
+++ b/src/views/lessons/StudentLessonView.vue
@@ -318,6 +318,7 @@ import lessonService from '@/services/lesson'
 import knowledgeCheckService from '@/services/knowledgeCheck'
 import chapterProgressService from '@/services/chapterProgress'
 import api from '@/services/api'
+import { apiOrigin } from '@/constants/http'
 
 const route = useRoute()
 const router = useRouter()
@@ -383,7 +384,7 @@ const getImageUrl = (imagePath) => {
     return imagePath
   }
   // Sinon, construire l'URL avec le backend
-  const backendUrl = import.meta.env.VITE_API_URL.replace('/api', '')
+  const backendUrl = apiOrigin()
   return `${backendUrl}/storage/${imagePath}`
 }
 
@@ -393,7 +394,7 @@ const getVideoUrl = (chapter) => {
 
   // Si c'est un chemin relatif (vidéo uploadée), construire l'URL complète
   if (url.startsWith('/storage/') || (url && !url.startsWith('http'))) {
-    const backendUrl = import.meta.env.VITE_API_URL.replace('/api', '')
+    const backendUrl = apiOrigin()
     return `${backendUrl}${url}`
   }
 

--- a/src/views/student/StudentLessonView.vue
+++ b/src/views/student/StudentLessonView.vue
@@ -282,6 +282,7 @@ import lessonService from '@/services/lesson'
 import chapterProgressService from '@/services/chapterProgress'
 import api from '@/services/api'
 import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
+import { apiOrigin } from '@/constants/http'
 
 export default {
   name: 'StudentLessonView',
@@ -492,7 +493,7 @@ export default {
       if (!slide) return ''
       if (slide.startsWith('http')) return slide
       // Relative path — prepend API base URL
-      const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+      const baseUrl = apiOrigin()
       return `${baseUrl}/storage/${slide}`
     },
 
@@ -500,7 +501,7 @@ export default {
       const path = chapter.pdf_url || chapter.file_converted_path
       if (!path) return ''
       if (path.startsWith('http')) return path
-      const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+      const baseUrl = apiOrigin()
       return `${baseUrl}/storage/${path}`
     },
 

--- a/src/views/student/StudentSchedule.vue
+++ b/src/views/student/StudentSchedule.vue
@@ -29,6 +29,7 @@ import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
 import { lmsService } from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { buildJitsiUrl } from '@/constants/visio'
 
 const router = useRouter()
 
@@ -47,8 +48,10 @@ async function handleEventAction({ type, data }) {
         console.log('[StudentSchedule] Rejoint visio:', data.id)
         // Ouvrir Jitsi
         const roomId = data.visio?.room_id || data.visio_room_id || `seance_${data.id}`
-        const userName = encodeURIComponent(currentUser.value?.name || 'Etudiant')
-        const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
+        const jitsiLink = buildJitsiUrl(roomId, {
+          displayName: currentUser.value?.name || 'Etudiant',
+          prejoinDisabled: true,
+        })
         window.open(jitsiLink, '_blank')
       } catch (error) {
         console.error('[StudentSchedule] Erreur rejoindre visio:', error)

--- a/src/views/student/StudentSettings.vue
+++ b/src/views/student/StudentSettings.vue
@@ -177,6 +177,7 @@ import ThemeToggle from '@/components/ui/ThemeToggle.vue'
 import Modal from '@/components/ui/Modal.vue'
 import { auth } from '@/services/api'
 import { toast } from '@/services/toast'
+import { STORAGE_KEYS } from '@/constants/storageKeys'
 import {
   UserIcon,
   AdjustmentsHorizontalIcon,
@@ -230,13 +231,13 @@ export default {
         emailNotifications: this.emailNotifications,
         visioReminders: this.visioReminders
       }
-      localStorage.setItem('userPreferences', JSON.stringify(preferences))
+      localStorage.setItem(STORAGE_KEYS.USER_PREFERENCES, JSON.stringify(preferences))
       console.log('[SETTINGS] Préférences sauvegardées:', preferences)
       toast.success('Vos préférences ont été sauvegardées')
     },
 
     loadPreferences() {
-      const saved = localStorage.getItem('userPreferences')
+      const saved = localStorage.getItem(STORAGE_KEYS.USER_PREFERENCES)
       if (saved) {
         const preferences = JSON.parse(saved)
         this.emailNotifications = preferences.emailNotifications ?? true

--- a/src/views/teacher/TeacherSchedule.vue
+++ b/src/views/teacher/TeacherSchedule.vue
@@ -30,6 +30,7 @@ import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
 import { lmsService } from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
+import { buildJitsiUrl } from '@/constants/visio'
 
 const router = useRouter()
 const calendarRef = ref(null)
@@ -45,8 +46,10 @@ async function handleEventAction({ type, data }) {
       // Enseignant rejoint la visio active - ouvrir Jitsi directement
       {
         const roomId = data.visio?.room_id || data.visio_room_id || `seance_${data.id}`
-        const userName = encodeURIComponent(currentUser.value?.name || 'Enseignant')
-        const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
+        const jitsiLink = buildJitsiUrl(roomId, {
+          displayName: currentUser.value?.name || 'Enseignant',
+          prejoinDisabled: true,
+        })
         window.open(jitsiLink, '_blank')
       }
       break
@@ -59,8 +62,10 @@ async function handleEventAction({ type, data }) {
           console.log('[TeacherSchedule] Visio demarree:', data.id)
           // Ouvrir Jitsi
           const roomId = result.data?.visio_room_id || data.visio?.room_id || `seance_${data.id}`
-          const userName = encodeURIComponent(currentUser.value?.name || 'Enseignant')
-          const jitsiLink = `https://meet.jit.si/${roomId}#config.prejoinConfig.enabled=false&userInfo.displayName=${userName}`
+          const jitsiLink = buildJitsiUrl(roomId, {
+            displayName: currentUser.value?.name || 'Enseignant',
+            prejoinDisabled: true,
+          })
           window.open(jitsiLink, '_blank')
           // Rafraichir le calendrier
           if (calendarRef.value?.refreshEvents) {

--- a/src/views/teacher/TeacherSettings.vue
+++ b/src/views/teacher/TeacherSettings.vue
@@ -177,6 +177,7 @@ import ThemeToggle from '@/components/ui/ThemeToggle.vue'
 import Modal from '@/components/ui/Modal.vue'
 import { auth } from '@/services/api'
 import { toast } from '@/services/toast'
+import { STORAGE_KEYS } from '@/constants/storageKeys'
 import {
   UserIcon,
   AdjustmentsHorizontalIcon,
@@ -230,13 +231,13 @@ export default {
         emailNotifications: this.emailNotifications,
         seanceReminders: this.seanceReminders
       }
-      localStorage.setItem('teacherPreferences', JSON.stringify(preferences))
+      localStorage.setItem(STORAGE_KEYS.TEACHER_PREFERENCES, JSON.stringify(preferences))
       console.log('[SETTINGS] Préférences sauvegardées:', preferences)
       toast.success('Vos préférences ont été sauvegardées')
     },
 
     loadPreferences() {
-      const saved = localStorage.getItem('teacherPreferences')
+      const saved = localStorage.getItem(STORAGE_KEYS.TEACHER_PREFERENCES)
       if (saved) {
         const preferences = JSON.parse(saved)
         this.emailNotifications = preferences.emailNotifications ?? true

--- a/src/views/teacher/TeacherVisioList.vue
+++ b/src/views/teacher/TeacherVisioList.vue
@@ -116,7 +116,7 @@
               <div class="card-actions">
                 <a
                   v-if="seance.visio?.room_id"
-                  :href="`https://meet.jit.si/${seance.visio.room_id}`"
+                  :href="buildJitsiUrl(seance.visio.room_id)"
                   target="_blank"
                   class="btn-action btn-join"
                 >
@@ -236,6 +236,7 @@ import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import { lmsService } from '@/services/lms'
 import { readCache, writeCache, clearCache } from '@/services/cache'
+import { buildJitsiUrl } from '@/constants/visio'
 import {
   VideoCameraIcon,
   CalendarIcon,


### PR DESCRIPTION
## Contexte

TIER 1 de l'audit (épique #16). Élimination du hardcoding de configuration et des valeurs magiques (`PRODUCTION_STANDARDS §1.2/§1.6`, Vite env) : domaine Jitsi `meet.jit.si` (15 sites), fallbacks `localhost:8000`, heartbeat `30000`, taille upload `30 MB`, clés de storage en chaînes magiques.

## 4 modules gelés (`Object.freeze`, cohérents `roles.js`/`errorMessages.js`)

- **`src/constants/visio.js`** : `getJitsiDomain()` (`VITE_JITSI_DOMAIN`, défaut `meet.jit.si`), `buildJitsiUrl(roomId, {displayName, prejoinDisabled})`, `jitsiExternalApiSrc()`, `HEARTBEAT_INTERVAL_MS`, `PARTICIPATION_EXPIRATION_MS`.
- **`src/constants/http.js`** : `apiBaseUrl()` (**throw en prod** si `VITE_API_URL` absent — plus de fallback localhost silencieux), `apiOrigin()`.
- **`src/constants/storageKeys.js`** : `STORAGE_KEYS` + helpers scopés `themeKey`/`sidebarKey`/`visioParticipationKey` (hors clés du store auth #19).
- **`src/constants/upload.js`** : `MAX_FILE_SIZE_BYTES`/`LABEL` + `ACCEPTED_FILE_TYPES`.

## Migration complète (~30 sites)

Jitsi (10 fichiers — **nom brut** passé à `buildJitsiUrl`, anti double-encodage, variables pré-encodées supprimées), API (`apiBaseUrl`/`apiOrigin`), heartbeat, upload, clés de storage. **Bug corrigé** : clé de thème non-scopée de `main.js` alignée sur la clé scopée par tenant (#24-NOTE-2).

## Vérifications

| Commande | Résultat |
|---|---|
| `npm run test` | **136 tests verts** (21 constants : gel, `getJitsiDomain` défaut/env, `buildJitsiUrl` 3 formes, `apiBaseUrl` prod-throw/dev-fallback, clés scopées, upload) |
| `npm run test:contract` | **28/28** |
| `npm run build` | réussi |
| grep | 0 `meet.jit.si` exécutable hors constants, 0 `localhost:8000` hors constants, 0 `30000` heartbeat |

## Corrections de comportement assumées (honnêteté)

- **Beacon `useVisioParticipation`** : double `/api/api/` (typo) → `/api/` unique. ⚠️ Le chemin `/api/seances/.../leave-visio` reste **erroné** (vrai endpoint backend `/api/lms/seances/.../leave`) — **bug de contrat pré-existant séparé** à filer (famille #17), non corrigé ici.
- `lessons/StudentLessonView` : `VITE_API_URL.replace('/api','')` → `apiOrigin()` = **byte-identique**.

## Hors périmètre / non inclus

- `AdminInstitutions.vue`, `.env.production`, `.backup`, `node_modules` : WIP/bruit non liés, **exclus** du commit.
- Dette #24-FE-1 : reliquat éventuel.

## Spec

`.claude/specs/constants/` (requirements, design, tasks).

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
