### PR TITLE
refactor(services): split lms.js par domaine — #26 PR2/3

### DIFF
--- a/src/services/lms.js
+++ b/src/services/lms.js
@@ -1,472 +1,53 @@
-import api from './api'
+/**
+ * Baril LMS — point d'entrée rétro-compatible (#26).
+ *
+ * lms.js couvrait 6 domaines en 466 lignes (violation SRP / §5 ≤ 300 l.).
+ * Il est désormais découpé par domaine, miroir du split backend
+ * (LMSDataController → 7 controllers) :
+ *   - lmsClasses.js        — classes enrichies
+ *   - lmsMatieres.js       — matières enrichies
+ *   - lmsTeachers.js       — enseignants / dashboard
+ *   - lmsSeances.js        — séances & présences
+ *   - lmsVisio.js          — cycle de vie visio
+ *   - lmsNotifications.js  — préférences & rappels de séance
+ *
+ * Frontière (#26) : lms* = données ENRICHIES `/lms/*` ; klassciService
+ * (src/services/klassci.js) = proxy BRUT KLASSCI `/proxy/*`.
+ *
+ * Compatibilité : `lmsService` (named + default) reste un objet unique
+ * composant tous les domaines, afin de ne casser aucun des appelants
+ * existants. Le code NOUVEAU peut importer directement le service de
+ * domaine (ex. `import { lmsVisioService } from '@/services/lmsVisio'`).
+ *
+ * RETIRÉ (#26) : lmsService.getClasses (`/proxy/classes`) — doublon strict de
+ * klassciService.getClasses. Les appelants utilisent désormais klassciService.
+ */
+import { lmsClassesService } from './lmsClasses'
+import { lmsMatieresService } from './lmsMatieres'
+import { lmsTeachersService } from './lmsTeachers'
+import { lmsSeancesService } from './lmsSeances'
+import { lmsVisioService } from './lmsVisio'
+import { lmsNotificationsService } from './lmsNotifications'
+
+// Réexport des services de domaine (imports granulaires recommandés à terme).
+export { lmsClassesService } from './lmsClasses'
+export { lmsMatieresService } from './lmsMatieres'
+export { lmsTeachersService } from './lmsTeachers'
+export { lmsSeancesService } from './lmsSeances'
+export { lmsVisioService } from './lmsVisio'
+export { lmsNotificationsService } from './lmsNotifications'
 
 /**
- * Service LMS — données ENRICHIES (endpoints `/lms/*`).
- * Ces endpoints combinent les données KLASSCI avec les données locales LMS
- * (leçons, présences, visio, stats…).
- *
- * Frontière d'usage (#26) :
- *  - lmsService (CE fichier) : données enrichies LMS via `/lms/*`.
- *  - klassciService (src/services/klassci.js) : proxy BRUT KLASSCI via `/proxy/*`.
- * Pour une donnée enrichie → lmsService ; pour la donnée KLASSCI brute → klassciService.
- *
- * IMPORTANT: L'intercepteur dans api.js (ligne 31) retourne déjà response.data
- * Donc on ne doit PAS faire .data une deuxième fois ici
+ * Façade rétro-compatible : agrège les méthodes de tous les domaines.
+ * (Aucune collision de nom entre domaines — vérifié #26.)
  */
 export const lmsService = {
-  /**
-   * Récupérer détails complets d'une classe (KLASSCI + données LMS)
-   * @param {number} classeId
-   * @returns {Promise<Object>}
-   */
-  async getClasseDetails(classeId) {
-    try {
-      // api.get retourne déjà response.data grâce à l'intercepteur
-      return await api.get(`/lms/classes/${classeId}`)
-    } catch (error) {
-      console.error('Erreur récupération classe enrichie:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer les étudiants d'une classe
-   * @param {number} classeId
-   * @returns {Promise<Object>} { success, data: { etudiants } }
-   */
-  async getClasseEtudiants(classeId) {
-    try {
-      return await api.get(`/lms/classes/${classeId}/etudiants`)
-    } catch (error) {
-      console.error('Erreur récupération étudiants classe:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer détails complets d'une matière (KLASSCI + Lessons LMS + Séances + Évaluations)
-   * @param {number} matiereId
-   * @returns {Promise<Object>} { success, data: { matiere, lessons, seances_programmees, evaluations_programmees, statistiques } }
-   */
-  async getMatiereDetails(matiereId) {
-    try {
-      // api.get retourne déjà response.data grâce à l'intercepteur
-      return await api.get(`/lms/matieres/${matiereId}`)
-    } catch (error) {
-      console.error('Erreur récupération matière enrichie:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer toutes les classes (via proxy KLASSCI)
-   * @returns {Promise<Object>} { success, data: [...] }
-   */
-  async getClasses() {
-    try {
-      return await api.get('/proxy/classes')
-    } catch (error) {
-      console.error('Erreur récupération classes:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer tous les enseignants (via LMS + KLASSCI)
-   * @param {boolean} withDetails - Inclure détails complets (classes, matières, stats)
-   * @returns {Promise<Object>} { success, data: [...] }
-   */
-  async getEnseignants(withDetails = false) {
-    try {
-      const url = withDetails ? '/lms/enseignants?with_details=true' : '/lms/enseignants'
-      return await api.get(url)
-    } catch (error) {
-      console.error('Erreur récupération enseignants:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer séances à venir avec filtres
-   * @param {Object} params - { days, teacher_id, classe_id }
-   * @returns {Promise<Array>}
-   */
-  async getUpcomingSeances(params = {}) {
-    try {
-      return await api.get('/lms/seances/upcoming', { params })
-    } catch (error) {
-      console.error('Erreur récupération séances à venir:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer détails complets d'une séance (avec infos visio et fenêtre temporelle)
-   * @param {number} seanceId
-   * @returns {Promise<Object>} { seance, visio, participants }
-   */
-  async getSeanceDetails(seanceId) {
-    try {
-      return await api.get(`/lms/seances/${seanceId}/details`)
-    } catch (error) {
-      console.error('Erreur récupération détails séance:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer participants autorisés d'une séance
-   * @param {number} seanceId
-   * @returns {Promise<Object>} { teacher, students, total }
-   */
-  async getSeanceParticipants(seanceId) {
-    try {
-      return await api.get(`/lms/seances/${seanceId}/participants`)
-    } catch (error) {
-      console.error('Erreur récupération participants séance:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Valider l'accès d'un participant à une séance
-   * @param {number} seanceId
-   * @param {number} userId
-   * @returns {Promise<Object>} { authorized, reason, user_role, seance }
-   */
-  async validateParticipant(seanceId, userId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/validate-participant`, {
-        user_id: userId
-      })
-    } catch (error) {
-      console.error('Erreur validation participant:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Toggle visio pour une séance (coordinateurs uniquement)
-   * @param {number} seanceId
-   * @param {boolean} enabled
-   * @param {string} visioType - 'jitsi'|'zoom'|'teams'|'bbb'
-   * @returns {Promise<Object>}
-   */
-  async toggleVisio(seanceId, enabled, visioType = 'jitsi') {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/toggle-visio`, {
-        enabled,
-        visio_type: visioType
-      })
-    } catch (error) {
-      console.error('Erreur toggle visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Synchroniser attendances depuis session vidéo
-   * @param {number} seanceId
-   * @param {string} date - 'YYYY-MM-DD'
-   * @param {Array} participants - [{ user_id, joined_at, left_at, duration_minutes }]
-   * @returns {Promise<Object>}
-   */
-  async syncVideoAttendances(seanceId, date, participants) {
-    try {
-      return await api.post('/lms/attendances/from-video-session', {
-        seance_cours_id: seanceId,
-        date,
-        participants
-      })
-    } catch (error) {
-      console.error('Erreur sync attendances vidéo:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer préférences de notification d'un utilisateur
-   * @param {number} userId
-   * @returns {Promise<Object>}
-   */
-  async getNotificationPreferences(userId) {
-    try {
-      return await api.get(`/lms/notifications/preferences/${userId}`)
-    } catch (error) {
-      console.error('Erreur récupération préférences notifications:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Envoyer rappel de séance
-   * @param {Object} data - { seance_id, user_ids, reminder_time }
-   * @returns {Promise<Object>}
-   */
-  async sendSessionReminder(data) {
-    try {
-      return await api.post('/lms/notifications/send-session-reminder', data)
-    } catch (error) {
-      console.error('Erreur envoi rappel séance:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer les séances de l'enseignant connecté
-   * @param {boolean} forceRefresh - Si true, bypass le cache KLASSCI
-   * @returns {Promise<Object>} { success, data: [...] }
-   */
-  async getMyTeachingSeances(forceRefresh = false) {
-    try {
-      const params = forceRefresh ? { refresh: true } : {}
-      return await api.get('/lms/seances/my-teaching', { params })
-    } catch (error) {
-      console.error('Erreur récupération mes séances enseignant:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer les séances/cours de l'étudiant connecté
-   * @param {boolean} forceRefresh - Si true, bypass le cache KLASSCI
-   * @returns {Promise<Object>} { success, data: [...] }
-   */
-  async getMyClassesSeances(forceRefresh = false) {
-    try {
-      const params = forceRefresh ? { refresh: true } : {}
-      return await api.get('/lms/seances/my-classes', { params })
-    } catch (error) {
-      console.error('Erreur récupération mes cours étudiant:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Activer la visio pour une séance (enseignant)
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async activateVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/activate-visio`)
-    } catch (error) {
-      console.error('Erreur activation visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Désactiver la visio pour une séance (enseignant)
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async deactivateVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/deactivate-visio`)
-    } catch (error) {
-      console.error('Erreur désactivation visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Démarrer la visio (enseignant)
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async startVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/start-visio`)
-    } catch (error) {
-      console.error('Erreur démarrage visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Terminer la visio (enseignant)
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async endVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/end-visio`)
-    } catch (error) {
-      console.error('Erreur fin visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Rejoindre une visio (étudiant)
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async joinVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/join`)
-    } catch (error) {
-      console.error('Erreur rejoindre visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Enregistrer la sortie d'un participant de la visio
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async leaveVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/leave`)
-    } catch (error) {
-      console.error('Erreur leave visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Envoyer un heartbeat (ping d'activité) pour le participant
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async heartbeatVisio(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/heartbeat`)
-    } catch (error) {
-      console.error('Erreur heartbeat visio:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer la liste des participants à une visio (OPTION B)
-   * @param {number} seanceId
-   * @returns {Promise<Object>}
-   */
-  async getVisioParticipants(seanceId) {
-    try {
-      // Participants CONNECTÉS (route renommée backend). NE PAS confondre avec
-      // getSeanceParticipants → /participants (participants AUTORISÉS).
-      return await api.get(`/lms/seances/${seanceId}/visio-participants`)
-    } catch (error) {
-      console.error('Erreur récupération participants:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer le dashboard enseignant (matières, classes, stats)
-   * @returns {Promise<Object>} { success, data: { matieres, classes, stats } }
-   */
-  async getTeacherDashboard() {
-    try {
-      return await api.get('/proxy/me/teacher-dashboard')
-    } catch (error) {
-      console.error('Erreur récupération dashboard enseignant:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupérer les matières de l'enseignant avec statistiques enrichies
-   * @returns {Promise<Object>} { success, data: [...] }
-   */
-  async getMyMatieres() {
-    try {
-      return await api.get('/lms/teacher/my-matieres')
-    } catch (error) {
-      console.error('Erreur récupération mes matières:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Masquer une séance (étudiant uniquement)
-   * @param {number} seanceId
-   * @returns {Promise<Object>} { success, message }
-   */
-  async hideSeance(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/hide`)
-    } catch (error) {
-      console.error('Erreur masquage séance:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Réafficher une séance (étudiant uniquement)
-   * @param {number} seanceId
-   * @returns {Promise<Object>} { success, message }
-   */
-  async unhideSeance(seanceId) {
-    try {
-      return await api.post(`/lms/seances/${seanceId}/unhide`)
-    } catch (error) {
-      console.error('Erreur réaffichage séance:', error)
-      throw error
-    }
-  }
-,
-
-  /**
-   * Récupérer l'historique des présences (accessible même si séances archivées)
-   * @param {Object} params - Paramètres de filtrage { page, per_page, date_from, date_to, seance_id }
-   * @returns {Promise<Object>} { success, data: [...], pagination: {...} }
-   */
-  async getAttendanceHistory(params = {}) {
-    try {
-      return await api.get('/lms/attendance/history', { params })
-    } catch (error) {
-      console.error('Erreur récupération historique présences:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupère l'historique des séances avec statistiques de présences
-   * @param {Object} params - Paramètres de requête (page, per_page, date_from, date_to, search)
-   * @returns {Promise<Object>} { success, data: [...], pagination: {...} }
-   */
-  async getSeancesHistory(params = {}) {
-    try {
-      return await api.get('/lms/seances/history', { params })
-    } catch (error) {
-      console.error('Erreur récupération historique séances:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Récupère les détails des présences pour une séance spécifique
-   * @param {Number} seanceId - ID de la séance
-   * @returns {Promise<Object>} { success, seance: {...}, statistics: {...}, attendances: [...] }
-   */
-  async getSeanceAttendances(seanceId) {
-    try {
-      return await api.get(`/lms/seances/${seanceId}/attendances`)
-    } catch (error) {
-      console.error('Erreur récupération présences séance:', error)
-      throw error
-    }
-  },
-
-  /**
-   * Supprime une séance
-   * @param {Number} seanceId - ID de la séance
-   * @returns {Promise<Object>}
-   */
-  async deleteSeance(seanceId) {
-    try {
-      return await api.delete(`/lms/seances/${seanceId}`)
-    } catch (error) {
-      console.error('Erreur suppression séance:', error)
-      throw error
-    }
-  }
-
+  ...lmsClassesService,
+  ...lmsMatieresService,
+  ...lmsTeachersService,
+  ...lmsSeancesService,
+  ...lmsVisioService,
+  ...lmsNotificationsService
 }
 
 export default lmsService

--- a/src/services/lmsClasses.js
+++ b/src/services/lmsClasses.js
@@ -1,0 +1,40 @@
+import api from './api'
+
+/**
+ * Service LMS — domaine CLASSES (données enrichies `/lms/classes/*`).
+ * Frontière (#26) : données enrichies LMS. Pour la liste brute des classes
+ * KLASSCI, utiliser klassciService.getClasses (`/proxy/classes`).
+ *
+ * NOTE intercepteur : api.js retourne déjà response.data (ne pas refaire .data ici).
+ */
+export const lmsClassesService = {
+  /**
+   * Récupérer détails complets d'une classe (KLASSCI + données LMS)
+   * @param {number} classeId
+   * @returns {Promise<Object>}
+   */
+  async getClasseDetails(classeId) {
+    try {
+      return await api.get(`/lms/classes/${classeId}`)
+    } catch (error) {
+      console.error('Erreur récupération classe enrichie:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer les étudiants d'une classe
+   * @param {number} classeId
+   * @returns {Promise<Object>} { success, data: { etudiants } }
+   */
+  async getClasseEtudiants(classeId) {
+    try {
+      return await api.get(`/lms/classes/${classeId}/etudiants`)
+    } catch (error) {
+      console.error('Erreur récupération étudiants classe:', error)
+      throw error
+    }
+  }
+}
+
+export default lmsClassesService

--- a/src/services/lmsMatieres.js
+++ b/src/services/lmsMatieres.js
@@ -1,0 +1,39 @@
+import api from './api'
+
+/**
+ * Service LMS — domaine MATIÈRES (données enrichies `/lms/matieres/*`, `/lms/teacher/*`).
+ * Source UNIQUE des détails matière enrichis (#26).
+ *
+ * NOTE intercepteur : api.js retourne déjà response.data (ne pas refaire .data ici).
+ */
+export const lmsMatieresService = {
+  /**
+   * Récupérer détails complets d'une matière
+   * (KLASSCI + Lessons LMS + Séances + Évaluations)
+   * @param {number} matiereId
+   * @returns {Promise<Object>} { success, data: { matiere, lessons, seances_programmees, evaluations_programmees, statistiques } }
+   */
+  async getMatiereDetails(matiereId) {
+    try {
+      return await api.get(`/lms/matieres/${matiereId}`)
+    } catch (error) {
+      console.error('Erreur récupération matière enrichie:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer les matières de l'enseignant avec statistiques enrichies
+   * @returns {Promise<Object>} { success, data: [...] }
+   */
+  async getMyMatieres() {
+    try {
+      return await api.get('/lms/teacher/my-matieres')
+    } catch (error) {
+      console.error('Erreur récupération mes matières:', error)
+      throw error
+    }
+  }
+}
+
+export default lmsMatieresService

--- a/src/services/lmsNotifications.js
+++ b/src/services/lmsNotifications.js
@@ -1,0 +1,40 @@
+import api from './api'
+
+/**
+ * Service LMS — domaine NOTIFICATIONS de séance (`/lms/notifications/*`).
+ * Préférences et rappels liés aux séances. Le client notifications général
+ * (cloche, mark-as-read) reste src/services/notifications.js.
+ *
+ * NOTE intercepteur : api.js retourne déjà response.data (ne pas refaire .data ici).
+ */
+export const lmsNotificationsService = {
+  /**
+   * Récupérer préférences de notification d'un utilisateur
+   * @param {number} userId
+   * @returns {Promise<Object>}
+   */
+  async getNotificationPreferences(userId) {
+    try {
+      return await api.get(`/lms/notifications/preferences/${userId}`)
+    } catch (error) {
+      console.error('Erreur récupération préférences notifications:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Envoyer rappel de séance
+   * @param {Object} data - { seance_id, user_ids, reminder_time }
+   * @returns {Promise<Object>}
+   */
+  async sendSessionReminder(data) {
+    try {
+      return await api.post('/lms/notifications/send-session-reminder', data)
+    } catch (error) {
+      console.error('Erreur envoi rappel séance:', error)
+      throw error
+    }
+  }
+}
+
+export default lmsNotificationsService

--- a/src/services/lmsSeances.js
+++ b/src/services/lmsSeances.js
@@ -1,0 +1,206 @@
+import api from './api'
+
+/**
+ * Service LMS — domaine SÉANCES & PRÉSENCES (`/lms/seances/*`, `/lms/attendance*`).
+ * Couvre le cycle de vie des séances (hors visio, cf. lmsVisioService) :
+ * consultation, participants autorisés, présences, historique, suppression.
+ *
+ * NOTE intercepteur : api.js retourne déjà response.data (ne pas refaire .data ici).
+ */
+export const lmsSeancesService = {
+  /**
+   * Récupérer séances à venir avec filtres
+   * @param {Object} params - { days, teacher_id, classe_id }
+   * @returns {Promise<Array>}
+   */
+  async getUpcomingSeances(params = {}) {
+    try {
+      return await api.get('/lms/seances/upcoming', { params })
+    } catch (error) {
+      console.error('Erreur récupération séances à venir:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer détails complets d'une séance (avec infos visio et fenêtre temporelle)
+   * @param {number} seanceId
+   * @returns {Promise<Object>} { seance, visio, participants }
+   */
+  async getSeanceDetails(seanceId) {
+    try {
+      return await api.get(`/lms/seances/${seanceId}/details`)
+    } catch (error) {
+      console.error('Erreur récupération détails séance:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer participants AUTORISÉS d'une séance.
+   * NE PAS confondre avec lmsVisioService.getVisioParticipants (participants CONNECTÉS).
+   * @param {number} seanceId
+   * @returns {Promise<Object>} { teacher, students, total }
+   */
+  async getSeanceParticipants(seanceId) {
+    try {
+      return await api.get(`/lms/seances/${seanceId}/participants`)
+    } catch (error) {
+      console.error('Erreur récupération participants séance:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Valider l'accès d'un participant à une séance
+   * @param {number} seanceId
+   * @param {number} userId
+   * @returns {Promise<Object>} { authorized, reason, user_role, seance }
+   */
+  async validateParticipant(seanceId, userId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/validate-participant`, {
+        user_id: userId
+      })
+    } catch (error) {
+      console.error('Erreur validation participant:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Synchroniser attendances depuis session vidéo
+   * @param {number} seanceId
+   * @param {string} date - 'YYYY-MM-DD'
+   * @param {Array} participants - [{ user_id, joined_at, left_at, duration_minutes }]
+   * @returns {Promise<Object>}
+   */
+  async syncVideoAttendances(seanceId, date, participants) {
+    try {
+      return await api.post('/lms/attendances/from-video-session', {
+        seance_cours_id: seanceId,
+        date,
+        participants
+      })
+    } catch (error) {
+      console.error('Erreur sync attendances vidéo:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer les séances de l'enseignant connecté
+   * @param {boolean} forceRefresh - Si true, bypass le cache KLASSCI
+   * @returns {Promise<Object>} { success, data: [...] }
+   */
+  async getMyTeachingSeances(forceRefresh = false) {
+    try {
+      const params = forceRefresh ? { refresh: true } : {}
+      return await api.get('/lms/seances/my-teaching', { params })
+    } catch (error) {
+      console.error('Erreur récupération mes séances enseignant:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer les séances/cours de l'étudiant connecté
+   * @param {boolean} forceRefresh - Si true, bypass le cache KLASSCI
+   * @returns {Promise<Object>} { success, data: [...] }
+   */
+  async getMyClassesSeances(forceRefresh = false) {
+    try {
+      const params = forceRefresh ? { refresh: true } : {}
+      return await api.get('/lms/seances/my-classes', { params })
+    } catch (error) {
+      console.error('Erreur récupération mes cours étudiant:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Masquer une séance (étudiant uniquement)
+   * @param {number} seanceId
+   * @returns {Promise<Object>} { success, message }
+   */
+  async hideSeance(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/hide`)
+    } catch (error) {
+      console.error('Erreur masquage séance:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Réafficher une séance (étudiant uniquement)
+   * @param {number} seanceId
+   * @returns {Promise<Object>} { success, message }
+   */
+  async unhideSeance(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/unhide`)
+    } catch (error) {
+      console.error('Erreur réaffichage séance:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer l'historique des présences (accessible même si séances archivées)
+   * @param {Object} params - { page, per_page, date_from, date_to, seance_id }
+   * @returns {Promise<Object>} { success, data: [...], pagination: {...} }
+   */
+  async getAttendanceHistory(params = {}) {
+    try {
+      return await api.get('/lms/attendance/history', { params })
+    } catch (error) {
+      console.error('Erreur récupération historique présences:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupère l'historique des séances avec statistiques de présences
+   * @param {Object} params - { page, per_page, date_from, date_to, search }
+   * @returns {Promise<Object>} { success, data: [...], pagination: {...} }
+   */
+  async getSeancesHistory(params = {}) {
+    try {
+      return await api.get('/lms/seances/history', { params })
+    } catch (error) {
+      console.error('Erreur récupération historique séances:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupère les détails des présences pour une séance spécifique
+   * @param {Number} seanceId - ID de la séance
+   * @returns {Promise<Object>} { success, seance: {...}, statistics: {...}, attendances: [...] }
+   */
+  async getSeanceAttendances(seanceId) {
+    try {
+      return await api.get(`/lms/seances/${seanceId}/attendances`)
+    } catch (error) {
+      console.error('Erreur récupération présences séance:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Supprime une séance
+   * @param {Number} seanceId - ID de la séance
+   * @returns {Promise<Object>}
+   */
+  async deleteSeance(seanceId) {
+    try {
+      return await api.delete(`/lms/seances/${seanceId}`)
+    } catch (error) {
+      console.error('Erreur suppression séance:', error)
+      throw error
+    }
+  }
+}
+
+export default lmsSeancesService

--- a/src/services/lmsTeachers.js
+++ b/src/services/lmsTeachers.js
@@ -1,0 +1,38 @@
+import api from './api'
+
+/**
+ * Service LMS — domaine ENSEIGNANTS (`/lms/enseignants`, dashboard enseignant).
+ *
+ * NOTE intercepteur : api.js retourne déjà response.data (ne pas refaire .data ici).
+ */
+export const lmsTeachersService = {
+  /**
+   * Récupérer tous les enseignants (via LMS + KLASSCI)
+   * @param {boolean} withDetails - Inclure détails complets (classes, matières, stats)
+   * @returns {Promise<Object>} { success, data: [...] }
+   */
+  async getEnseignants(withDetails = false) {
+    try {
+      const url = withDetails ? '/lms/enseignants?with_details=true' : '/lms/enseignants'
+      return await api.get(url)
+    } catch (error) {
+      console.error('Erreur récupération enseignants:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer le dashboard enseignant (matières, classes, stats)
+   * @returns {Promise<Object>} { success, data: { matieres, classes, stats } }
+   */
+  async getTeacherDashboard() {
+    try {
+      return await api.get('/proxy/me/teacher-dashboard')
+    } catch (error) {
+      console.error('Erreur récupération dashboard enseignant:', error)
+      throw error
+    }
+  }
+}
+
+export default lmsTeachersService

--- a/src/services/lmsVisio.js
+++ b/src/services/lmsVisio.js
@@ -1,0 +1,143 @@
+import api from './api'
+
+/**
+ * Service LMS — domaine VISIO (`/lms/seances/{id}/{toggle,activate,...}-visio`, join/leave/heartbeat).
+ * Cycle de vie de la visioconférence d'une séance.
+ *
+ * NOTE intercepteur : api.js retourne déjà response.data (ne pas refaire .data ici).
+ */
+export const lmsVisioService = {
+  /**
+   * Toggle visio pour une séance (coordinateurs uniquement)
+   * @param {number} seanceId
+   * @param {boolean} enabled
+   * @param {string} visioType - 'jitsi'|'zoom'|'teams'|'bbb'
+   * @returns {Promise<Object>}
+   */
+  async toggleVisio(seanceId, enabled, visioType = 'jitsi') {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/toggle-visio`, {
+        enabled,
+        visio_type: visioType
+      })
+    } catch (error) {
+      console.error('Erreur toggle visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Activer la visio pour une séance (enseignant)
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async activateVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/activate-visio`)
+    } catch (error) {
+      console.error('Erreur activation visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Désactiver la visio pour une séance (enseignant)
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async deactivateVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/deactivate-visio`)
+    } catch (error) {
+      console.error('Erreur désactivation visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Démarrer la visio (enseignant)
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async startVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/start-visio`)
+    } catch (error) {
+      console.error('Erreur démarrage visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Terminer la visio (enseignant)
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async endVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/end-visio`)
+    } catch (error) {
+      console.error('Erreur fin visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Rejoindre une visio (étudiant)
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async joinVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/join`)
+    } catch (error) {
+      console.error('Erreur rejoindre visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Enregistrer la sortie d'un participant de la visio
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async leaveVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/leave`)
+    } catch (error) {
+      console.error('Erreur leave visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Envoyer un heartbeat (ping d'activité) pour le participant
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async heartbeatVisio(seanceId) {
+    try {
+      return await api.post(`/lms/seances/${seanceId}/heartbeat`)
+    } catch (error) {
+      console.error('Erreur heartbeat visio:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Récupérer la liste des participants CONNECTÉS à une visio.
+   * NE PAS confondre avec lmsSeancesService.getSeanceParticipants (participants AUTORISÉS).
+   * @param {number} seanceId
+   * @returns {Promise<Object>}
+   */
+  async getVisioParticipants(seanceId) {
+    try {
+      return await api.get(`/lms/seances/${seanceId}/visio-participants`)
+    } catch (error) {
+      console.error('Erreur récupération participants:', error)
+      throw error
+    }
+  }
+}
+
+export default lmsVisioService

--- a/src/views/coordinateur/SeanceManagement.vue
+++ b/src/views/coordinateur/SeanceManagement.vue
@@ -284,6 +284,7 @@ import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
 
 import lmsService from '@/services/lms'
+import { klassciService } from '@/services/klassci'
 import { readCache, writeCache, clearCache } from '@/services/cache'
 import { buildJitsiUrl } from '@/constants/visio'
 
@@ -339,12 +340,10 @@ const formatDate = (date) => {
 const loadClasses = async () => {
   try {
     console.log('[CLASSES] Chargement...')
-    const response = await lmsService.getClasses()
-
-    if (response && response.success) {
-      classes.value = response.data || []
-      console.log(`[OK] ${classes.value.length} classes chargées`)
-    }
+    // #26 : source unique des classes brutes = klassciService (/proxy/classes),
+    // qui renvoie directement le tableau (déballe response.data).
+    classes.value = await klassciService.getClasses()
+    console.log(`[OK] ${classes.value.length} classes chargées`)
   } catch (err) {
     console.error('[ERREUR] Chargement classes:', err)
   }

--- a/tests/unit/lmsServiceSplit.test.js
+++ b/tests/unit/lmsServiceSplit.test.js
@@ -1,0 +1,67 @@
+/**
+ * Tests du split lms.js par domaine (#26 PR2).
+ * Garantit que la façade rétro-compatible `lmsService` expose bien toutes les
+ * méthodes des modules domaine, que chaque module porte sa responsabilité, et
+ * que le doublon getClasses a bien été retiré.
+ */
+import { describe, it, expect } from 'vitest'
+import lmsService, {
+  lmsClassesService,
+  lmsMatieresService,
+  lmsTeachersService,
+  lmsSeancesService,
+  lmsVisioService,
+  lmsNotificationsService
+} from '@/services/lms'
+
+const DOMAINS = {
+  classes: { svc: lmsClassesService, methods: ['getClasseDetails', 'getClasseEtudiants'] },
+  matieres: { svc: lmsMatieresService, methods: ['getMatiereDetails', 'getMyMatieres'] },
+  teachers: { svc: lmsTeachersService, methods: ['getEnseignants', 'getTeacherDashboard'] },
+  seances: {
+    svc: lmsSeancesService,
+    methods: [
+      'getUpcomingSeances', 'getSeanceDetails', 'getSeanceParticipants',
+      'validateParticipant', 'syncVideoAttendances', 'getMyTeachingSeances',
+      'getMyClassesSeances', 'hideSeance', 'unhideSeance', 'getAttendanceHistory',
+      'getSeancesHistory', 'getSeanceAttendances', 'deleteSeance'
+    ]
+  },
+  visio: {
+    svc: lmsVisioService,
+    methods: [
+      'toggleVisio', 'activateVisio', 'deactivateVisio', 'startVisio', 'endVisio',
+      'joinVisio', 'leaveVisio', 'heartbeatVisio', 'getVisioParticipants'
+    ]
+  },
+  notifications: {
+    svc: lmsNotificationsService,
+    methods: ['getNotificationPreferences', 'sendSessionReminder']
+  }
+}
+
+describe('lms.js — split par domaine (#26)', () => {
+  it('chaque module domaine porte exactement ses méthodes', () => {
+    for (const [name, { svc, methods }] of Object.entries(DOMAINS)) {
+      for (const m of methods) {
+        expect(typeof svc[m], `${name}.${m}`).toBe('function')
+      }
+    }
+  })
+
+  it('la façade lmsService agrège toutes les méthodes de tous les domaines', () => {
+    const all = Object.values(DOMAINS).flatMap((d) => d.methods)
+    for (const m of all) {
+      expect(typeof lmsService[m], `lmsService.${m}`).toBe('function')
+    }
+  })
+
+  it('aucune collision de nom entre domaines (total des méthodes uniques)', () => {
+    const all = Object.values(DOMAINS).flatMap((d) => d.methods)
+    expect(new Set(all).size).toBe(all.length)
+  })
+
+  it('le doublon getClasses a été retiré de lmsService (#26)', () => {
+    expect(lmsService.getClasses).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## #26 — PR 2/3 : split de `lms.js` par domaine

Suite de #39. `lms.js` (466 l., 6 domaines) violait le SRP / §5 (service ≤ 300 l.).

### Changements
- **Découpe par domaine** (miroir du split backend `LMSDataController` → 7 controllers), chaque module ≤ 300 l. :
  - `lmsClasses.js` (40 l.) · `lmsMatieres.js` (39 l.) · `lmsTeachers.js` (38 l.) · `lmsSeances.js` (206 l.) · `lmsVisio.js` (143 l.) · `lmsNotifications.js` (40 l.)
- **`lms.js` → façade baril (53 l.)** : compose `lmsService` (named + default) à partir des 6 domaines → **rétro-compatibilité totale**, aucun des 19 appelants existants n'est modifié. Réexporte aussi chaque service de domaine pour les imports granulaires futurs.
- **Dédup** : `lmsService.getClasses` (doublon strict de `klassciService.getClasses` sur `/proxy/classes`) **retiré** ; `SeanceManagement.vue` repointé vers `klassciService.getClasses()` (adapté à la forme tableau renvoyée).

### Suite (réf #26)
- **PR3** — fusion des deux `StudentLessonView` (live tous les deux) + dédup heartbeat visio (store/composable).

### Vérifications
- ✅ `npm run test` → 159/159 (+ `lmsServiceSplit.test.js` : présence des méthodes par domaine, façade agrégée, absence du doublon `getClasses`)
- ✅ `npm run test:contract` → 28/28 (export default `lmsService` préservé)
- ✅ `npm run build` → OK (warning de chunk préexistant → #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)