### PR TITLE
refactor(visio): mutualiser le moteur heartbeat — #26 PR4/4 (clôt #26)

### DIFF
--- a/src/composables/useVisioHeartbeat.js
+++ b/src/composables/useVisioHeartbeat.js
@@ -1,0 +1,107 @@
+import { ref } from 'vue'
+import lmsService from '@/services/lms'
+import { VISIO_CONFIG } from '@/constants/visio'
+
+/**
+ * Moteur de heartbeat visio partagé (#26).
+ *
+ * Mutualise la logique Web Worker (+ fallback setInterval) qui était
+ * dupliquée à l'identique entre le store global (`stores/visio.js`) et le
+ * composable de liaison composant (`composables/useVisioParticipation.js`).
+ *
+ * Le Worker (`/heartbeat-worker.js`) émet un message `heartbeat` toutes les
+ * `VISIO_CONFIG.HEARTBEAT_INTERVAL_MS` ms ; on relaie alors un ping serveur.
+ * Si le Worker n'est pas supporté, on retombe sur un setInterval.
+ *
+ * @param {Object} opts
+ * @param {() => (number|string|null)} opts.getSeanceId - séance active courante
+ * @param {() => boolean} opts.isActive - true si une participation est en cours
+ * @param {() => void} [opts.onParticipationLost] - appelé sur 404 (participation perdue côté serveur)
+ * @param {string} [opts.logPrefix] - préfixe des logs (identité de l'appelant)
+ * @returns {{ start: () => void, stop: () => void, sendHeartbeat: () => Promise<void> }}
+ */
+export function useVisioHeartbeat({
+  getSeanceId,
+  isActive,
+  onParticipationLost,
+  logPrefix = '[VisioHeartbeat]'
+}) {
+  const worker = ref(null)
+  let fallbackInterval = null
+
+  /** Envoyer un heartbeat (ping d'activité) au serveur pour la séance active. */
+  const sendHeartbeat = async () => {
+    const seanceId = getSeanceId()
+    if (!isActive() || !seanceId) return
+
+    try {
+      await lmsService.heartbeatVisio(seanceId)
+      console.log(`${logPrefix} 💓 Heartbeat envoyé (séance ${seanceId})`)
+    } catch (error) {
+      console.error(`${logPrefix} Erreur heartbeat:`, error)
+      // 404 = participation introuvable côté serveur : on arrête et on prévient.
+      if (error.response?.status === 404) {
+        console.warn(`${logPrefix} ⚠️ Participation non trouvée, arrêt heartbeat`)
+        stop()
+        onParticipationLost?.()
+      }
+    }
+  }
+
+  /** Fallback si le Web Worker n'est pas supporté. */
+  const fallback = () => {
+    console.warn(`${logPrefix} Fallback sur setInterval (Worker non supporté)`)
+    if (fallbackInterval) clearInterval(fallbackInterval)
+    sendHeartbeat()
+    fallbackInterval = setInterval(sendHeartbeat, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
+  }
+
+  /** Démarrer le heartbeat (Web Worker, fallback setInterval si indisponible). */
+  const start = () => {
+    stop()
+
+    try {
+      worker.value = new Worker('/heartbeat-worker.js')
+
+      worker.value.addEventListener('message', async (e) => {
+        const { type } = e.data || {}
+        if (type === 'heartbeat') {
+          await sendHeartbeat()
+        } else if (type === 'started') {
+          console.log(`${logPrefix} 💓 Worker démarré`)
+        } else if (type === 'stopped') {
+          console.log(`${logPrefix} 💔 Worker arrêté`)
+        } else if (type === 'error') {
+          console.error(`${logPrefix} Erreur Worker:`, e.data.error)
+        }
+      })
+
+      worker.value.addEventListener('error', (error) => {
+        console.error(`${logPrefix} Erreur Worker:`, error)
+      })
+
+      worker.value.postMessage({ command: 'start', interval: VISIO_CONFIG.HEARTBEAT_INTERVAL_MS })
+      sendHeartbeat() // premier ping immédiat
+      console.log(`${logPrefix} 💓 Heartbeat démarré (Web Worker)`)
+    } catch (error) {
+      console.error(`${logPrefix} Erreur création Worker:`, error)
+      fallback()
+    }
+  }
+
+  /** Arrêter le heartbeat (Worker ou fallback). */
+  const stop = () => {
+    if (worker.value) {
+      worker.value.postMessage({ command: 'stop' })
+      worker.value.terminate()
+      worker.value = null
+      console.log(`${logPrefix} 💔 Worker terminé`)
+    }
+    if (fallbackInterval) {
+      clearInterval(fallbackInterval)
+      fallbackInterval = null
+    }
+  }
+
+  return { start, stop, sendHeartbeat }
+}

--- a/src/composables/useVisioParticipation.js
+++ b/src/composables/useVisioParticipation.js
@@ -1,8 +1,8 @@
 import { ref, onBeforeUnmount } from 'vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
-import { VISIO_CONFIG } from '@/constants/visio'
 import { apiOrigin } from '@/constants/http'
+import { useVisioHeartbeat } from '@/composables/useVisioHeartbeat'
 
 /**
  * Composable pour gérer la participation à une visioconférence
@@ -20,109 +20,16 @@ export function useVisioParticipation(seanceId) {
   // États réactifs
   const isInVisio = ref(false)
   const visioWindow = ref(null)
-  const heartbeatWorker = ref(null)
 
-  /**
-   * Démarrer le Web Worker pour le heartbeat
-   * Le Worker tourne en arrière-plan, indépendant de l'état de l'onglet
-   */
-  const startHeartbeat = () => {
-    stopHeartbeat()
-
-    try {
-      // Créer le Worker
-      heartbeatWorker.value = new Worker('/heartbeat-worker.js')
-
-      // Écouter les messages du Worker
-      heartbeatWorker.value.addEventListener('message', async (e) => {
-        const { type, timestamp } = e.data
-
-        if (type === 'heartbeat') {
-          // Le Worker demande d'envoyer un heartbeat
-          await sendHeartbeat()
-        } else if (type === 'started') {
-          console.log('[useVisioParticipation] 💓 Worker démarré')
-        } else if (type === 'stopped') {
-          console.log('[useVisioParticipation] 💔 Worker arrêté')
-        } else if (type === 'error') {
-          console.error('[useVisioParticipation] Erreur Worker:', e.data.error)
-        }
-      })
-
-      // Gérer les erreurs du Worker
-      heartbeatWorker.value.addEventListener('error', (error) => {
-        console.error('[useVisioParticipation] Erreur Worker:', error)
-      })
-
-      // Démarrer le Worker (30 secondes)
-      heartbeatWorker.value.postMessage({ command: 'start', interval: VISIO_CONFIG.HEARTBEAT_INTERVAL_MS })
-
-      // Premier heartbeat immédiat
-      sendHeartbeat()
-
-      console.log('[useVisioParticipation] 💓 Heartbeat démarré (Web Worker, 30s)')
-
-    } catch (error) {
-      console.error('[useVisioParticipation] Erreur création Worker:', error)
-      // Fallback sur setInterval si Worker non supporté
-      fallbackHeartbeat()
-    }
-  }
-
-  /**
-   * Fallback heartbeat avec setInterval (si Worker non supporté)
-   */
-  let fallbackInterval = null
-  const fallbackHeartbeat = () => {
-    console.warn('[useVisioParticipation] Fallback sur setInterval (Worker non supporté)')
-
-    if (fallbackInterval) clearInterval(fallbackInterval)
-
-    sendHeartbeat()
-    fallbackInterval = setInterval(() => {
-      sendHeartbeat()
-    }, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
-  }
-
-  /**
-   * Arrêter le heartbeat (Worker ou fallback)
-   */
-  const stopHeartbeat = () => {
-    // Arrêter le Worker
-    if (heartbeatWorker.value) {
-      heartbeatWorker.value.postMessage({ command: 'stop' })
-      heartbeatWorker.value.terminate()
-      heartbeatWorker.value = null
-      console.log('[useVisioParticipation] 💔 Worker terminé')
-    }
-
-    // Arrêter le fallback
-    if (fallbackInterval) {
-      clearInterval(fallbackInterval)
-      fallbackInterval = null
-    }
-  }
-
-  /**
-   * Envoyer un heartbeat au serveur
-   */
-  const sendHeartbeat = async () => {
-    if (!isInVisio.value) return
-
-    try {
-      await lmsService.heartbeatVisio(seanceId)
-      console.log(`[useVisioParticipation] 💓 Heartbeat envoyé (séance ${seanceId})`)
-    } catch (error) {
-      console.error('[useVisioParticipation] Erreur heartbeat:', error)
-
-      // Si 404 (participation non trouvée), arrêter le heartbeat
-      if (error.response?.status === 404) {
-        console.warn('[useVisioParticipation] ⚠️ Participation non trouvée, arrêt heartbeat')
-        stopHeartbeat()
-        isInVisio.value = false
-      }
-    }
-  }
+  // Heartbeat (moteur Web Worker mutualisé — #26)
+  const { start: startHeartbeat, stop: stopHeartbeat, sendHeartbeat } = useVisioHeartbeat({
+    getSeanceId: () => seanceId,
+    isActive: () => isInVisio.value,
+    onParticipationLost: () => {
+      isInVisio.value = false
+    },
+    logPrefix: '[useVisioParticipation]'
+  })
 
   /**
    * Page Visibility API - Heartbeat immédiat au retour sur l'onglet

--- a/src/stores/visio.js
+++ b/src/stores/visio.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
-import { VISIO_CONFIG } from '@/constants/visio'
+import { useVisioHeartbeat } from '@/composables/useVisioHeartbeat'
 
 /**
  * Store Pinia global pour gérer la participation aux visioconférences
@@ -25,114 +25,20 @@ export const useVisioStore = defineStore('visio', () => {
   const activeSeanceId = ref(null)
   const isInVisio = ref(false)
   const visioWindow = ref(null)
-  const heartbeatWorker = ref(null)
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // Gestion du Web Worker (Heartbeat)
+  // Heartbeat (moteur Web Worker mutualisé — #26)
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  /**
-   * Démarrer le Web Worker pour le heartbeat
-   * Le Worker tourne en arrière-plan, indépendant de l'état de l'onglet
-   */
-  const startHeartbeat = () => {
-    stopHeartbeat()
-
-    try {
-      // Créer le Worker
-      heartbeatWorker.value = new Worker('/heartbeat-worker.js')
-
-      // Écouter les messages du Worker
-      heartbeatWorker.value.addEventListener('message', async (e) => {
-        const { type } = e.data
-
-        if (type === 'heartbeat') {
-          // Le Worker demande d'envoyer un heartbeat
-          await sendHeartbeat()
-        } else if (type === 'started') {
-          console.log('[VisioStore] 💓 Worker démarré')
-        } else if (type === 'stopped') {
-          console.log('[VisioStore] 💔 Worker arrêté')
-        } else if (type === 'error') {
-          console.error('[VisioStore] Erreur Worker:', e.data.error)
-        }
-      })
-
-      // Gérer les erreurs du Worker
-      heartbeatWorker.value.addEventListener('error', (error) => {
-        console.error('[VisioStore] Erreur Worker:', error)
-      })
-
-      // Démarrer le Worker (30 secondes)
-      heartbeatWorker.value.postMessage({ command: 'start', interval: VISIO_CONFIG.HEARTBEAT_INTERVAL_MS })
-
-      // Premier heartbeat immédiat
-      sendHeartbeat()
-
-      console.log('[VisioStore] 💓 Heartbeat démarré (Web Worker, 30s)')
-
-    } catch (error) {
-      console.error('[VisioStore] Erreur création Worker:', error)
-      // Fallback sur setInterval si Worker non supporté
-      fallbackHeartbeat()
-    }
-  }
-
-  /**
-   * Fallback heartbeat avec setInterval (si Worker non supporté)
-   */
-  let fallbackInterval = null
-  const fallbackHeartbeat = () => {
-    console.warn('[VisioStore] Fallback sur setInterval (Worker non supporté)')
-
-    if (fallbackInterval) clearInterval(fallbackInterval)
-
-    sendHeartbeat()
-    fallbackInterval = setInterval(() => {
-      sendHeartbeat()
-    }, VISIO_CONFIG.HEARTBEAT_INTERVAL_MS)
-  }
-
-  /**
-   * Arrêter le heartbeat (Worker ou fallback)
-   */
-  const stopHeartbeat = () => {
-    // Arrêter le Worker
-    if (heartbeatWorker.value) {
-      heartbeatWorker.value.postMessage({ command: 'stop' })
-      heartbeatWorker.value.terminate()
-      heartbeatWorker.value = null
-      console.log('[VisioStore] 💔 Worker terminé')
-    }
-
-    // Arrêter le fallback
-    if (fallbackInterval) {
-      clearInterval(fallbackInterval)
-      fallbackInterval = null
-    }
-  }
-
-  /**
-   * Envoyer un heartbeat au serveur
-   */
-  const sendHeartbeat = async () => {
-    if (!isInVisio.value || !activeSeanceId.value) return
-
-    try {
-      await lmsService.heartbeatVisio(activeSeanceId.value)
-      console.log(`[VisioStore] 💓 Heartbeat envoyé (séance ${activeSeanceId.value})`)
-    } catch (error) {
-      console.error('[VisioStore] Erreur heartbeat:', error)
-
-      // Si 404 (participation non trouvée), arrêter le heartbeat
-      if (error.response?.status === 404) {
-        console.warn('[VisioStore] ⚠️ Participation non trouvée, arrêt heartbeat')
-        stopHeartbeat()
-        isInVisio.value = false
-        activeSeanceId.value = null
-      }
-    }
-  }
+  const { start: startHeartbeat, stop: stopHeartbeat, sendHeartbeat } = useVisioHeartbeat({
+    getSeanceId: () => activeSeanceId.value,
+    isActive: () => isInVisio.value,
+    onParticipationLost: () => {
+      isInVisio.value = false
+      activeSeanceId.value = null
+    },
+    logPrefix: '[VisioStore]'
+  })
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   // Page Visibility API

--- a/tests/unit/useVisioHeartbeat.test.js
+++ b/tests/unit/useVisioHeartbeat.test.js
@@ -1,0 +1,64 @@
+/**
+ * Tests du moteur de heartbeat visio mutualisé (#26) — useVisioHeartbeat.
+ * Couvre sendHeartbeat : actif/inactif, garde seanceId, et perte de
+ * participation (404 → arrêt + callback). Le Web Worker n'existe pas sous
+ * jsdom ; on cible ici la logique d'envoi, indépendante du transport.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const { mockHeartbeat } = vi.hoisted(() => ({ mockHeartbeat: vi.fn() }))
+
+vi.mock('@/services/lms', () => ({
+  default: { heartbeatVisio: mockHeartbeat }
+}))
+
+import { useVisioHeartbeat } from '@/composables/useVisioHeartbeat'
+
+describe('useVisioHeartbeat (#26)', () => {
+  beforeEach(() => {
+    mockHeartbeat.mockReset()
+    mockHeartbeat.mockResolvedValue({ success: true })
+  })
+
+  it('envoie un heartbeat quand actif et séance présente', async () => {
+    const hb = useVisioHeartbeat({ getSeanceId: () => 42, isActive: () => true })
+    await hb.sendHeartbeat()
+    expect(mockHeartbeat).toHaveBeenCalledWith(42)
+  })
+
+  it("n'envoie rien si inactif", async () => {
+    const hb = useVisioHeartbeat({ getSeanceId: () => 42, isActive: () => false })
+    await hb.sendHeartbeat()
+    expect(mockHeartbeat).not.toHaveBeenCalled()
+  })
+
+  it("n'envoie rien sans séance active", async () => {
+    const hb = useVisioHeartbeat({ getSeanceId: () => null, isActive: () => true })
+    await hb.sendHeartbeat()
+    expect(mockHeartbeat).not.toHaveBeenCalled()
+  })
+
+  it('sur 404, appelle onParticipationLost', async () => {
+    const onLost = vi.fn()
+    mockHeartbeat.mockRejectedValue({ response: { status: 404 } })
+    const hb = useVisioHeartbeat({
+      getSeanceId: () => 7,
+      isActive: () => true,
+      onParticipationLost: onLost
+    })
+    await hb.sendHeartbeat()
+    expect(onLost).toHaveBeenCalledOnce()
+  })
+
+  it('sur erreur non-404, ne déclenche pas onParticipationLost', async () => {
+    const onLost = vi.fn()
+    mockHeartbeat.mockRejectedValue({ response: { status: 500 } })
+    const hb = useVisioHeartbeat({
+      getSeanceId: () => 7,
+      isActive: () => true,
+      onParticipationLost: onLost
+    })
+    await hb.sendHeartbeat()
+    expect(onLost).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## #26 — PR 4/4 : dédup du heartbeat visio (clôt #26)

Dernière tranche de #26 (après #39, #40, #41).

### Constat
La logique **Web Worker** du heartbeat (start/stop/fallback/sendHeartbeat) était **dupliquée à l'identique** entre :
- `stores/visio.js` — participation visio globale (état persistant à travers la navigation),
- `composables/useVisioParticipation.js` — liaison par composant (utilisé par 3 vues).

### Changements
- ➕ **Factory partagée `useVisioHeartbeat.js`** (107 l.) : moteur Worker + fallback `setInterval`, paramétré par accesseurs (`getSeanceId` / `isActive` / `onParticipationLost` / `logPrefix`).
- ♻️ Store et composable délèguent au moteur partagé → **−208 lignes** dupliquées.
- ✅ Test `useVisioHeartbeat.test.js` (actif / inactif / garde séance / 404→callback / non-404).

**Comportement préservé** : chaque consommateur conserve son état et son lifecycle (store persistant — sa raison d'être ; composable nettoyé au démontage). Seule la mécanique worker est mutualisée → **zéro changement de comportement**.

### Dette tracée (nécessite le backend — NON touchée ici)
Le **Beacon de sortie** est cassé dans les deux fichiers :
- store : double `/api` (`${VITE_API_URL}/api/seances/...`),
- composable : chemin inexistant `/api/seances/:id/leave-visio` (le vrai = `/api/lms/seances/:id/leave`),
- auth Bearer incompatible avec `navigator.sendBeacon`.

→ Sera filé comme **issue #17-family** (contrat API). Laissé en l'état ici pour ne rien changer au comportement.

### Vérifications
- ✅ `npm run test` → 164/164
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)