### PR TITLE
refactor(ui): enrichir Modal + BaseButton réutilisable (#25)

### DIFF
--- a/.claude/specs/ui-components/design.md
+++ b/.claude/specs/ui-components/design.md
@@ -1,0 +1,599 @@
+# Design Document — Réutilisabilité des composants UI (ui-components)
+
+> Issue GitHub #25, TIER 1 de la roadmap d'audit (épique #16).
+> Spec-driven (CONTRIBUTING §A). Requirements approuvé : `.claude/specs/ui-components/requirements.md`.
+> Toutes les décisions ci-dessous appliquent la règle « UNE seule solution, jamais A ou B » (PRODUCTION_STANDARDS §6, citée dans la mémoire projet `lms-backend-rules-location.md`).
+
+## Overview
+
+### Objectif
+
+Remplacer la duplication massive de markup de modales et de boutons par les **mécanismes officiels de réutilisation de Vue 3** : composition par slots, fallthrough attributes (`$attrs` + `inheritAttrs:false`), et base components purement présentationnels. La cible est `src/components/ui/Modal.vue` (déjà existant, sous-utilisé) enrichi sans régression, complété par un nouveau `BaseButton.vue` qui pose le pattern wrapper transparent.
+
+### Scope de cette feature (livrable)
+
+1. **Enrichir `ui/Modal.vue`** : `title` optionnelle, slot `header`, prop `size` validée, fermeture Échap, `inheritAttrs:false` + `v-bind="$attrs"`, source de fermeture unique — sans casser les 6 consommateurs actuels ni l'API `v-model:modelValue` / slot défaut / slot `footer` / close overlay+✕ / scroll-lock.
+2. **Créer `BaseButton.vue`** (`<script setup>`, `inheritAttrs:false`) : `variant`, `loading`, `disabled`, `type`, slot défaut (label) + slot `icon`.
+3. **Migrer 3 modales** inline/quasi-inline simples vers le pattern enrichi et **adopter `BaseButton`** dans 2 d'entre elles (preuve d'usage).
+4. **Documenter** les patterns (emplacement tranché : Décision E).
+5. **Tests Vitest** d'abord (TDD, PRODUCTION_STANDARDS §1.3) pour `Modal` et `BaseButton`.
+
+### Hors scope (et dette tracée)
+
+- Migration des modales complexes (`ParticipantsModal`, `JitsiModal`, `GlobalSearchModal`, `EventDetailModal`) → **dette `#25-FE-1`** (voir section « Dette tracée »).
+- Remplacement de tous les boutons du projet par `BaseButton` (#28, refonte god components).
+- Aucune modification backend ni de contrat d'API (R6.5).
+
+### État vérifié du code (lecture réelle, 2026-06-16)
+
+| Fichier | Constat (cité) |
+|---|---|
+| `src/components/ui/Modal.vue:28-31` | `title` `{ type: String, required: true }` → à rendre optionnelle (R1.3). |
+| `src/components/ui/Modal.vue:2-17` | Options API, `<transition>` racine, pas de `header`, pas de `size`, pas d'Échap, pas de `$attrs`. |
+| `src/components/ui/Modal.vue:44-46` | `close()` unique existe déjà → réutilisé comme source de fermeture unique (R1.11). |
+| `src/components/ui/Modal.vue:48-59` | scroll-lock via `watch(visible)` + `beforeUnmount` → à préserver (R1.1). |
+| `modals/QuickAddTeacherModal.vue:2` | `<Modal ... size="medium">` (prop non déclarée, ignorée → bug latent R1.8). Boutons locaux `.btn-cancel`/`.btn-primary` (lignes 277-311). |
+| `modals/GenerateReportModal.vue:2` | idem `size="medium"` + boutons locaux dupliqués (lignes 293-327). |
+| `modals/QuickCreateClasseModal.vue:2` | idem `size="medium"` + boutons locaux dupliqués (lignes 291-325). |
+| `visio/ParticipantsModal.vue` | header dégradé custom, tableau, auto-refresh 15 s, export PDF/Excel → **complexe, dette**. |
+| `calendar/EventDetailModal.vue` | overlay `.modal-overlay`/`.modal-container`, header avec badge, footer d'actions par rôle → **dette** (risque régression). |
+| `modals/GlobalSearchModal.vue:2-5` | `Teleport` + navigation clavier custom (↑/↓/Enter/Esc) → **complexe, dette**. |
+| `tests/unit/roles.test.js` | convention de test : docstring FR d'en-tête, import via `@`, `vitest`, `it.each`. Aucun `mount` encore. |
+| `vitest.config.js:19` | `include: ['tests/**/*.test.{js,mjs}', 'src/**/*.test.{js,mjs}']`, `environment: jsdom`, `globals: true`. |
+
+---
+
+## Architecture Design
+
+### System Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph Consommateurs
+        QAT[QuickAddTeacherModal]
+        GRM[GenerateReportModal]
+        QCC[QuickCreateClasseModal]
+        SET[3 vues Settings student/teacher/admin]
+    end
+
+    subgraph CoucheUI[Couche ui presentationnelle]
+        MODAL[ui/Modal.vue enrichi]
+        BTN[ui/BaseButton.vue nouveau]
+    end
+
+    subgraph Dette[Dette tracee 25-FE-1]
+        PART[visio/ParticipantsModal]
+        EVT[calendar/EventDetailModal]
+        SEARCH[modals/GlobalSearchModal]
+        JITSI[visio/JitsiModal]
+    end
+
+    QAT --> MODAL
+    GRM --> MODAL
+    QCC --> MODAL
+    SET --> MODAL
+    QAT --> BTN
+    GRM --> BTN
+
+    MODAL -.->|inheritAttrs false plus v-bind attrs| NATIVE1[div modal-container natif]
+    BTN -.->|inheritAttrs false plus v-bind attrs| NATIVE2[button natif]
+
+    PART -.reste inline.-> X[markup overlay local]
+    EVT -.reste inline.-> X
+    SEARCH -.reste inline.-> X
+    JITSI -.reste inline.-> X
+```
+
+### Data Flow Diagram — ouverture/fermeture d'une Modal
+
+```mermaid
+graph LR
+    A[Parent v-model modelValue] --> B[Modal prop modelValue]
+    B --> C{visible getter}
+    C -->|true| D[render overlay plus container]
+    D --> E{source de fermeture}
+    E -->|clic overlay self| F[close]
+    E -->|clic croix| F
+    E -->|touche Echap| F
+    F --> G[visible setter emit update modelValue false]
+    G --> A
+    C -->|watch true| H[body overflow hidden]
+    C -->|watch false| I[body overflow restaure]
+```
+
+### Data Flow Diagram — fallthrough `$attrs` de BaseButton
+
+```mermaid
+graph LR
+    P[Parent BaseButton click submit class aria] --> Q[BaseButton inheritAttrs false]
+    Q --> R[props declarees variant loading disabled type]
+    Q --> S[attrs non declares click type class aria]
+    R --> T[classes calculees plus etat disabled]
+    S --> U[v-bind attrs sur button interne]
+    T --> V[button natif]
+    U --> V
+    V --> W{disabled ou loading}
+    W -->|non| X[click parent declenche]
+    W -->|oui| Y[clic bloque par disabled natif]
+```
+
+---
+
+## Décisions tranchées (une seule option par point, justifiée — §6)
+
+### D1 — `title` optionnelle + slot `header` (Tranche A, R1.3 / R1.4 / R1.5)
+
+**Décision.** `title` devient `{ type: String, default: '' }` (suppression de `required: true`). Le rendu de l'en-tête suit cette priorité unique :
+
+1. Si le slot `header` est fourni → on rend `<slot name="header" />` **à la place** du header par défaut, suivi d'un bouton ✕ accessible **toujours présent** (positionné en absolu dans la zone header) pour garantir une commande de fermeture (R1.5).
+2. Sinon, si `title` est non vide → header par défaut `title` + ✕ (comportement actuel préservé).
+3. Sinon (ni slot ni title) → header réduit ne contenant que le ✕ accessible (`aria-label="Fermer"`), pas de plantage (R1.5).
+
+**Justification.** Le slot `header` doit pouvoir porter un header custom (cas dégradé des modales inline) tout en conservant une fermeture accessible, ce que R1.4 et R1.5 imposent conjointement. Garder le ✕ hors du slot évite d'obliger chaque header custom à réimplémenter la fermeture (DRY) et garantit l'accessibilité invariante.
+
+### D2 — `size` : ensemble `sm|md|lg|xl` + alias `medium`→`md` normalisé (Tranche A, R1.6 / R1.7 / R1.8)
+
+**Décision.** `size: { type: String, default: 'md', validator }`. Le `validator` accepte l'ensemble canonique `['sm','md','lg','xl']` **et** l'alias historique `'medium'` (pour ne pas faire échouer la validation des 3 consommateurs actuels). Une `computed normalizedSize` mappe `'medium' -> 'md'` puis applique une **classe par taille** (`modal-sm` … `modal-xl`) portant le `max-width`. Toute valeur hors ensemble déclenche l'avertissement Vue (dev) et `normalizedSize` retombe sur `'md'`.
+
+Largeurs (alignées sur l'existant `max-width: 500px`, qui devient `md`) :
+
+| size | max-width | classe |
+|---|---|---|
+| `sm` | 400px | `.modal-sm` |
+| `md` (défaut) | 500px | `.modal-md` |
+| `lg` | 720px | `.modal-lg` |
+| `xl` | 960px | `.modal-xl` |
+
+**Justification.** R1.8 exige de résoudre l'incohérence `medium` **sans casser** QuickAddTeacher/GenerateReport. Deux issues étaient possibles : (a) normaliser `medium`→`md` dans le composant, ou (b) éditer les 3 consommateurs pour passer `md`. On choisit **(a) la normalisation dans le composant** comme comportement canonique robuste (un consommateur tiers futur qui écrirait `medium` ne casse pas), **et** on corrige aussi les 3 consommateurs vers `md` lors de leur migration (D5) pour supprimer la dette de nommage à la source. L'alias reste supporté et **documenté** : c'est un mapping explicite, pas un attribut ignoré (R1.8 satisfait). `medium` n'est pas dans l'ensemble canonique annoncé (on ne l'encourage pas), seulement toléré.
+
+### D3 — `Modal.vue` reste en Options API + `inheritAttrs:false` (Tranche A, R1.9)
+
+**Décision.** Conserver l'Options API existante et ajouter `inheritAttrs: false`, puis `v-bind="$attrs"` sur le **conteneur de contenu** (`.modal-container`), pas sur le `<transition>` racine. La fermeture Échap utilise `mounted`/`beforeUnmount` + un `watch(visible)` pour attacher/détacher le listener `keydown`.
+
+**Justification.** Réécrire en `<script setup>` est un risque de régression gratuit sur un composant à 6 consommateurs, sans bénéfice fonctionnel pour les critères demandés ; PRODUCTION_STANDARDS impose « meilleure solution, jamais la plus rapide » mais aussi non-régression (R6.4) — ici la valeur est la transparence d'attributs, atteignable en Options API par `inheritAttrs:false`. Migration de paradigme = hors scope, non justifiée par un requirement.
+
+### D4 — `BaseButton.vue` en `<script setup>`, sous `src/components/ui/` (Tranche B, R2)
+
+**Décision.** Nouveau composant `src/components/ui/BaseButton.vue` en `<script setup>` (composant neuf, aucun consommateur à protéger → paradigme moderne adopté d'emblée), `inheritAttrs: false` (via `defineOptions`) + `v-bind="$attrs"` sur le `<button>` interne. Emplacement `ui/` (et non un dossier `base/` séparé) pour cohabiter avec `Modal.vue` et limiter la dispersion ; le préfixe `Base` marque la nature présentationnelle (Style Guide Vue).
+
+**Justification.** Un composant neuf doit poser le **meilleur** pattern (composition + `$attrs`), pas dupliquer le legacy Options. `defineOptions({ inheritAttrs: false })` est la voie idiomatique en `<script setup>` (doc Vue, fallthrough attributes).
+
+### D5 — Périmètre de migration : 3 modales `modals/*` (Tranche D, R3)
+
+**Décision.** Migrer **exactement** ces 3 fichiers, déjà construits autour de `<Modal>` (donc « quasi-inline » : ils consomment Modal mais dupliquent boutons + passent `size="medium"`) :
+
+| Fichier | Action de migration |
+|---|---|
+| `modals/QuickAddTeacherModal.vue` | `size="medium"` → `size="md"` ; remplacer `.btn-cancel`/`.btn-primary` locaux par `<BaseButton>` ; supprimer les styles de boutons morts (R3.6). |
+| `modals/GenerateReportModal.vue` | idem (adoption `BaseButton` démonstrative R2.9). |
+| `modals/QuickCreateClasseModal.vue` | `size="medium"` → `size="md"` ; conserve ses boutons OU adopte `BaseButton` (au minimum corrige `size`). |
+
+**Adoption `BaseButton` (R2.9, 1 à 2 emplacements)** : `QuickAddTeacherModal` **et** `GenerateReportModal` (2 emplacements démonstratifs). `QuickCreateClasseModal` corrige au moins `size` (les 3 partagent le bug latent R1.8).
+
+**Justification.** Ces 3 fichiers présentent **le bug latent `size="medium"` (R1.8)** et la **duplication exacte** des styles `.btn-cancel`/`.btn-primary` (vérifié : blocs identiques dans les 3). Les migrer corrige le bug à la source et démontre les deux patterns (slots Modal + `$attrs` BaseButton) sur du markup réel, à faible risque (formulaires simples, footer standard). Les vraies modales `modal-overlay` inline restantes sont soit complexes (dette, voir ci-dessous), soit hors du « représentatif simple » exigé par R3.1.
+
+### D6 — Modales laissées en dette `#25-FE-1` (Tranche D, R3.3)
+
+**Décision.** Restent inline, tracées :
+
+| Fichier | Raison (risque de régression) |
+|---|---|
+| `visio/ParticipantsModal.vue` | Header dégradé violet custom, tableau de présence, **auto-refresh 15 s** (`setInterval`), export PDF/Excel, prop `seanceId` + `$emit('close')` (pas `v-model`). Migration ≠ triviale. |
+| `calendar/EventDetailModal.vue` | Footer d'actions conditionnelles par rôle, badge de statut dans le header, `$emit('close'/'action')` (pas `v-model`). Risque sur le contrat d'événements. |
+| `modals/GlobalSearchModal.vue` | `Teleport to body` + navigation clavier custom (↑/↓/Enter/Esc) qui entrerait en conflit avec l'Échap de `Modal`. |
+| `visio/JitsiModal.vue` | Intégration tierce (Jitsi), cycle de vie spécifique. |
+
+**Justification.** R3.3 autorise explicitement la dette tracée pour les modales à risque. Forcer leur migration violerait R6.4 (non-régression). La dette est **incrémentale** et documentée (D7), pas masquée (PRODUCTION_STANDARDS §1.6).
+
+### D7 — Documentation des patterns : section de CE design + `src/components/ui/README.md` court (Tranche E, R4)
+
+**Décision.** La documentation de référence vit dans **`src/components/ui/README.md`** (court, au plus près du code, lu par tout contributeur ouvrant `ui/`), et la présente conception en conserve la synthèse (section « Documentation des patterns »). Le README couvre : composition par slots, wrapper transparent `inheritAttrs:false` + `v-bind="$attrs"`, convention `Base*` (préfixe, présentationnel, sans store), API publique de `Modal` et `BaseButton`, référence à la dette `#25-FE-1`, et la règle anti-copier-coller sourcée Vue.
+
+**Justification.** Un `design.md` n'est pas lu lors de l'écriture quotidienne de composants ; un `README.md` dans `ui/` est découvert naturellement et survit à la clôture de la spec. Le design garde la version normative (traçabilité), le README la version opérationnelle.
+
+### D8 — Base components additionnels : `BaseButton` seul maintenant (Tranche C, R2.1)
+
+**Décision.** Créer **uniquement `BaseButton.vue`** dans cette feature. `BaseCard`/`BaseInput` ne sont **pas** créés ici → dette d'opportunité tracée `#25-FE-2` (non bloquante, à créer quand un 2e besoin réel apparaît).
+
+**Justification.** R2 n'exige qu'« au moins un » base component pour **poser le pattern**. Créer `BaseCard`/`BaseInput` sans consommateur réel serait de l'abstraction prématurée (anti-pattern, à l'inverse du besoin DRY constaté sur les boutons). On crée l'abstraction là où la duplication est **prouvée** (boutons `.btn-*` recopiés dans ≥3 fichiers).
+
+### D9 — Emplacement des tests : `tests/unit/` (Tranche test, R5.1)
+
+**Décision.** Les tests vont dans **`tests/unit/Modal.test.js`** et **`tests/unit/BaseButton.test.js`**, conformément à R5.1 (« sous `tests/unit/` ») et à la convention existante `tests/unit/roles.test.js`. (Le prompt évoquait `src/components/ui/__tests__/` ; `vitest.config.js:19` collecte les deux emplacements, mais R5.1 est normatif → on suit `tests/unit/`.)
+
+**Justification.** Cohérence avec le seul test existant et avec le requirement normatif. `vitest.config.js` collecte `tests/**/*.test.{js,mjs}` (ligne 19) → exécutable par `npm run test` sans config supplémentaire (R5.1).
+
+---
+
+## Composants et Interfaces (API exacte)
+
+### `ui/Modal.vue` (enrichi — Options API)
+
+**Props**
+
+```ts
+interface ModalProps {
+  modelValue: boolean            // default false — v-model (inchangé)
+  title?: string                 // default '' — OPTIONNELLE désormais (R1.3)
+  size?: 'sm' | 'md' | 'lg' | 'xl'   // default 'md' ; alias toléré 'medium' -> 'md' (R1.6/1.8)
+}
+```
+
+`size` validator (rejette + warn dev, retombe sur défaut via `normalizedSize`) :
+
+```js
+size: {
+  type: String,
+  default: 'md',
+  validator: (v) => ['sm', 'md', 'lg', 'xl', 'medium'].includes(v),
+}
+```
+
+**Computed**
+
+- `visible` (get/set) — inchangé (`get` = `modelValue`, `set` = `emit('update:modelValue', value)`).
+- `normalizedSize` — `this.size === 'medium' ? 'md' : (['sm','md','lg','xl'].includes(this.size) ? this.size : 'md')`. Pilote la classe `modal-{normalizedSize}` sur `.modal-container`.
+
+**Émissions**
+
+- `update:modelValue: (value: boolean)` — unique canal de fermeture (R1.11).
+
+**Slots**
+
+| Slot | Rendu |
+|---|---|
+| `header` (nommé) | Remplace le header par défaut quand fourni ; ✕ accessible toujours rendu (R1.4/R1.5). |
+| défaut | body (inchangé). |
+| `footer` (nommé) | rendu **uniquement** si `$slots.footer` (R1.2, inchangé). |
+
+**Attributs**
+
+- `inheritAttrs: false` ; `v-bind="$attrs"` sur `.modal-container` (R1.9). `class`/`id`/`aria-*`/`data-*` non déclarés atteignent le conteneur visible.
+
+**Cycle de vie / fermeture (R1.10, R1.11)**
+
+- `close()` : unique point de sortie → `this.visible = false`. Appelé par overlay (`@click.self`), ✕, et Échap.
+- `onKeydown(e)` : si `e.key === 'Escape'` et `visible` → `close()`.
+- `watch(visible)` : `true` → `document.body.style.overflow='hidden'` + `document.addEventListener('keydown', onKeydown)` ; `false` → restaure overflow + `removeEventListener`.
+- `beforeUnmount()` : restaure overflow + `removeEventListener` (pas de fuite, R1.10).
+
+**Taille de fichier (R1.12 / §1.1).** Cible < 300 lignes. Estimation ~210 lignes (template + script + style). Pas d'extraction nécessaire ; si dépassement, extraction d'un composable `useScrollLock`/`useEscapeClose` (tracée). Marge actuelle suffisante → pas d'extraction prématurée (D8 même logique).
+
+**Squelette template (priorité header — D1)**
+
+```html
+<transition name="modal-fade">
+  <div v-if="visible" class="modal-overlay" @click.self="close">
+    <div class="modal-container" :class="`modal-${normalizedSize}`" v-bind="$attrs">
+      <div class="modal-header">
+        <slot name="header">
+          <h3 v-if="title" class="modal-title">{{ title }}</h3>
+        </slot>
+        <button class="modal-close-btn" aria-label="Fermer" @click="close">✕</button>
+      </div>
+      <div class="modal-body"><slot></slot></div>
+      <div class="modal-footer" v-if="$slots.footer"><slot name="footer"></slot></div>
+    </div>
+  </div>
+</transition>
+```
+
+> Note D1 : le ✕ est **hors** du slot `header`, donc présent dans les 3 cas (slot custom, title, ni l'un ni l'autre) → fermeture accessible garantie (R1.5).
+
+### `ui/BaseButton.vue` (nouveau — `<script setup>`)
+
+**Props**
+
+```ts
+interface BaseButtonProps {
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost'  // default 'primary' (R2.2)
+  loading?: boolean    // default false (R2.3/2.4)
+  disabled?: boolean   // default false (R2.3)
+  type?: 'button' | 'submit'  // default 'button' (note ci-dessous)
+}
+```
+
+`variant` validator : `(v) => ['primary','secondary','danger','ghost'].includes(v)`.
+
+> `type` est **déclaré en prop** avec `default:'button'` pour un comportement sûr par défaut, **et** `type="submit"` passé par le parent doit traverser (R2.7). Comme une prop déclarée ne tombe pas dans `$attrs`, on lie `type` explicitement : `:type="type"`. Le test R5.7 (`type="submit"` → `<button type="submit">`) passe via cette liaison. Tout **autre** attribut natif non déclaré (`@click`, `aria-*`, `class`, `id`, `form`, `name`, `value`) traverse via `v-bind="$attrs"`.
+
+**État désactivé (R2.3/R2.4 — non contournable client)**
+
+- `isDisabled = computed(() => props.disabled || props.loading)`.
+- `<button :disabled="isDisabled">` → quand `loading` OU `disabled`, le bouton natif est désactivé ; un `@click` parent ne se déclenche pas (R2.4/R2.6 négatif).
+
+**Attributs**
+
+- `defineOptions({ inheritAttrs: false })` ; `v-bind="$attrs"` sur le `<button>` interne (R2.5). Le `@click` non déclaré traverse (R2.6) ; `type="submit"` via liaison explicite (R2.7).
+
+**Slots**
+
+| Slot | Rendu |
+|---|---|
+| défaut | label du bouton (R2.8, pas de prop texte). |
+| `icon` (nommé, optionnel) | icône avant le label. |
+
+**Émissions** : aucune émission propre. Les listeners (`@click`, etc.) traversent via `$attrs` directement sur le `<button>` natif (pas de ré-émission manuelle — évite le double-clic et reste idiomatique).
+
+**Squelette**
+
+```html
+<template>
+  <button :type="type" :disabled="isDisabled" :class="['base-btn', `base-btn--${variant}`, { 'is-loading': loading }]" v-bind="$attrs">
+    <span v-if="loading" class="base-btn__spinner" aria-hidden="true"></span>
+    <span v-else-if="$slots.icon" class="base-btn__icon"><slot name="icon" /></span>
+    <span class="base-btn__label"><slot /></span>
+  </button>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+defineOptions({ inheritAttrs: false })
+const props = defineProps({
+  variant: { type: String, default: 'primary', validator: (v) => ['primary','secondary','danger','ghost'].includes(v) },
+  loading: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  type: { type: String, default: 'button', validator: (v) => ['button','submit'].includes(v) },
+})
+const isDisabled = computed(() => props.disabled || props.loading)
+</script>
+```
+
+Styles scopés via variables CSS du projet (`--card-bg`, `--text-primary`, `--border-primary`, etc.), `primary` reproduisant le dégradé bleu existant (`.btn-primary` des modales) pour parité visuelle après migration.
+
+---
+
+## Data Models
+
+### Core Data Structure Definitions
+
+Les composants sont **présentationnels et sans état global** (R2.1 / R6.2). Pas de store, pas d'entité métier. Les seuls « modèles » sont les contrats de props/slots ci-dessus et les tables de mapping internes.
+
+```ts
+// Mapping de taille (Modal) — interne, pur
+type CanonicalSize = 'sm' | 'md' | 'lg' | 'xl'
+const SIZE_MAX_WIDTH: Record<CanonicalSize, string> = {
+  sm: '400px', md: '500px', lg: '720px', xl: '960px',
+}
+const SIZE_ALIASES: Record<string, CanonicalSize> = { medium: 'md' } // R1.8
+
+// Variantes (BaseButton) — interne, pur
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost'
+```
+
+### Data Model Diagram
+
+```mermaid
+classDiagram
+    class Modal {
+        +Boolean modelValue
+        +String title
+        +String size
+        +visible() Boolean
+        +normalizedSize() String
+        +close() void
+        +onKeydown(e) void
+    }
+    class BaseButton {
+        +String variant
+        +Boolean loading
+        +Boolean disabled
+        +String type
+        +isDisabled() Boolean
+    }
+    class Consumer {
+        +open()
+        +submit()
+    }
+    Consumer --> Modal : v-model plus slots
+    Consumer --> BaseButton : slot label plus attrs
+    note for Modal "inheritAttrs false plus v-bind attrs sur modal-container"
+    note for BaseButton "inheritAttrs false plus v-bind attrs sur button"
+```
+
+---
+
+## Business Process
+
+### Process 1 — Migration d'une modale `modals/*` vers le pattern enrichi
+
+```mermaid
+flowchart TD
+    A[Modale modals cible] --> B[Remplacer size medium par size md]
+    B --> C{Boutons footer dupliques}
+    C -->|oui| D[Remplacer btn-cancel et btn-primary par BaseButton]
+    C -->|non| E[Conserver footer]
+    D --> F[Supprimer styles btn morts R3.6]
+    E --> G[Verifier slot footer rendu seulement si fourni]
+    F --> G
+    G --> H[Lancer npm run test]
+    H --> I{Tests Modal et BaseButton verts}
+    I -->|oui| J[Comportement observable preserve R3.2]
+    I -->|non| K[Corriger sans casser API]
+    K --> H
+```
+
+### Process 2 — Fermeture unique de la Modal (overlay / ✕ / Échap)
+
+```mermaid
+sequenceDiagram
+    participant U as Utilisateur
+    participant M as Modal
+    participant P as Parent
+    U->>M: clic overlay self OU clic croix OU touche Echap
+    M->>M: close
+    M->>M: visible setter
+    M->>P: emit update modelValue false
+    P->>M: modelValue devient false
+    M->>M: watch visible false
+    M->>M: body overflow restaure plus removeEventListener keydown
+```
+
+### Process 3 — Clic sur BaseButton avec fallthrough `$attrs`
+
+```mermaid
+flowchart TD
+    A[Parent attache click sur BaseButton] --> B[BaseButton inheritAttrs false]
+    B --> C[v-bind attrs sur button interne]
+    C --> D{isDisabled vrai}
+    D -->|non| E[clic atteint button natif]
+    E --> F[handler parent declenche R2.6]
+    D -->|oui loading ou disabled| G[button disabled natif]
+    G --> H[aucun clic emis R2.4]
+```
+
+---
+
+## Error Handling
+
+Composants purement présentationnels → pas d'I/O, pas d'erreur réseau à gérer dans `Modal`/`BaseButton`. La stratégie d'erreur porte sur la **robustesse du contrat de composant** :
+
+| Cas | Comportement | Critère |
+|---|---|---|
+| `size` invalide | `validator` → warn Vue (dev) ; `normalizedSize` retombe sur `'md'` ; aucun crash ni largeur indéfinie. | R1.7 |
+| `size="medium"` (alias legacy) | accepté, mappé `md`, documenté. | R1.8 |
+| Ni slot `header` ni `title` | header réduit au ✕ accessible, rendu non cassé. | R1.5 |
+| `footer` absent | aucune zone footer (`v-if="$slots.footer"`). | R1.2 |
+| Listener Échap | ajouté à l'ouverture, retiré à la fermeture **et** `beforeUnmount` → pas de fuite. | R1.10 |
+| `variant` invalide (BaseButton) | `validator` → warn dev ; classe `base-btn--undefined` évitée car défaut `'primary'` appliqué par Vue. | R2.2 |
+| Clic sur bouton `loading`/`disabled` | bloqué côté natif (`:disabled`), handler parent non appelé — état non contournable client (R4 §1.4 production : ne jamais faire confiance au client → désactivation effective, pas seulement visuelle). | R2.3/R2.4 |
+
+Les erreurs métier (soumission de formulaire, appels API) restent dans les **consommateurs** (ex. `handleSubmit` de `QuickAddTeacherModal` conserve son `try/catch` + `toast`), inchangés par la migration (R3.2 : comportement observable préservé).
+
+---
+
+## Testing Strategy
+
+> TDD obligatoire : tests écrits **avant** l'implémentation (PRODUCTION_STANDARDS §1.3, R5.9). Outils : Vitest + `@vue/test-utils` (`mount`), `jsdom` (déjà configurés). Convention `tests/unit/roles.test.js` : docstring FR d'en-tête, import via `@`, `describe/it`, `it.each`.
+
+### Fichier `tests/unit/Modal.test.js`
+
+| # | Cas testé | Assertion | Req |
+|---|---|---|---|
+| 1 | slot défaut (body) rendu | `wrapper.find('.modal-body').text()` contient le contenu | R5.3 |
+| 2 | slot `footer` rendu **seulement** si fourni | sans slot → `find('.modal-footer').exists() === false` ; avec → `true` | R5.3 |
+| 3 | slot `header` remplace l'en-tête par défaut | header custom rendu, `.modal-title` par défaut absent, ✕ toujours présent | R5.3 |
+| 4 | fermeture ✕ | `find('.modal-close-btn').trigger('click')` → `emitted('update:modelValue')[0] === [false]` | R5.2 |
+| 5 | fermeture overlay | `find('.modal-overlay').trigger('click')` (self) → émet `false` | R5.2 |
+| 6 | fermeture Échap | `document` keydown `Escape` (visible) → émet `false` | R5.2 |
+| 7 | scroll-lock | à `modelValue=true` → `document.body.style.overflow === 'hidden'` ; à `false`/unmount → `''` | R5.4 |
+| 8 | `size` valide | `size:'lg'` → `.modal-container` porte `.modal-lg` | R5.5 |
+| 9 | `size` invalide + alias | validator(`'zzz'`)=false ; `normalizedSize` rendu = `md` ; `size:'medium'` → `.modal-md` | R5.5 |
+| 10 | `$attrs` traverse | `attrs:{ id:'x', class:'custom' }` → présents sur `.modal-container`, pas sur racine `<transition>` | R1.9 |
+
+### Fichier `tests/unit/BaseButton.test.js`
+
+| # | Cas testé | Assertion | Req |
+|---|---|---|---|
+| 1 | `@click` non déclaré traverse | `mount(BaseButton, { attrs:{ onClick } }); find('button').trigger('click')` → `onClick` appelé | R5.6 |
+| 2 | `type="submit"` traverse | `attrs/props type:'submit'` → `find('button').attributes('type') === 'submit'` | R5.7 |
+| 3 | `variant` applique la classe | `variant:'danger'` → `find('button').classes()` contient `base-btn--danger` | R5.8 |
+| 4 | défaut `variant` | sans prop → `base-btn--primary` | R5.8 |
+| 5 | `disabled` | `disabled:true` → `button[disabled]` présent ; clic ne déclenche pas le handler | R5.8 |
+| 6 | `loading` | `loading:true` → `button[disabled]` + spinner rendu + aucun clic effectif | R5.8 |
+| 7 | slot défaut (label) | `slots:{ default:'Enregistrer' }` → texte rendu | R2.8 |
+| 8 | slot `icon` | `slots:{ icon, default }` → icône rendue avant label | R2 |
+
+### Critère d'échec (R5.9)
+
+`npm run test` **doit échouer** si l'un de ces contrats est violé (assertions de régression). Aucun test « tolérant ». Les tests sont commités/validés avant le code d'implémentation (TDD).
+
+---
+
+## Mapping de migration
+
+| Source (avant) | Cible (après) | Changement précis | Statut |
+|---|---|---|---|
+| `Modal.vue` `title` requis | `title` optionnel `default:''` | suppression `required:true` | Enrichi |
+| `Modal.vue` (pas de header) | slot `header` + ✕ invariant | nouveau slot, priorité D1 | Enrichi |
+| `Modal.vue` (pas de size) | prop `size` validée + classes | `sm/md/lg/xl` + alias `medium`→`md` | Enrichi |
+| `Modal.vue` (pas d'Échap) | listener keydown Escape | ajout/cleanup watch+beforeUnmount | Enrichi |
+| `Modal.vue` (pas d'attrs) | `inheritAttrs:false`+`v-bind="$attrs"` sur `.modal-container` | transparence d'attributs | Enrichi |
+| `QuickAddTeacherModal` `size="medium"` | `size="md"` | corrige bug latent R1.8 | Migré |
+| `QuickAddTeacherModal` `.btn-cancel/.btn-primary` | `<BaseButton variant="secondary">` / `<BaseButton variant="primary" type="submit" :loading>` | adoption BaseButton + suppression styles morts | Migré |
+| `GenerateReportModal` `size="medium"` + boutons | `size="md"` + `<BaseButton>` | idem (2e adoption démonstrative) | Migré |
+| `QuickCreateClasseModal` `size="medium"` | `size="md"` (+ BaseButton optionnel) | corrige bug latent | Migré |
+| `visio/ParticipantsModal` | — | inchangé | **Dette #25-FE-1** |
+| `calendar/EventDetailModal` | — | inchangé | **Dette #25-FE-1** |
+| `modals/GlobalSearchModal` | — | inchangé | **Dette #25-FE-1** |
+| `visio/JitsiModal` | — | inchangé | **Dette #25-FE-1** |
+| `BaseCard` / `BaseInput` | — | non créés | **Dette #25-FE-2** |
+
+> Les 11 autres fichiers `modal-overlay`/`fixed inset-0` listés par grep (`ChapterManager`, `SeanceAttendanceHistory`, `AdminUsers`, `AdminEnseignants`, `AdminInstitutions`, `TeacherEvaluations`, `TeacherLessons`, `AdminMatieres`, `TakeEvaluation`, `MatiereDetails`, `AttendanceHistory`, `TipTapEditor`, `CalendarWidget`) ne sont **pas** dans le périmètre de cette feature (R3.1 = « sous-ensemble représentatif »). Ils relèvent de la migration incrémentale future, non bloquante (R6.7). Aucune **nouvelle** modale inline ne sera introduite dans les fichiers migrés (R3.5).
+
+---
+
+## Dette tracée
+
+### `#25-FE-1` — Modales inline complexes non migrées
+
+Voir D6. Justification par fichier documentée. Migration incrémentale autorisée par R3.3/R6.7. **Risque** : duplication persistante de markup overlay sur 4 fichiers complexes. **Quand la payer** : à l'apparition d'un besoin de cohérence visuelle ou lors de la refonte god components (#28). **Non masquée** : référencée dans `src/components/ui/README.md` (D7/R4.4).
+
+### `#25-FE-2` — Base components additionnels non créés
+
+`BaseCard`, `BaseInput` non créés (D8). **Risque** : faible (pas de duplication prouvée comparable aux boutons). **Quand la payer** : au 2e besoin réel concret. Anti-abstraction-prématurée assumée.
+
+### `#25-FE-3` (potentielle, conditionnelle) — Extraction composable si `Modal.vue` dépasse §1.1
+
+Si l'enrichissement porte `Modal.vue` au-delà de ~300 lignes, extraire `useScrollLock` / `useEscapeClose`. Estimation actuelle ~210 lignes → **non déclenchée**, mais tracée pour vigilance (R1.12).
+
+> Aucune dette n'est silencieuse (PRODUCTION_STANDARDS §1.6 « surfacer plutôt que masquer »).
+
+---
+
+## Conformité PRODUCTION_STANDARDS
+
+| Règle (source : mémoire `lms-backend-rules-location.md`) | Application dans ce design |
+|---|---|
+| **§1.1 Zero God Code / taille de fichier** | `Modal.vue` cible <300 l (~210 estimé) ; `BaseButton.vue` ~80 l ; dépassement éventuel → extraction composable tracée `#25-FE-3` (R1.12/R6.6). |
+| **§1.3 Tests obligatoires (TDD)** | 10 tests `Modal` + 8 tests `BaseButton`, écrits **avant** l'implémentation ; `npm run test` échoue sur violation de contrat (R5.9). |
+| **§1.6 Citer la règle / sourcer la best practice** | Chaque décision cite son requirement (R1.x…) ; patterns sourcés doc Vue (slots, fallthrough attributes, base components — vuejs.org) dans le README ; dette explicitement tracée. |
+| **SOLID — SRP** | `Modal` = présentation modale ; `BaseButton` = présentation bouton ; logique métier reste dans les consommateurs (séparation présentation/métier). |
+| **SOLID — OCP** | Extension par slots/`$attrs`/`variant` sans édition du composant (R6.1). |
+| **Production, pas prototype** | État `disabled`/`loading` désactivé **effectivement** côté natif (non contournable client), accessibilité du ✕ et `aria-label`, validators de props, pas de copier-coller (R6.1). |
+| **Une seule solution (§6)** | D1–D9 tranchent chacune une unique option justifiée, jamais « A ou B ». |
+| **CONTRIBUTING §A (spec-driven)** | Ce design suit requirements approuvé ; accord explicite requis avant implémentation et avant tout commit/push. |
+| **Pas de modif backend** | Aucun fichier backend ni contrat d'API touché (R6.5). |
+
+---
+
+## Traçabilité design → requirements
+
+| Requirement | Critères | Couvert par |
+|---|---|---|
+| **R1** Modal enrichie sans régression | 1.1–1.12 | D1, D2, D3, API `Modal`, Process 2, Error Handling, tests 1-10 |
+| R1.1/1.2 API préservée | — | API `Modal` (slots/footer/close/scroll-lock), test 2/4/5/7 |
+| R1.3 `title` optionnelle | — | D1, props `Modal` |
+| R1.4/1.5 slot `header` + ✕ accessible | — | D1, squelette template, test 3 |
+| R1.6/1.7 `size` validée | — | D2, validator, test 8/9 |
+| R1.8 incohérence `medium` | — | D2 (alias normalisé + correction consommateurs), test 9, mapping |
+| R1.9 `$attrs` sur conteneur | — | D3, squelette, test 10 |
+| R1.10/1.11 Échap + fermeture unique | — | API `close()`/`onKeydown`, Process 2, test 6 |
+| R1.12 taille fichier | — | §1.1, dette `#25-FE-3` |
+| **R2** BaseButton `$attrs` | 2.1–2.9 | D4, D8, API `BaseButton`, Process 3, tests B1-B8 |
+| R2.2 `variant` | — | props, test B3/B4 |
+| R2.3/2.4 disabled/loading non contournable | — | `isDisabled`, Error Handling, test B5/B6 |
+| R2.5/2.6/2.7 fallthrough click/type | — | D4, `v-bind="$attrs"` + `:type`, test B1/B2 |
+| R2.8 slot label | — | slot défaut, test B7 |
+| R2.9 adoption 1-2 emplacements | — | D5 (QuickAddTeacher + GenerateReport) |
+| **R3** Migration sous-ensemble | 3.1–3.6 | D5, D6, Mapping de migration, Process 1 |
+| R3.3 dette modales complexes | — | D6, dette `#25-FE-1` |
+| R3.6 pas de code mort | — | D5 (suppression styles `.btn-*`), Process 1 |
+| **R4** Documentation patterns | 4.1–4.5 | D7, `src/components/ui/README.md` |
+| **R5** Tests Vitest | 5.1–5.9 | D9, Testing Strategy (18 cas), TDD |
+| **R6** Conformité Vue + non-régression | 6.1–6.7 | Conformité PRODUCTION_STANDARDS, D3 (non-régression Options API), R6.2 (sans store), dette incrémentale R6.7 |
+
+---
+
+## Documentation des patterns (synthèse — détail dans `src/components/ui/README.md`)
+
+1. **Composition par slots** : un composant fournit des « trous » nommés/défaut ; le parent injecte le contenu. Ne jamais recopier le markup d'une modale — utiliser `Modal` + slots `header`/défaut/`footer`. (vuejs.org/guide/components/slots)
+2. **Wrapper transparent `$attrs`** : `inheritAttrs:false` + `v-bind="$attrs"` sur l'élément interne réel pour que `class`/listeners/`aria-*`/`type` du parent atteignent l'élément natif sans re-déclarer chaque attribut en prop. (vuejs.org/guide/components/attrs)
+3. **Base components** : préfixe `Base`, purement présentationnels, **sans store ni état global**, pilotés par props + slots. (vuejs.org/style-guide)
+4. **Règle anti-copier-coller** : interdiction d'introduire un nouveau markup `modal-overlay`/`fixed inset-0 … bg-opacity-50` ; toute nouvelle modale passe par `ui/Modal.vue`, tout nouveau bouton standard par `ui/BaseButton.vue`. (DRY, vuejs.org/guide/reusability)
+5. **Dette `#25-FE-1`** : modales restées inline et raison (ParticipantsModal, EventDetailModal, GlobalSearchModal, JitsiModal).
+
+---
+
+**Does the design look good? If so, we can move on to the implementation plan.**
+(Si vous souhaitez des ajustements — valeurs de `size`, périmètre de migration, emplacement de la doc, ou tout autre point tranché — indiquez-les et je révise avant de produire les tasks.)

--- a/.claude/specs/ui-components/requirements.md
+++ b/.claude/specs/ui-components/requirements.md
@@ -1,0 +1,134 @@
+# Requirements Document — Réutilisabilité des composants UI (ui-components)
+
+## Introduction
+
+Le frontend Vue 3 (`lms-frontend`) souffre d'une duplication massive de markup d'interface : chaque modale est réécrite « à la main » dans la vue qui en a besoin, et les boutons sont recopiés avec leurs classes Tailwind/CSS d'un fichier à l'autre. Cette feature pose les mécanismes officiels de réutilisation de Vue 3 (slots, fallthrough attributes `$attrs`, base components) pour remplacer le copier-coller, en s'appuyant sur le composant `src/components/ui/Modal.vue` qui existe déjà mais reste sous-utilisé.
+
+Issue GitHub #25, TIER 1 de la roadmap d'audit (épique #16).
+
+### État vérifié du code (grep + lecture, 2026-06-16)
+
+- `src/components/ui/Modal.vue` existe (Options API). API actuelle : `v-model:modelValue`, prop `title` **REQUISE** (`type: String, required: true`), slot par défaut = body, slot nommé `footer` (rendu uniquement si `$slots.footer`), fermeture sur clic overlay (`@click.self`) et bouton ✕, lock du scroll body via `watch(visible)` + `beforeUnmount`, animation `transition name="modal-fade"`, responsive `@media (max-width: 768px)`.
+- **Absences confirmées dans `Modal.vue`** : pas de slot `header`, pas de prop `size`, **pas de fermeture au clavier (Échap)**, pas de `$attrs`/`inheritAttrs`.
+- **6 fichiers** importent `ui/Modal.vue` : `views/student/StudentSettings.vue`, `views/teacher/TeacherSettings.vue`, `views/admin/AdminSettings.vue`, `components/modals/QuickAddTeacherModal.vue`, `components/modals/GenerateReportModal.vue`, `components/modals/QuickCreateClasseModal.vue`.
+- **Régression latente détectée** : `QuickAddTeacherModal.vue` et `GenerateReportModal.vue` passent déjà `size="medium"` à `<Modal>`, mais `Modal.vue` ne déclare pas cette prop → l'attribut est ignoré silencieusement (aujourd'hui sans `inheritAttrs:false`, il tombe sur le `<transition>` racine et n'a aucun effet visuel). Toute évolution doit lever cette incohérence sans casser ces deux consommateurs.
+- **19 fichiers** réinventent une modale inline (markup `modal-overlay` OU `fixed inset-0 ... flex` + `bg-opacity-50`) au lieu d'utiliser `ui/Modal.vue` (20 occurrences du motif, dont `Modal.vue` lui-même). Exemples lus : `components/visio/ParticipantsModal.vue` (header dégradé custom, tableau, auto-refresh — modale complexe), `components/calendar/EventDetailModal.vue` (modale de détail standard avec header/body custom).
+- **0 occurrence** de `$attrs` / `useAttrs` / `inheritAttrs` dans tout `src/`.
+- **0 composant `Base*`** : aucune couche de composants de présentation réutilisables ; les boutons sont dupliqués (ex. `.btn-cancel` / `.btn-primary` redéfinis localement dans `QuickAddTeacherModal.vue`).
+- Outillage de test présent : Vitest 4.1.8, `@vue/test-utils` 2.4.11, jsdom 29 (`package.json`), config `vitest.config.js`. Convention de test : `tests/unit/*.test.js`, import via alias `@`, docstring française d'en-tête, usage de `it.each` (réf. `tests/unit/roles.test.js`). **Aucun test de montage de composant n'existe encore** (`mount`/`shallowMount` absents du dossier `tests/`).
+
+### Paradigme de référence (sourcé)
+
+- Vue 3 a abandonné l'héritage de classe : la réutilisation se fait par **composition** — base components + props/slots + wrapper `v-bind="$attrs"` + composables (vuejs.org/guide/reusability).
+- **Slots / named slots / scoped slots** pour la composition de rendu (vuejs.org/guide/components/slots).
+- **Fallthrough attributes** : `$attrs` + `inheritAttrs:false` pour qu'un wrapper transmette classes/listeners/attributs vers son élément interne (vuejs.org/guide/components/attrs).
+- **Base components** : préfixe `Base`/`App`/`V`, purement présentationnels, sans état global (Style Guide vuejs.org/style-guide).
+- **Anti-pattern** : copier-coller un composant pour le modifier (violation DRY).
+
+### Périmètre
+
+- **Dans le périmètre** : enrichissement de `ui/Modal.vue` sans régression ; création d'au moins `BaseButton.vue` démontrant le pattern `$attrs` ; migration d'un sous-ensemble représentatif de modales inline simples ; documentation des patterns ; tests Vitest pour `Modal` et `BaseButton`.
+- **Hors périmètre** : refonte des god components (#28) ; remplacement de **tous** les boutons par `BaseButton` (on pose le pattern + 1 à 2 adoptions démonstratives seulement) ; i18n ; toute modification backend.
+- **Dette autorisée et tracée (#25-FE-1)** : les modales complexes (ex. `ParticipantsModal.vue`, `JitsiModal.vue`) dont la migration est risquée peuvent rester inline si elles sont déclarées explicitement comme dette. La migration est incrémentale.
+- **Standards applicables** : PRODUCTION_STANDARDS §1.1 (tailles de fichier, Zero God Code), §1.3 (tests obligatoires), §1.6 (citer la règle / sourcer la best practice) ; CONTRIBUTING (workflow spec-driven, accord explicite avant commit/push). « Une seule solution, jamais A ou B » : le **design** tranchera les choix ouverts ci-dessous.
+
+### Décisions laissées au design
+
+1. Liste exacte des enrichissements de `Modal.vue` (valeurs de `size`, contrat du slot `header` vs `title`, comportement Échap).
+2. Quels base components créer au-delà du `BaseButton` obligatoire.
+3. Le périmètre précis de migration (quelles modales inline parmi les 19, lesquelles restent en dette tracée).
+4. L'emplacement de la documentation des patterns (fichier dédié court OU section dans `design.md`).
+
+---
+
+## Requirements
+
+### Requirement 1 — Modal canonique enrichie, sans régression
+
+**User Story:** En tant que développeur frontend, je veux que `ui/Modal.vue` soit la seule modale canonique, enrichie pour couvrir les besoins des modales inline existantes, afin de pouvoir composer toute modale par slots sans recopier de markup.
+
+#### Acceptance Criteria
+
+1. WHERE le composant `src/components/ui/Modal.vue` est concerné, le système SHALL conserver sans régression l'API publique existante : `v-model:modelValue`, slot par défaut (body), slot nommé `footer` rendu seulement s'il est fourni, fermeture sur clic overlay (`@click.self`), fermeture sur le bouton ✕, lock du scroll body à l'ouverture et restauration à la fermeture/`beforeUnmount`.
+2. WHEN un consommateur ne fournit aucun contenu pour le slot `footer`, THEN le système SHALL ne rendre aucune zone de pied de modale (parité avec le comportement actuel `v-if="$slots.footer"`).
+3. The system SHALL rendre la prop `title` **OPTIONNELLE** (suppression de `required: true`) tout en préservant le rendu du titre lorsque `title` est fournie, afin de ne pas casser les 6 consommateurs actuels qui passent `title`.
+4. The system SHALL exposer un slot nommé `header` qui, lorsqu'il est fourni, remplace le rendu par défaut de l'en-tête (le `title` + bouton ✕), permettant un en-tête custom (cas du header dégradé des modales inline) tout en conservant un moyen de fermeture accessible.
+5. WHEN ni le slot `header` ni la prop `title` ne sont fournis, THEN le système SHALL néanmoins afficher une commande de fermeture (bouton ✕) accessible, sans planter le rendu.
+6. The system SHALL exposer une prop `size` à valeurs contraintes (ensemble fini, p. ex. `sm` / `md` / `lg` / `xl`, valeurs exactes tranchées par le design) avec une valeur par défaut, et appliquer une largeur maximale correspondante au conteneur de la modale.
+7. IF un consommateur fournit une valeur de `size` hors de l'ensemble autorisé, THEN le système SHALL la rejeter via un `validator` de prop (avertissement Vue en développement) et retomber sur la taille par défaut.
+8. WHERE les consommateurs `QuickAddTeacherModal.vue` et `GenerateReportModal.vue` passent aujourd'hui `size="medium"`, THEN le système SHALL résoudre l'incohérence de nommage de façon explicite (alignement de la valeur attendue OU mapping documenté), de sorte qu'après la feature ces deux modales rendent une taille intentionnelle et non un attribut ignoré.
+9. The system SHALL déclarer `inheritAttrs: false` et appliquer `v-bind="$attrs"` sur le conteneur de contenu de la modale (et non sur l'élément `<transition>` racine), afin que les `class`, `id` et attributs non déclarés passés par un consommateur atteignent le conteneur visible de la modale.
+10. WHEN l'utilisateur appuie sur la touche Échap alors que la modale est ouverte, THEN le système SHALL fermer la modale (émission de `update:modelValue=false`), et SHALL retirer l'écouteur clavier à la fermeture et dans `beforeUnmount` (pas de fuite d'écouteur).
+11. WHEN la modale se ferme par overlay, par ✕ ou par Échap, THEN le système SHALL passer par le même mécanisme `close()` unique (source de fermeture unique, pas de logique dupliquée).
+12. The system SHALL maintenir `Modal.vue` sous la limite de taille de fichier des PRODUCTION_STANDARDS (§1.1) ; si l'enrichissement risque de dépasser la limite, le design SHALL prévoir une extraction (composable/sous-composant).
+
+### Requirement 2 — Base component démontrant le pattern wrapper `$attrs`
+
+**User Story:** En tant que développeur frontend, je veux au moins un composant de base réutilisable et purement présentationnel (`BaseButton.vue`) illustrant le pattern fallthrough `$attrs`, afin de standardiser les boutons et de servir de gabarit pour les futurs base components.
+
+#### Acceptance Criteria
+
+1. The system SHALL créer un composant `BaseButton.vue` (préfixe `Base`, sous `src/components/ui/` ou un dossier base tranché par le design) purement présentationnel, **sans accès à un store Pinia ni à un état global**.
+2. The system SHALL exposer une prop `variant` à valeurs contraintes couvrant au minimum `primary`, `secondary`, `danger`, `ghost`, avec validation de prop et variante par défaut.
+3. The system SHALL exposer des états `loading` et `disabled` ; WHEN `loading` est vrai OU `disabled` est vrai, THEN le rendu `<button>` interne SHALL avoir l'attribut `disabled` actif (état désactivé non contournable côté client).
+4. WHEN `loading` est vrai, THEN le système SHALL afficher un indicateur de chargement et SHALL empêcher l'émission d'un clic effectif (le bouton est désactivé).
+5. The system SHALL déclarer `inheritAttrs: false` et appliquer `v-bind="$attrs"` sur le `<button>` interne, de sorte qu'un attribut/listener non déclaré passé par le parent (`type`, `@click`, `aria-*`, `class` supplémentaire, etc.) **traverse** jusqu'au `<button>` réel.
+6. WHEN un parent attache `@click` à `<BaseButton>` et que le bouton n'est ni `disabled` ni `loading`, THEN le clic sur le `<button>` interne SHALL déclencher le handler du parent.
+7. WHEN un parent passe `type="submit"` à `<BaseButton>`, THEN le `<button>` interne rendu SHALL porter `type="submit"`.
+8. The system SHALL accepter le contenu du libellé via le slot par défaut (composition de rendu), sans prop de texte obligatoire.
+9. The system SHALL adopter `BaseButton` dans 1 à 2 emplacements démonstratifs (périmètre exact tranché par le design), à titre de preuve d'usage, sans imposer une refonte de tous les boutons (hors périmètre).
+
+### Requirement 3 — Migration d'un sous-ensemble représentatif de modales inline
+
+**User Story:** En tant que mainteneur, je veux migrer les modales inline « simples » vers `ui/Modal.vue` en préservant comportement et rendu, afin de réduire la duplication de markup de façon incrémentale et sûre.
+
+#### Acceptance Criteria
+
+1. The system SHALL migrer vers `ui/Modal.vue` un sous-ensemble représentatif de modales inline de type confirmation/formulaire simple (liste précise tranchée par le design parmi les 19 fichiers identifiés).
+2. WHEN une modale est migrée, THEN le système SHALL préserver son comportement observable : ouverture/fermeture, fermeture overlay/✕/Échap, soumission de formulaire, émissions d'événements existantes, et rendu visuel équivalent.
+3. WHERE une modale inline complexe présente un risque de régression élevé à la migration (ex. header dégradé custom, tableau, auto-refresh comme `ParticipantsModal.vue`, ou intégration tierce comme `JitsiModal.vue`), THEN le système SHALL la laisser en l'état et l'inscrire explicitement comme **dette tracée `#25-FE-1`** (fichier + raison) plutôt que de forcer une migration risquée.
+4. WHEN une modale migrée nécessite un en-tête non standard, THEN le système SHALL utiliser le slot `header` de `Modal.vue` (Requirement 1.4) plutôt que de réintroduire du markup d'overlay inline.
+5. The system SHALL NOT introduire de nouvelle modale construite avec le markup inline (`modal-overlay` / `fixed inset-0 ... flex` + `bg-opacity-50`) dans les fichiers concernés par la migration ; toute nouvelle modale SHALL passer par `ui/Modal.vue`.
+6. WHEN la migration d'une modale est terminée, THEN le système SHALL supprimer le markup d'overlay et les styles de modale désormais inutiles dans le fichier migré (pas de code mort).
+
+### Requirement 4 — Documentation des patterns de réutilisation
+
+**User Story:** En tant que contributeur, je veux une documentation courte des patterns retenus (slots, wrapper `$attrs`, base components), afin que toute nouvelle UI réutilise ces mécanismes au lieu de dupliquer du markup.
+
+#### Acceptance Criteria
+
+1. The system SHALL produire une documentation (fichier court dédié OU section dans `design.md`, emplacement tranché par le design) décrivant les patterns retenus : composition par slots, wrapper transparent via `inheritAttrs:false` + `v-bind="$attrs"`, et convention des base components (préfixe, purement présentationnel, sans store).
+2. The system SHALL documenter l'API publique enrichie de `ui/Modal.vue` (props `modelValue`, `title`, `size` ; slots `header`/défaut/`footer` ; événements ; fermeture Échap/overlay/✕).
+3. The system SHALL documenter l'API publique de `BaseButton.vue` (props `variant`, `loading`, `disabled` ; slot par défaut ; transmission des attributs via `$attrs`).
+4. The system SHALL référencer la dette tracée `#25-FE-1` (modales restées inline et raison) dans la documentation.
+5. The system SHALL inclure une règle explicite « ne pas copier-coller un composant ni du markup d'overlay ; réutiliser `Modal`/`BaseButton` par slots et `$attrs` » sourcée sur la doc Vue.
+
+### Requirement 5 — Couverture de tests Vitest
+
+**User Story:** En tant qu'équipe, je veux des tests unitaires de composant (Vitest + @vue/test-utils) pour `Modal` et `BaseButton`, afin de garantir le contrat des slots et la traversée des attributs et d'éviter les régressions futures.
+
+#### Acceptance Criteria
+
+1. The system SHALL ajouter des tests sous `tests/unit/` suivant la convention existante (import via alias `@`, docstring d'en-tête, `vitest`, montage via `@vue/test-utils`), exécutables par `npm run test`.
+2. WHEN la modale est ouverte et que l'utilisateur déclenche la fermeture (overlay, ✕, ou Échap), THEN le test SHALL vérifier que `Modal` émet `update:modelValue` avec `false`.
+3. The system SHALL tester le rendu conditionnel des slots de `Modal` : slot par défaut (body) rendu, slot `footer` rendu seulement s'il est fourni, slot `header` remplaçant l'en-tête par défaut quand fourni.
+4. The system SHALL tester le scroll-lock de `Modal` : `document.body` est verrouillé à l'ouverture et restauré à la fermeture/démontage.
+5. The system SHALL tester la prop `size` de `Modal` : une valeur valide applique la largeur attendue ; une valeur invalide déclenche la validation et retombe sur le défaut.
+6. WHEN un `@click` non déclaré est attaché à `BaseButton` et que le bouton est actif, THEN le test SHALL vérifier que le `<button>` interne reçoit l'événement (preuve que `$attrs` traverse).
+7. WHEN `type="submit"` (attribut non déclaré) est passé à `BaseButton`, THEN le test SHALL vérifier que le `<button>` interne porte `type="submit"`.
+8. The system SHALL tester les `variant` de `BaseButton` (classe/rendu attendu par variante) et l'état `disabled`/`loading` (bouton désactivé + aucun clic effectif émis).
+9. The system SHALL faire échouer la suite (`npm run test`) si l'un de ces contrats est violé (les tests sont des assertions de régression, écrits avant l'implémentation conformément à PRODUCTION_STANDARDS §1.3 / TDD).
+
+### Requirement 6 — Conformité au paradigme Vue et non-régression globale
+
+**User Story:** En tant que gardien de la qualité, je veux que la solution respecte le paradigme officiel de réutilisation Vue 3 et n'introduise aucune régression sur les consommateurs existants, afin que l'amélioration soit durable et conforme aux standards.
+
+#### Acceptance Criteria
+
+1. The system SHALL réaliser la réutilisation exclusivement par composition de rendu (slots) et extension par attributs (`$attrs`), SANS duplication de markup ni héritage de classe simulé.
+2. The system SHALL NOT introduire d'état global (store, données partagées) dans les composants de présentation `Base*`.
+3. WHERE un base component enveloppe un élément natif, THEN le système SHALL utiliser `inheritAttrs:false` + `v-bind="$attrs"` plutôt que de re-déclarer chaque attribut natif en prop.
+4. The system SHALL préserver le fonctionnement des 6 consommateurs actuels de `ui/Modal.vue` après enrichissement (aucune erreur de console, rendu et fermeture inchangés ou améliorés).
+5. The system SHALL NOT modifier le backend ni aucun contrat d'API.
+6. The system SHALL respecter les limites de taille de fichier des PRODUCTION_STANDARDS (§1.1) pour tout fichier créé ou modifié ; tout dépassement inévitable SHALL être déclaré comme dette tracée plutôt que masqué.
+7. The system SHALL permettre une livraison incrémentale : Modal enrichie + BaseButton + tests peuvent être livrés indépendamment de la migration complète des modales inline, le reste étant tracé en dette `#25-FE-1`.

--- a/.claude/specs/ui-components/tasks.md
+++ b/.claude/specs/ui-components/tasks.md
@@ -1,0 +1,172 @@
+# Implementation Plan — Réutilisabilité des composants UI (ui-components)
+
+> Issue GitHub #25, TIER 1 (épique #16). Spec-driven (CONTRIBUTING §A).
+> Requirements + Design approuvés : `.claude/specs/ui-components/requirements.md`, `.claude/specs/ui-components/design.md`.
+> **TDD obligatoire** (PRODUCTION_STANDARDS §1.3 / R5.9) : les tests de montage sont écrits **avant** l'implémentation (rouge → vert). Outils : Vitest 4 + `@vue/test-utils` 2 + jsdom (déjà configurés, `vitest.config.js:19` collecte `tests/**/*.test.{js,mjs}` et `src/**/*.test.{js,mjs}`).
+> **Ordre imposé par le design** : tests Modal (rouge) → Modal enrichi (vert) → tests BaseButton (rouge) → BaseButton (vert) → migration des 3 modales → doc → vérification finale.
+>
+> **Conflits de fichiers à respecter (séquence stricte)** :
+> - `src/components/ui/Modal.vue` est **enrichi en tâche 2** puis **consommé en tâche 5** → la tâche 5 dépend de 2.
+> - `src/components/ui/BaseButton.vue` est **créé en tâche 4** puis **adopté en tâche 5** → la tâche 5 dépend de 4.
+> - Les tests de chaque composant (tâches 1 et 3) doivent rester **rouges** jusqu'à l'implémentation correspondante (tâches 2 et 4), conformément au TDD.
+
+---
+
+- [ ] 1. Écrire les tests de montage de `Modal` (rouge, TDD) — 10 cas du design
+  - Créer `tests/unit/Modal.test.js` (convention `tests/unit/roles.test.js` : docstring FR d'en-tête, import via alias `@`, `vitest`, `describe/it`, `it.each` au besoin) ; importer `Modal` depuis `@/components/ui/Modal.vue`, monter via `mount` de `@vue/test-utils`.
+  - Cas 1 — slot défaut (body) : `wrapper.find('.modal-body').text()` contient le contenu injecté.
+  - Cas 2 — slot `footer` conditionnel : sans slot `footer` → `find('.modal-footer').exists() === false` ; avec slot `footer` → `exists() === true`.
+  - Cas 3 — slot `header` remplace l'en-tête : header custom rendu, `.modal-title` par défaut absent, **bouton ✕ toujours présent** (D1, ✕ hors slot).
+  - Cas 4 — fermeture ✕ : `find('.modal-close-btn').trigger('click')` → `emitted('update:modelValue')[0]` égal `[false]`.
+  - Cas 5 — fermeture overlay : `find('.modal-overlay').trigger('click')` (`@click.self`) → émet `false`.
+  - Cas 6 — fermeture Échap : dispatch `keydown` `Escape` sur `document` alors que `modelValue=true` → émet `false`.
+  - Cas 7 — scroll-lock : `modelValue=true` → `document.body.style.overflow === 'hidden'` ; passage à `false` puis `unmount()` → overflow restauré (`''`).
+  - Cas 8 — `size` valide : `size:'lg'` → `.modal-container` porte la classe `modal-lg`.
+  - Cas 9 — `size` invalide + alias : valeur `'zzz'` → `normalizedSize` rend `modal-md` ; `size:'medium'` → `modal-md` (D2).
+  - Cas 10 — `$attrs` traverse : monter avec `attrs:{ id:'x', class:'custom' }` → présents sur `.modal-container`, **absents** de l'élément racine (`<transition>`) (R1.9).
+  - Exécuter `npm run test tests/unit/Modal.test.js` et **constater l'échec** (composant pas encore enrichi : ni `header`, ni `size`, ni Échap, ni `$attrs`) — preuve TDD rouge.
+  - Fichiers : `tests/unit/Modal.test.js`.
+  - Critère de complétion : `npm run test` exécute ces 10 cas et ils échouent (rouge). `grep -c "it(" tests/unit/Modal.test.js` ≥ 10 (ou décompte équivalent via `it.each`).
+  - Décision design : D9 (emplacement `tests/unit/`), D1, D2, D3, Testing Strategy (tableau 10 cas).
+  - _Requirements: R5.1, R5.2, R5.3, R5.4, R5.5, R1.9_
+
+- [ ] 2. Enrichir `src/components/ui/Modal.vue` sans régression (Options API) → tests tâche 1 au vert
+  - **NE PAS migrer en `<script setup>`** : conserver l'Options API existante (D3). Préserver l'API publique : `v-model:modelValue`, slot défaut (body), slot `footer` conditionnel (`v-if="$slots.footer"`), fermeture overlay (`@click.self`) + ✕, scroll-lock via `watch(visible)` + `beforeUnmount`, animation `modal-fade` (R1.1, R1.2).
+  - Prop `title` : passer de `{ type: String, required: true }` à `{ type: String, default: '' }` (R1.3).
+  - Slot `header` (D1) : `<slot name="header">` enveloppant le rendu par défaut `<h3 v-if="title" class="modal-title">{{ title }}</h3>` ; **bouton ✕ rendu hors du slot** (toujours présent : slot custom, title seul, ou ni l'un ni l'autre → ✕ accessible `aria-label="Fermer"`) (R1.4, R1.5).
+  - Prop `size` (D2) : `{ type: String, default: 'md', validator: (v) => ['sm','md','lg','xl','medium'].includes(v) }`. `computed normalizedSize` : `'medium' → 'md'`, valeur hors ensemble canonique → `'md'`. Appliquer `:class="`modal-${normalizedSize}`"` sur `.modal-container` (R1.6, R1.7, R1.8). Styles `.modal-sm`(400px) `.modal-md`(500px) `.modal-lg`(720px) `.modal-xl`(960px) — `md` reprend l'actuel `max-width:500px`.
+  - Fallthrough attributs : ajouter `inheritAttrs: false` dans les options + `v-bind="$attrs"` sur `.modal-container` (et **non** sur le `<transition>` racine) (R1.9).
+  - Fermeture Échap (R1.10, R1.11) : méthode `close()` unique (réutiliser l'existante `Modal.vue:44-46`) appelée par overlay/✕/Échap ; méthode `onKeydown(e)` (`Escape` + `visible` → `close()`) ; dans `watch(visible)` : `true` → `document.addEventListener('keydown', onKeydown)`, `false` → `removeEventListener` ; `beforeUnmount()` retire le listener **et** restaure l'overflow (pas de fuite).
+  - Vérifier la taille de fichier < 300 lignes (R1.12 / §1.1) ; aucune extraction de composable attendue (~210 l estimé, dette `#25-FE-3` non déclenchée).
+  - Exécuter `npm run test tests/unit/Modal.test.js` → **10 cas verts**.
+  - Fichiers : `src/components/ui/Modal.vue`.
+  - Critère de complétion : `npm run test tests/unit/Modal.test.js` tous verts ; `grep -n "inheritAttrs" src/components/ui/Modal.vue` présent ; `grep -n "required: true" src/components/ui/Modal.vue` absent ; nb de lignes < 300.
+  - Décision design : D1, D2, D3 ; API `Modal` ; squelette template du design.
+  - _Requirements: R1.1, R1.2, R1.3, R1.4, R1.5, R1.6, R1.7, R1.8, R1.9, R1.10, R1.11, R1.12, R6.4_
+
+- [ ] 3. Écrire les tests de montage de `BaseButton` (rouge, TDD) — 8 cas du design
+  - Créer `tests/unit/BaseButton.test.js` (même convention : docstring FR, import `@`, `vitest`, `mount`) ; importer depuis `@/components/ui/BaseButton.vue`.
+  - Cas 1 — `@click` non déclaré traverse : `mount(BaseButton, { attrs: { onClick } })` ; `find('button').trigger('click')` → `onClick` appelé (preuve `$attrs`) (R5.6).
+  - Cas 2 — `type="submit"` traverse : passer `type:'submit'` → `find('button').attributes('type') === 'submit'` (R5.7).
+  - Cas 3 — `class` custom traverse : `attrs:{ class:'ma-classe' }` → `find('button').classes()` contient `ma-classe` (R5.6 / R1.9 analogue).
+  - Cas 4 — `variant` applique la classe : `variant:'danger'` → classes du `<button>` contiennent `base-btn--danger` (R5.8).
+  - Cas 5 — défaut `variant` : sans prop → `base-btn--primary` (R5.8).
+  - Cas 6 — `disabled` : `disabled:true` → attribut `disabled` présent sur `<button>` ; un `@click` parent **ne se déclenche pas** (R5.8, R2.6 négatif).
+  - Cas 7 — `loading` : `loading:true` → `<button>` `disabled` + spinner rendu (`.base-btn__spinner`) + aucun clic effectif (R5.8, R2.4).
+  - Cas 8 — slot label + slot icon : `slots:{ default:'Enregistrer' }` → texte rendu ; `slots:{ icon, default }` → icône rendue avant le label (R2.8, R2).
+  - Exécuter `npm run test tests/unit/BaseButton.test.js` et **constater l'échec** (fichier composant inexistant) — preuve TDD rouge.
+  - Fichiers : `tests/unit/BaseButton.test.js`.
+  - Critère de complétion : `npm run test` exécute ces cas et ils échouent (rouge, import manquant). 8 cas présents.
+  - Décision design : D9 (emplacement) ; D4 ; Testing Strategy (tableau 8 cas BaseButton).
+  - _Requirements: R5.6, R5.7, R5.8, R2.8_
+
+- [ ] 4. Créer `src/components/ui/BaseButton.vue` (`<script setup>`) → tests tâche 3 au vert
+  - Créer le composant en `<script setup>` (composant neuf, paradigme moderne — D4) sous `src/components/ui/` (cohabitation avec `Modal.vue`, pas de dossier `base/` séparé — D4).
+  - `defineOptions({ inheritAttrs: false })` ; props via `defineProps` : `variant` (`default:'primary'`, validator `['primary','secondary','danger','ghost']`), `loading` (Boolean, `false`), `disabled` (Boolean, `false`), `type` (`default:'button'`, validator `['button','submit']`) (R2.2, R2.3).
+  - `computed isDisabled = props.disabled || props.loading` (R2.3, R2.4 — état désactivé non contournable côté client).
+  - Template `<button>` : `:type="type"` lié **explicitement** (une prop déclarée ne tombe pas dans `$attrs`, donc liaison directe pour que `type="submit"` traverse — R2.7), `:disabled="isDisabled"`, `:class="['base-btn', `base-btn--${variant}`, { 'is-loading': loading }]"`, **`v-bind="$attrs"`** sur le `<button>` interne pour que `@click`/`aria-*`/`class`/`id`/`form`/`name`/`value` non déclarés traversent (R2.5, R2.6).
+  - Slots : slot par défaut = label (`.base-btn__label`, pas de prop texte — R2.8) ; slot nommé `icon` (avant le label, `v-else-if="$slots.icon"`) ; spinner `.base-btn__spinner` `aria-hidden` quand `loading`.
+  - Aucune émission propre (les listeners traversent via `$attrs` directement sur le natif — pas de ré-émission, design « Émissions : aucune »).
+  - Styles **scopés** via variables CSS du projet (`--card-bg`, `--text-primary`, `--border-primary`, etc.) ; `primary` reproduit le dégradé bleu existant (`.btn-primary` des modales) pour parité visuelle post-migration. Sans store ni état global (R2.1, R6.2).
+  - Exécuter `npm run test tests/unit/BaseButton.test.js` → **8 cas verts**.
+  - Fichiers : `src/components/ui/BaseButton.vue`.
+  - Critère de complétion : `npm run test tests/unit/BaseButton.test.js` tous verts ; `grep -n "inheritAttrs: false" src/components/ui/BaseButton.vue` présent ; `grep -n "useStore\|pinia" src/components/ui/BaseButton.vue` absent (sans état global).
+  - Décision design : D4, D8 ; API `BaseButton` ; squelette du design.
+  - _Requirements: R2.1, R2.2, R2.3, R2.4, R2.5, R2.6, R2.7, R2.8, R6.2, R6.3_
+
+- [ ] 5. Migrer les 3 modales `modals/*` vers `ui/Modal` enrichi + adopter `BaseButton` (dépend de 2 et 4)
+  - **Dépendance** : nécessite `Modal.vue` enrichi (tâche 2) **et** `BaseButton.vue` (tâche 4). Préserver le comportement observable de chaque modale : ouverture/fermeture, overlay/✕/Échap, soumission de formulaire, émissions existantes, rendu équivalent (R3.2).
+- [ ] 5.1 `src/components/modals/QuickAddTeacherModal.vue` — corriger `size` + adopter `BaseButton`
+  - Remplacer `size="medium"` par `size="md"` sur `<Modal>` (corrige le bug latent R1.8 à la source ; l'alias reste toléré par le composant mais on supprime la dette de nommage — D2/D5).
+  - Remplacer les boutons locaux `.btn-cancel` / `.btn-primary` (lignes ~277-311) par `<BaseButton variant="secondary">` (annuler) et `<BaseButton variant="primary" type="submit" :loading="...">` (soumettre), via le slot `footer` de `Modal` si besoin.
+  - Supprimer les styles `.btn-cancel` / `.btn-primary` désormais morts dans le `<style>` du fichier (R3.6 — pas de code mort).
+  - Conserver `handleSubmit`/`try-catch`/`toast` inchangés (logique métier hors scope — R3.2).
+  - Fichiers : `src/components/modals/QuickAddTeacherModal.vue`.
+  - Critère : `grep -n "size=\"medium\"" src/components/modals/QuickAddTeacherModal.vue` absent ; `grep -n "BaseButton" ...` présent ; `grep -n "btn-cancel\|btn-primary" ...` absent (styles morts retirés).
+  - Décision design : D5 (adoption démonstrative), D2.
+  - _Requirements: R3.1, R3.2, R3.6, R2.9, R1.8_
+- [ ] 5.2 `src/components/modals/GenerateReportModal.vue` — corriger `size` + adopter `BaseButton`
+  - `size="medium"` → `size="md"` (R1.8).
+  - Remplacer les boutons locaux dupliqués (lignes ~293-327) par `<BaseButton>` (2e adoption démonstrative R2.9) ; supprimer les styles `.btn-*` morts (R3.6).
+  - Préserver le comportement (génération de rapport, émissions, fermeture).
+  - Fichiers : `src/components/modals/GenerateReportModal.vue`.
+  - Critère : `grep -n "size=\"medium\"" ...` absent ; `grep -n "BaseButton" ...` présent ; styles `.btn-*` dupliqués retirés.
+  - Décision design : D5, D2.
+  - _Requirements: R3.1, R3.2, R3.6, R2.9, R1.8_
+- [ ] 5.3 `src/components/modals/QuickCreateClasseModal.vue` — corriger `size` (BaseButton optionnel)
+  - `size="medium"` → `size="md"` (corrige le bug latent partagé R1.8 — minimum requis par D5).
+  - Optionnel : adopter `<BaseButton>` (sinon conserver ses boutons) ; si adoption, supprimer les styles `.btn-*` morts (R3.6).
+  - Préserver le comportement (création de classe, émissions, fermeture).
+  - Fichiers : `src/components/modals/QuickCreateClasseModal.vue`.
+  - Critère : `grep -n "size=\"medium\"" ...` absent ; si BaseButton adopté, styles morts retirés.
+  - Décision design : D5, D2.
+  - _Requirements: R3.1, R3.2, R3.6, R1.8_
+
+- [ ] 6. Documenter les patterns dans `src/components/ui/README.md` (D7)
+  - Créer `src/components/ui/README.md` (court, au plus près du code) couvrant : (1) composition par slots (ne jamais recopier le markup d'une modale, utiliser `Modal` + slots `header`/défaut/`footer`) ; (2) wrapper transparent `inheritAttrs:false` + `v-bind="$attrs"` sur l'élément interne ; (3) convention base components (préfixe `Base`, purement présentationnel, **sans store ni état global**) — sources doc Vue citées (vuejs.org slots / attrs / style-guide / reusability) (R4.1, R4.5).
+  - Documenter l'API publique enrichie de `ui/Modal.vue` : props `modelValue`/`title`/`size` (+ alias `medium`→`md`), slots `header`/défaut/`footer`, événement `update:modelValue`, fermeture Échap/overlay/✕ (R4.2).
+  - Documenter l'API publique de `BaseButton.vue` : props `variant`/`loading`/`disabled`/`type`, slot défaut (label) + slot `icon`, transmission `$attrs` (`@click`/`type`/`aria-*`/`class`) (R4.3).
+  - Référencer la dette tracée **`#25-FE-1`** (ParticipantsModal, EventDetailModal, GlobalSearchModal, JitsiModal — fichier + raison) et mentionner `#25-FE-2` (BaseCard/BaseInput non créés) (R4.4).
+  - Inclure la **règle anti-copier-coller** explicite (« ne pas dupliquer une modale ni un markup `modal-overlay`/`fixed inset-0 … bg-opacity-50` ; réutiliser `Modal`/`BaseButton` par slots et `$attrs` »), sourcée Vue/DRY (R4.5).
+  - Fichiers : `src/components/ui/README.md`.
+  - Critère : fichier présent ; `grep -i "25-FE-1" src/components/ui/README.md` présent ; sections Modal + BaseButton + règle anti-copier-coller présentes.
+  - Décision design : D7, section « Documentation des patterns » du design.
+  - _Requirements: R4.1, R4.2, R4.3, R4.4, R4.5_
+
+- [ ] 7. Vérification finale (non-régression globale + traçabilité dette)
+  - `npm run test` : la suite passe ; **Modal (10) + BaseButton (8) verts** ; total de tests ≥ avant la feature (aucun test existant cassé, ex. `roles.test.js`) (R5.9, R6.4).
+  - `npm run test:contract` toujours vert (aucun contrat d'API touché — R6.5).
+  - `npm run build` réussit (pas d'erreur de compilation sur les composants enrichis/migrés).
+  - Grep de migration : pour `QuickAddTeacherModal.vue`, `GenerateReportModal.vue`, `QuickCreateClasseModal.vue` → confirmer l'import de `ui/Modal` (`grep -rn "ui/Modal" src/components/modals/`) et **l'absence de markup `modal-overlay` inline** (`grep -rn "modal-overlay" src/components/modals/QuickAddTeacherModal.vue src/components/modals/GenerateReportModal.vue src/components/modals/QuickCreateClasseModal.vue` → 0).
+  - Confirmer l'absence de `size="medium"` dans les 3 modales migrées (`grep -rn 'size="medium"' src/components/modals/` → 0).
+  - Compteur dette **`#25-FE-1`** : recompter les modales inline restantes (`grep -rln "modal-overlay\|fixed inset-0" src/ | wc -l`) et vérifier que les 4 fichiers de dette (ParticipantsModal, EventDetailModal, GlobalSearchModal, JitsiModal) sont **inchangés** (NE PAS migrer) ; consigner le compte dans la note de vérification.
+  - Vérifier les 6 consommateurs historiques de `Modal` (3 vues Settings + 3 modales) : aucune erreur console, rendu/fermeture inchangés ou améliorés (R6.4).
+  - Fichiers : aucun nouveau fichier (vérification seule).
+  - Critère : toutes les commandes ci-dessus passent ; greps conformes ; dette `#25-FE-1` = 4 fichiers intacts.
+  - Décision design : Mapping de migration, Dette tracée, Conformité PRODUCTION_STANDARDS.
+  - _Requirements: R5.9, R6.4, R6.5, R6.6, R6.7, R3.3, R3.5_
+
+---
+
+## Tasks Dependency Diagram
+
+```mermaid
+flowchart TD
+    T1[Tâche 1: Tests Modal rouge - 10 cas]
+    T2[Tâche 2: Enrichir Modal.vue Options API - vert]
+    T3[Tâche 3: Tests BaseButton rouge - 8 cas]
+    T4[Tâche 4: Créer BaseButton.vue script setup - vert]
+    T5_1[Tâche 5.1: Migrer QuickAddTeacherModal + BaseButton]
+    T5_2[Tâche 5.2: Migrer GenerateReportModal + BaseButton]
+    T5_3[Tâche 5.3: Migrer QuickCreateClasseModal size]
+    T6[Tâche 6: Doc README.md ui patterns]
+    T7[Tâche 7: Vérification finale build+test+grep]
+
+    T1 --> T2
+    T3 --> T4
+    T2 --> T5_1
+    T2 --> T5_2
+    T2 --> T5_3
+    T4 --> T5_1
+    T4 --> T5_2
+    T2 --> T6
+    T4 --> T6
+    T5_1 --> T7
+    T5_2 --> T7
+    T5_3 --> T7
+    T6 --> T7
+
+    style T1 fill:#ffcdd2
+    style T3 fill:#ffcdd2
+    style T2 fill:#c8e6c9
+    style T4 fill:#c8e6c9
+    style T5_1 fill:#e1f5fe
+    style T5_2 fill:#e1f5fe
+    style T5_3 fill:#e1f5fe
+```
+
+**Notes de séquencement (conflits de fichiers)** :
+- `Modal.vue` : **modifié en tâche 2**, puis **consommé en tâches 5.1/5.2/5.3** → 5.x après 2. Le TDD impose que les tests de la tâche 1 restent rouges jusqu'à la tâche 2.
+- `BaseButton.vue` : **créé en tâche 4**, puis **adopté en tâches 5.1/5.2** → 5.1/5.2 après 4. Tests tâche 3 rouges jusqu'à la tâche 4.
+- Les tâches 1 et 3 (tests rouges) sont indépendantes et parallélisables. Les tâches 2 et 4 sont indépendantes une fois leurs tests respectifs écrits. Les sous-tâches 5.1/5.2/5.3 touchent des fichiers distincts (parallélisables entre elles une fois 2 et 4 terminées).
+- **Aucune tâche backend, aucune tâche non technique** (R6.5). Les 4 modales de dette `#25-FE-1` ne sont **pas** migrées (D6). `BaseCard`/`BaseInput` non créés → dette `#25-FE-2` (D8).

--- a/src/components/modals/GenerateReportModal.vue
+++ b/src/components/modals/GenerateReportModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal v-model="isOpen" title="Générer un Rapport PDF" size="medium">
+  <Modal v-model="isOpen" title="Générer un Rapport PDF" size="md">
     <form @submit.prevent="handleGenerate" class="report-form">
       <!-- Type de rapport -->
       <div class="form-group">
@@ -69,23 +69,12 @@
     </form>
 
     <template #footer>
-      <button
-        type="button"
-        class="btn-cancel"
-        @click="handleCancel"
-        :disabled="loading"
-      >
+      <BaseButton variant="secondary" :disabled="loading" @click="handleCancel">
         Annuler
-      </button>
-      <button
-        type="submit"
-        class="btn-primary"
-        @click="handleGenerate"
-        :disabled="loading || !form.type"
-      >
-        <span v-if="loading">Génération en cours...</span>
-        <span v-else>Générer PDF</span>
-      </button>
+      </BaseButton>
+      <BaseButton variant="primary" :loading="loading" :disabled="!form.type" @click="handleGenerate">
+        Générer PDF
+      </BaseButton>
     </template>
   </Modal>
 </template>
@@ -93,6 +82,7 @@
 <script setup>
 import { ref, watch, onMounted, computed } from 'vue'
 import Modal from '@/components/ui/Modal.vue'
+import BaseButton from '@/components/ui/BaseButton.vue'
 import { klassciService } from '@/services/klassci'
 import api from '@/services/api'
 import { toast } from '@/services/toast'
@@ -288,41 +278,5 @@ onMounted(() => {
   margin: 0;
   font-size: 0.875rem;
   color: #1e40af;
-}
-
-.btn-cancel,
-.btn-primary {
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-  font-size: 0.875rem;
-}
-
-.btn-cancel {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
-.btn-cancel:hover:not(:disabled) {
-  background: var(--bg-tertiary);
-}
-
-.btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: scale(1.02);
-}
-
-.btn-cancel:disabled,
-.btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 </style>

--- a/src/components/modals/QuickAddTeacherModal.vue
+++ b/src/components/modals/QuickAddTeacherModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal v-model="isOpen" title="Ajout rapide - Enseignant" size="medium">
+  <Modal v-model="isOpen" title="Ajout rapide - Enseignant" size="md">
     <form @submit.prevent="handleSubmit" class="quick-form">
       <!-- Nom -->
       <div class="form-group">
@@ -92,23 +92,12 @@
     </form>
 
     <template #footer>
-      <button
-        type="button"
-        class="btn-cancel"
-        @click="handleCancel"
-        :disabled="loading"
-      >
+      <BaseButton variant="secondary" :disabled="loading" @click="handleCancel">
         Annuler
-      </button>
-      <button
-        type="submit"
-        class="btn-primary"
-        @click="handleSubmit"
-        :disabled="loading"
-      >
-        <span v-if="loading">Création en cours...</span>
-        <span v-else>Ajouter l'enseignant</span>
-      </button>
+      </BaseButton>
+      <BaseButton variant="primary" :loading="loading" @click="handleSubmit">
+        Ajouter l'enseignant
+      </BaseButton>
     </template>
   </Modal>
 </template>
@@ -116,6 +105,7 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
 import Modal from '@/components/ui/Modal.vue'
+import BaseButton from '@/components/ui/BaseButton.vue'
 import { klassciService } from '@/services/klassci'
 import { toast } from '@/services/toast'
 
@@ -272,41 +262,5 @@ onMounted(() => {
   color: #dc2626;
   border-radius: 0.5rem;
   font-size: 0.875rem;
-}
-
-.btn-cancel,
-.btn-primary {
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-  font-size: 0.875rem;
-}
-
-.btn-cancel {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
-.btn-cancel:hover:not(:disabled) {
-  background: var(--bg-tertiary);
-}
-
-.btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: scale(1.02);
-}
-
-.btn-cancel:disabled,
-.btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 </style>

--- a/src/components/modals/QuickCreateClasseModal.vue
+++ b/src/components/modals/QuickCreateClasseModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal v-model="isOpen" title="Création rapide - Classe" size="medium">
+  <Modal v-model="isOpen" title="Création rapide - Classe" size="md">
     <form @submit.prevent="handleSubmit" class="quick-form">
       <!-- Nom de la classe -->
       <div class="form-group">
@@ -94,23 +94,12 @@
     </form>
 
     <template #footer>
-      <button
-        type="button"
-        class="btn-cancel"
-        @click="handleCancel"
-        :disabled="loading"
-      >
+      <BaseButton variant="secondary" :disabled="loading" @click="handleCancel">
         Annuler
-      </button>
-      <button
-        type="submit"
-        class="btn-primary"
-        @click="handleSubmit"
-        :disabled="loading"
-      >
-        <span v-if="loading">Création en cours...</span>
-        <span v-else>Créer la classe</span>
-      </button>
+      </BaseButton>
+      <BaseButton variant="primary" :loading="loading" @click="handleSubmit">
+        Créer la classe
+      </BaseButton>
     </template>
   </Modal>
 </template>
@@ -118,6 +107,7 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
 import Modal from '@/components/ui/Modal.vue'
+import BaseButton from '@/components/ui/BaseButton.vue'
 import { klassciService } from '@/services/klassci'
 import { toast } from '@/services/toast'
 
@@ -286,41 +276,5 @@ onMounted(() => {
   color: #dc2626;
   border-radius: 0.5rem;
   font-size: 0.875rem;
-}
-
-.btn-cancel,
-.btn-primary {
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-  font-size: 0.875rem;
-}
-
-.btn-cancel {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
-.btn-cancel:hover:not(:disabled) {
-  background: var(--bg-tertiary);
-}
-
-.btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: scale(1.02);
-}
-
-.btn-cancel:disabled,
-.btn-primary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 </style>

--- a/src/components/ui/BaseButton.vue
+++ b/src/components/ui/BaseButton.vue
@@ -1,0 +1,125 @@
+<template>
+  <button
+    :type="type"
+    :disabled="isDisabled"
+    :class="['base-btn', `base-btn--${variant}`, { 'is-loading': loading }]"
+    v-bind="$attrs"
+  >
+    <span v-if="loading" class="base-btn__spinner" aria-hidden="true"></span>
+    <span v-else-if="$slots.icon" class="base-btn__icon"><slot name="icon" /></span>
+    <span class="base-btn__label"><slot /></span>
+  </button>
+</template>
+
+<script setup>
+/**
+ * BaseButton — bouton de base réutilisable (#25).
+ * Variantes visuelles + états loading/disabled + slots label/icon.
+ * inheritAttrs:false : les attributs (data-*, aria-*, @click natif…) traversent sur le <button>.
+ */
+import { computed } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  variant: {
+    type: String,
+    default: 'primary',
+    validator: (v) => ['primary', 'secondary', 'danger', 'ghost'].includes(v)
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  },
+  disabled: {
+    type: Boolean,
+    default: false
+  },
+  type: {
+    type: String,
+    default: 'button',
+    validator: (v) => ['button', 'submit', 'reset'].includes(v)
+  }
+})
+
+// Un bouton en chargement est désactivé pour éviter les doubles soumissions.
+const isDisabled = computed(() => props.disabled || props.loading)
+</script>
+
+<style scoped>
+.base-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, opacity 0.2s, color 0.2s;
+}
+
+.base-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.base-btn--primary {
+  background: var(--accent-primary, #4f46e5);
+  color: #fff;
+}
+
+.base-btn--primary:hover:not(:disabled) {
+  background: var(--accent-primary-hover, #4338ca);
+}
+
+.base-btn--secondary {
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-primary, #111827);
+  border-color: var(--border-primary, #e5e7eb);
+}
+
+.base-btn--secondary:hover:not(:disabled) {
+  background: var(--bg-tertiary, #e5e7eb);
+}
+
+.base-btn--danger {
+  background: var(--danger, #dc2626);
+  color: #fff;
+}
+
+.base-btn--danger:hover:not(:disabled) {
+  background: var(--danger-hover, #b91c1c);
+}
+
+.base-btn--ghost {
+  background: transparent;
+  color: var(--text-secondary, #6b7280);
+}
+
+.base-btn--ghost:hover:not(:disabled) {
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-primary, #111827);
+}
+
+.base-btn__icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.base-btn__spinner {
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: base-btn-spin 0.6s linear infinite;
+}
+
+@keyframes base-btn-spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/src/components/ui/Modal.vue
+++ b/src/components/ui/Modal.vue
@@ -1,10 +1,14 @@
 <template>
   <transition name="modal-fade">
     <div v-if="visible" class="modal-overlay" @click.self="close">
-      <div class="modal-container">
+      <!-- $attrs sur le conteneur visible (inheritAttrs:false) : class/id/aria-*/data-* traversent -->
+      <div class="modal-container" :class="`modal-${normalizedSize}`" v-bind="$attrs">
         <div class="modal-header">
-          <h3 class="modal-title">{{ title }}</h3>
-          <button class="modal-close-btn" @click="close">✕</button>
+          <!-- Slot header custom ; sinon title optionnelle. Le ✕ reste TOUJOURS rendu (hors slot). -->
+          <slot name="header">
+            <h3 v-if="title" class="modal-title">{{ title }}</h3>
+          </slot>
+          <button class="modal-close-btn" aria-label="Fermer" @click="close">✕</button>
         </div>
         <div class="modal-body">
           <slot></slot>
@@ -20,6 +24,8 @@
 <script>
 export default {
   name: 'Modal',
+  // Les attributs non déclarés (class, aria-*, data-*) vont sur .modal-container, pas la racine transition.
+  inheritAttrs: false,
   props: {
     modelValue: {
       type: Boolean,
@@ -27,7 +33,12 @@ export default {
     },
     title: {
       type: String,
-      required: true
+      default: ''
+    },
+    size: {
+      type: String,
+      default: 'md',
+      validator: (v) => ['sm', 'md', 'lg', 'xl', 'medium'].includes(v)
     }
   },
   computed: {
@@ -38,24 +49,41 @@ export default {
       set(value) {
         this.$emit('update:modelValue', value)
       }
+    },
+    // Normalise l'alias 'medium' → 'md' et retombe sur 'md' si valeur inattendue.
+    normalizedSize() {
+      if (this.size === 'medium') return 'md'
+      return ['sm', 'md', 'lg', 'xl'].includes(this.size) ? this.size : 'md'
     }
   },
   methods: {
     close() {
       this.visible = false
+    },
+    onKeydown(e) {
+      if (e.key === 'Escape' && this.visible) {
+        this.close()
+      }
     }
   },
   watch: {
-    visible(newVal) {
-      if (newVal) {
-        document.body.style.overflow = 'hidden'
-      } else {
-        document.body.style.overflow = ''
+    visible: {
+      immediate: true,
+      handler(newVal) {
+        if (typeof document === 'undefined') return
+        if (newVal) {
+          document.body.style.overflow = 'hidden'
+          document.addEventListener('keydown', this.onKeydown)
+        } else {
+          document.body.style.overflow = ''
+          document.removeEventListener('keydown', this.onKeydown)
+        }
       }
     }
   },
   beforeUnmount() {
     document.body.style.overflow = ''
+    document.removeEventListener('keydown', this.onKeydown)
   }
 }
 </script>

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -1,0 +1,103 @@
+# Composants UI de base (`src/components/ui/`)
+
+Briques d'interface réutilisables, sans logique métier. Elles encapsulent
+l'apparence et le comportement transverses (overlay, focus, états) pour que les
+vues n'aient plus à les réimplémenter. Objectif : **réutilisabilité + DRY**
+(cf. `PRODUCTION_STANDARDS.md`).
+
+Toutes adoptent le patron de composant englobant Vue 3 :
+`inheritAttrs: false` + `v-bind="$attrs"` sur l'élément racine pertinent, pour
+que les attributs non déclarés (`class`, `id`, `aria-*`, `data-*`, écouteurs
+natifs) traversent jusqu'au bon nœud du DOM sans prop dédiée.
+
+---
+
+## `Modal.vue`
+
+Fenêtre modale avec overlay, verrouillage du défilement et fermeture par ✕ /
+clic extérieur / `Échap`.
+
+### Props
+
+| Prop         | Type    | Défaut | Description |
+|--------------|---------|--------|-------------|
+| `modelValue` | Boolean | `false`| Ouverture (`v-model`). |
+| `title`      | String  | `''`   | Titre optionnel. Si vide et pas de slot `header`, aucun en-tête textuel n'est rendu (le ✕ reste). |
+| `size`       | String  | `'md'` | `sm` \| `md` \| `lg` \| `xl`. L'alias historique `medium` est normalisé en `md`. |
+
+### Événements
+
+| Événement            | Charge   | Émis quand |
+|----------------------|----------|------------|
+| `update:modelValue`  | `false`  | Fermeture via ✕, clic sur l'overlay ou `Échap`. |
+
+### Slots
+
+| Slot      | Rôle |
+|-----------|------|
+| (défaut)  | Corps de la modale. |
+| `header`  | Remplace l'en-tête par défaut. **Le bouton ✕ reste toujours rendu**, hors du slot. |
+| `footer`  | Pied de modale (boutons d'action). Non rendu si absent. |
+
+### `$attrs`
+
+`inheritAttrs: false` : `class`, `id`, `data-*`, `aria-*` se posent sur
+`.modal-container` (et non sur la racine `<transition>`).
+
+### Exemple
+
+```vue
+<Modal v-model="open" title="Modifier" size="lg" class="modal-edition">
+  <FormulaireEdition />
+  <template #footer>
+    <BaseButton variant="secondary" @click="open = false">Annuler</BaseButton>
+    <BaseButton variant="primary" :loading="saving" @click="save">Enregistrer</BaseButton>
+  </template>
+</Modal>
+```
+
+---
+
+## `BaseButton.vue`
+
+Bouton de base avec variantes visuelles et états `loading` / `disabled`.
+En `loading`, un spinner remplace l'icône et le bouton est automatiquement
+désactivé (anti double-soumission).
+
+### Props
+
+| Prop       | Type    | Défaut      | Description |
+|------------|---------|-------------|-------------|
+| `variant`  | String  | `'primary'` | `primary` \| `secondary` \| `danger` \| `ghost`. |
+| `loading`  | Boolean | `false`     | Affiche le spinner et désactive le bouton. |
+| `disabled` | Boolean | `false`     | Désactive le bouton. |
+| `type`     | String  | `'button'`  | `button` \| `submit` \| `reset` (lié explicitement, jamais via `$attrs`). |
+
+### Slots
+
+| Slot     | Rôle |
+|----------|------|
+| (défaut) | Libellé du bouton. |
+| `icon`   | Icône affichée avant le libellé (masquée pendant `loading`). |
+
+### `$attrs`
+
+`inheritAttrs: false` : les écouteurs natifs (`@click`), `data-*`, `aria-*`
+traversent jusqu'au `<button>`.
+
+### Exemple
+
+```vue
+<BaseButton variant="danger" :loading="deleting" @click="remove">
+  <template #icon><IconTrash /></template>
+  Supprimer
+</BaseButton>
+```
+
+---
+
+## Tests
+
+`tests/unit/Modal.test.js` et `tests/unit/BaseButton.test.js`
+(`@vue/test-utils` + Vitest) : slots, événements, états, `size`, traversée
+`$attrs`. Lancer : `npm run test`.

--- a/tests/unit/BaseButton.test.js
+++ b/tests/unit/BaseButton.test.js
@@ -1,0 +1,62 @@
+/**
+ * Tests du composant BaseButton (#25) — src/components/ui/BaseButton.vue
+ * Variantes, états loading/disabled, type explicite, slots label/icon, $attrs.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import BaseButton from '@/components/ui/BaseButton.vue'
+
+describe('ui/BaseButton (#25)', () => {
+  it('rend le label via slot par défaut', () => {
+    const w = mount(BaseButton, { slots: { default: 'Enregistrer' } })
+    expect(w.find('.base-btn__label').text()).toBe('Enregistrer')
+  })
+
+  it('variant primary par défaut', () => {
+    const w = mount(BaseButton, { slots: { default: 'X' } })
+    expect(w.find('button').classes()).toContain('base-btn--primary')
+  })
+
+  it('variant danger appliquée', () => {
+    const w = mount(BaseButton, { props: { variant: 'danger' }, slots: { default: 'X' } })
+    expect(w.find('button').classes()).toContain('base-btn--danger')
+  })
+
+  it('type button par défaut, submit respecté', () => {
+    expect(mount(BaseButton, { slots: { default: 'X' } }).find('button').attributes('type')).toBe('button')
+    const w = mount(BaseButton, { props: { type: 'submit' }, slots: { default: 'X' } })
+    expect(w.find('button').attributes('type')).toBe('submit')
+  })
+
+  it('loading : spinner affiché, bouton désactivé, classe is-loading', () => {
+    const w = mount(BaseButton, { props: { loading: true }, slots: { default: 'X' } })
+    expect(w.find('.base-btn__spinner').exists()).toBe(true)
+    expect(w.find('button').attributes('disabled')).toBeDefined()
+    expect(w.find('button').classes()).toContain('is-loading')
+  })
+
+  it('disabled : bouton désactivé', () => {
+    const w = mount(BaseButton, { props: { disabled: true }, slots: { default: 'X' } })
+    expect(w.find('button').attributes('disabled')).toBeDefined()
+  })
+
+  it('slot icon rendu quand pas en loading', () => {
+    const w = mount(BaseButton, { slots: { default: 'X', icon: '<svg class="ic"></svg>' } })
+    expect(w.find('.base-btn__icon .ic').exists()).toBe(true)
+  })
+
+  it('clic émis quand actif, bloqué quand disabled', async () => {
+    const actif = mount(BaseButton, { slots: { default: 'X' } })
+    await actif.find('button').trigger('click')
+    expect(actif.emitted('click')).toBeTruthy()
+
+    const inactif = mount(BaseButton, { props: { disabled: true }, slots: { default: 'X' } })
+    await inactif.find('button').trigger('click')
+    expect(inactif.emitted('click')).toBeFalsy()
+  })
+
+  it('$attrs : data-testid traverse vers le <button>', () => {
+    const w = mount(BaseButton, { attrs: { 'data-testid': 'save' }, slots: { default: 'X' } })
+    expect(w.find('button').attributes('data-testid')).toBe('save')
+  })
+})

--- a/tests/unit/Modal.test.js
+++ b/tests/unit/Modal.test.js
@@ -1,0 +1,75 @@
+/**
+ * Tests du composant Modal enrichi (#25) — src/components/ui/Modal.vue
+ * Premiers tests de montage (@vue/test-utils) : slots header/body/footer,
+ * fermeture ✕/overlay/Échap, scroll-lock, prop size (+ alias medium), $attrs.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, afterEach } from 'vitest'
+import Modal from '@/components/ui/Modal.vue'
+
+afterEach(() => { document.body.style.overflow = '' })
+
+function mountModal(props = {}, slots = {}) {
+  return mount(Modal, { props: { modelValue: true, ...props }, slots })
+}
+
+describe('ui/Modal (#25)', () => {
+  it('rend title + body', () => {
+    const w = mountModal({ title: 'Titre' }, { default: '<p>corps</p>' })
+    expect(w.find('.modal-title').text()).toBe('Titre')
+    expect(w.find('.modal-body').html()).toContain('corps')
+  })
+
+  it('title optionnelle → pas de .modal-title, ✕ toujours présent', () => {
+    const w = mountModal()
+    expect(w.find('.modal-title').exists()).toBe(false)
+    expect(w.find('.modal-close-btn').exists()).toBe(true)
+  })
+
+  it('slot header remplace l\'en-tête mais garde le ✕', () => {
+    const w = mountModal({ title: 'X' }, { header: '<div class="custom-h">H</div>' })
+    expect(w.find('.custom-h').exists()).toBe(true)
+    expect(w.find('.modal-close-btn').exists()).toBe(true)
+  })
+
+  it('footer rendu uniquement si slot fourni', () => {
+    expect(mountModal().find('.modal-footer').exists()).toBe(false)
+    expect(mountModal({}, { footer: '<button>OK</button>' }).find('.modal-footer').exists()).toBe(true)
+  })
+
+  it('✕ émet update:modelValue=false', async () => {
+    const w = mountModal()
+    await w.find('.modal-close-btn').trigger('click')
+    expect(w.emitted('update:modelValue')[0]).toEqual([false])
+  })
+
+  it('clic sur l\'overlay émet false', async () => {
+    const w = mountModal()
+    await w.find('.modal-overlay').trigger('click')
+    expect(w.emitted('update:modelValue')[0]).toEqual([false])
+  })
+
+  it('Échap émet false', async () => {
+    const w = mountModal()
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await w.vm.$nextTick()
+    expect(w.emitted('update:modelValue')[0]).toEqual([false])
+    w.unmount()
+  })
+
+  it('scroll-lock du body quand visible', () => {
+    mountModal()
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('size : md par défaut, alias medium → md, lg respecté', () => {
+    expect(mountModal().find('.modal-container').classes()).toContain('modal-md')
+    expect(mountModal({ size: 'medium' }).find('.modal-container').classes()).toContain('modal-md')
+    expect(mountModal({ size: 'lg' }).find('.modal-container').classes()).toContain('modal-lg')
+  })
+
+  it('$attrs : une classe custom traverse vers .modal-container', () => {
+    const w = mountModal({ class: 'ma-classe-custom' })
+    expect(w.find('.modal-container').classes()).toContain('ma-classe-custom')
+  })
+})


### PR DESCRIPTION
## Objectif (#25)

Renforcer la couche de composants UI réutilisables (`src/components/ui/`) : enrichir `Modal` et introduire un `BaseButton` de base, pour éliminer la duplication de boutons dans les modals (DRY / réutilisabilité, cf. PRODUCTION_STANDARDS.md).

## Changements

**`Modal.vue`** (enrichi)
- `title` désormais **optionnelle** (défaut `''`)
- Prop `size` : `sm` / `md` / `lg` / `xl` (+ alias historique `medium` → `md`)
- Slot `header` (le bouton ✕ reste **invariant**, hors slot)
- Fermeture au clavier (`Échap`) + cleanup du listener au démontage
- Patron composant englobant : `inheritAttrs:false` + `v-bind="$attrs"` sur `.modal-container`

**`BaseButton.vue`** (nouveau, `<script setup>`)
- Variantes : `primary` / `secondary` / `danger` / `ghost`
- États `loading` (spinner + désactivation anti double-soumission) / `disabled`
- `type` lié explicitement (`button`/`submit`/`reset`), `$attrs` sur le `<button>`
- Slots `default` (label) + `icon`

**Migrations** — `QuickAddTeacherModal`, `GenerateReportModal`, `QuickCreateClasseModal` : `size="medium"`→`"md"`, footers migrés vers `BaseButton`, CSS de bouton mort supprimé.

**Doc + tests** — `src/components/ui/README.md` (API des 2 composants) ; tests unitaires `Modal.test.js` (10) + `BaseButton.test.js` (9).

## Vérifications
- ✅ `npm run test` → 155/155 (12 fichiers)
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK (warning de taille de chunk préexistant, relève de #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)