### PR TITLE
refactor(evaluations): extraire la logique pure de TeacherEvaluations — #28 (1/3)

### DIFF
--- a/.claude/specs/god-teacher-evaluations/requirements.md
+++ b/.claude/specs/god-teacher-evaluations/requirements.md
@@ -1,0 +1,58 @@
+# Requirements — Décomposition `TeacherEvaluations.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · `PRODUCTION_STANDARDS.md §1.1`
+> (aucun fichier > 300 lignes). 1 spec dédiée par god-component.
+
+## Investigation (code réel — vérifié 2026-06-18)
+
+`src/views/evaluations/TeacherEvaluations.vue` : **1877 lignes** (`<script setup>`,
+template 1-440 ≈ 440 l., script 442-944 ≈ 500 l., styles ≈ 940 l.).
+~11 responsabilités mélangées.
+
+Surface du script (fichier:ligne) :
+
+| Catégorie | Éléments |
+|---|---|
+| **Logique métier PURE** (extractible, testable) | `evaluationsWithOnline`/merge (:497), `isExpiredWithoutOnline` (:506), `expiredWithoutOnlineCount` (:521), `filteredEvaluations` (:526), `stats` (:553), `getStatusBadgeClass` (:682), `getStatusLabel` (:700), `getStatusTooltip` (:728) |
+| Mapper UI (icônes) | `getStatusIcon` (:714) — réfère des **composants** d'icônes importés → reste dans la vue |
+| Formatage date | `formatDate` (:742) — duplique `formatDateTime` (#23) → **non touché ici** (dette) |
+| Fetch (composable cible) | `loadData` (:564), `loadClasses` (:591), `loadMatieres` (:609), `loadEvaluationsKlassci` (:627), `loadEvaluationsLMS` (:651) |
+| Actions | create/submit/edit/view/sync/publish/preview/delete online version |
+| Template (sous-composants cibles) | modale création version en ligne, table des évaluations, cartes stats, barre de filtres |
+
+## Stratégie de livraison (incrémentale, par tranche TDD)
+
+Décomposition trop large pour une PR. On livre par tranches, du plus sûr au plus
+risqué, chacune gardée par les tests :
+
+- **Tranche 1 (cette PR)** — extraire la **logique métier pure** vers
+  `src/utils/evaluations.js` (TDD complet), la vue l'importe. **Zéro risque UI.**
+- **Tranche 2** — composable `useTeacherEvaluations` (fetch + état + cache).
+- **Tranche 3** — sous-composants à slots (table, stats, filtres, modale).
+
+## Exigences (tranche 1)
+
+### Besoin 1 — Logique métier pure extraite et testée
+**User story :** En tant que mainteneur, je veux la logique d'évaluation dans un
+module pur testable, afin de la fiabiliser et d'alléger la vue.
+
+- THE SYSTEM SHALL exposer dans `src/utils/evaluations.js` des fonctions **pures** :
+  `mergeWithOnlineVersions(klassci, lms)`, `isExpiredWithoutOnline(evaluation)`,
+  `filterEvaluations(evals, filters)`, `computeEvaluationStats(evals)`,
+  `getStatusLabel(status)`, `getStatusTooltip(status)`, `getStatusBadgeClass(evaluation)`.
+- WHEN ces fonctions reçoivent les mêmes entrées qu'aujourd'hui, THE SYSTEM SHALL
+  produire **exactement** les mêmes sorties (parité comportementale).
+- THE SYSTEM SHALL couvrir chaque fonction par des tests unitaires (happy path +
+  cas limites : pas de version en ligne, fenêtre fermée, date passée/future,
+  statuts inconnus).
+- WHEN la vue est refactorée, THE SYSTEM SHALL importer ces fonctions sans
+  changer le rendu ni le comportement (build + tests verts).
+
+### Hors périmètre (dette tracée)
+- `formatDate` → `formatDateTime` (#23-FE-1) : non touché ici (un doc WIP
+  d'affichage des dates d'évaluations est en cours côté utilisateur).
+- `getStatusIcon` : reste dans la vue (mappe des composants Vue).
+- Composable de fetch + sous-composants : tranches 2 et 3.
+
+## Vérification
+- `npm run test` (nouveaux tests `evaluations.test.js`) · `npm run test:contract` · `npm run build`.

--- a/src/utils/evaluations.js
+++ b/src/utils/evaluations.js
@@ -1,0 +1,132 @@
+/**
+ * Logique métier PURE des évaluations enseignant (#28).
+ *
+ * Extrait de `views/evaluations/TeacherEvaluations.vue` (god-component) :
+ * fusion KLASSCI ↔ versions LMS en ligne, calcul d'expiration, filtrage,
+ * statistiques et mappers de statut. Fonctions pures (aucun effet de bord,
+ * aucune dépendance Vue) → testables et réutilisables.
+ */
+
+/**
+ * Fusionne les évaluations KLASSCI avec leurs versions LMS en ligne.
+ * @param {Array<Object>} klassci - évaluations KLASSCI brutes
+ * @param {Array<Object>} lms - évaluations LMS (online), liées par klassci_evaluation_id
+ * @returns {Array<Object>} évaluations enrichies { ...eval, online_version, has_online }
+ */
+export function mergeWithOnlineVersions(klassci = [], lms = []) {
+  return klassci.map((evaluation) => ({
+    ...evaluation,
+    online_version: lms.find((e) => e.klassci_evaluation_id === evaluation.id),
+    has_online: lms.some((e) => e.klassci_evaluation_id === evaluation.id)
+  }))
+}
+
+/**
+ * Une évaluation est-elle expirée ET sans version en ligne ?
+ * @param {Object} evaluation - évaluation (idéalement enrichie via mergeWithOnlineVersions)
+ * @returns {boolean}
+ */
+export function isExpiredWithoutOnline(evaluation) {
+  if (evaluation.has_online) return false
+
+  // Statut de la fenêtre (programmation KLASSCI)
+  const window = evaluation.programmation?.window
+  if (window && !window.is_open && window.has_started) return true
+
+  // Date d'évaluation (programmation prioritaire)
+  const dateEval = evaluation.programmation?.date_evaluation || evaluation.date_evaluation
+  if (dateEval) {
+    return new Date(dateEval) < new Date()
+  }
+  return false
+}
+
+/**
+ * Filtre une liste d'évaluations enrichies.
+ * @param {Array<Object>} evaluations
+ * @param {Object} filters - { hideExpired, classe_id, matiere_id, statut }
+ * @returns {Array<Object>}
+ */
+export function filterEvaluations(evaluations = [], filters = {}) {
+  let filtered = evaluations
+
+  if (filters.hideExpired) {
+    filtered = filtered.filter((e) => !isExpiredWithoutOnline(e))
+  }
+  if (filters.classe_id) {
+    // Comparaison souple (id numérique vs valeur de <select> chaîne)
+    filtered = filtered.filter((e) => e.classe?.id == filters.classe_id)
+  }
+  if (filters.matiere_id) {
+    filtered = filtered.filter((e) => e.matiere?.id == filters.matiere_id)
+  }
+  if (filters.statut) {
+    filtered = filtered.filter((e) => e.status === filters.statut)
+  }
+  return filtered
+}
+
+/**
+ * Statistiques agrégées d'une liste d'évaluations enrichies.
+ * @param {Array<Object>} evaluations
+ * @returns {{ total:number, enCours:number, terminees:number, avecVersionEnLigne:number }}
+ */
+export function computeEvaluationStats(evaluations = []) {
+  return {
+    total: evaluations.length,
+    enCours: evaluations.filter((e) => e.programmation?.window?.is_open).length,
+    terminees: evaluations.filter((e) => e.status === 'terminee').length,
+    avecVersionEnLigne: evaluations.filter((e) => e.has_online).length
+  }
+}
+
+const STATUS_LABELS = {
+  planifiee: 'Planifiée',
+  en_cours: 'En cours',
+  terminee: 'Terminée',
+  brouillon: 'Brouillon',
+  draft: 'Brouillon',
+  in_progress: 'En cours',
+  completed: 'Terminée'
+}
+
+const STATUS_TOOLTIPS = {
+  planifiee: 'Évaluation programmée dans le calendrier KLASSCI',
+  en_cours: 'Fenêtre temporelle ouverte - Les étudiants peuvent composer',
+  terminee: 'Fenêtre fermée - Composition terminée',
+  brouillon: 'Évaluation en préparation, non encore programmée',
+  draft: 'Évaluation en préparation, non encore programmée',
+  in_progress: 'Fenêtre temporelle ouverte - Les étudiants peuvent composer',
+  completed: 'Fenêtre fermée - Composition terminée'
+}
+
+const STATUS_BADGE_CLASSES = {
+  planifiee: 'status-badge-planned',
+  en_cours: 'status-badge-active',
+  terminee: 'status-badge-finished',
+  brouillon: 'status-badge-draft'
+}
+
+/** Libellé lisible d'un statut (fallback : le statut brut). */
+export function getStatusLabel(status) {
+  return STATUS_LABELS[status] || status
+}
+
+/** Infobulle d'un statut (fallback générique). */
+export function getStatusTooltip(status) {
+  return STATUS_TOOLTIPS[status] || "Statut de l'évaluation"
+}
+
+/**
+ * Classe CSS du badge de statut. Une fenêtre ouverte prime sur le statut.
+ * @param {Object} evaluation
+ * @returns {string}
+ */
+export function getStatusBadgeClass(evaluation) {
+  const base = 'status-badge'
+  if (evaluation.programmation?.window?.is_open) {
+    return `${base} status-badge-active`
+  }
+  const suffix = STATUS_BADGE_CLASSES[evaluation.status] || 'status-badge-default'
+  return `${base} ${suffix}`
+}

--- a/src/views/evaluations/TeacherEvaluations.vue
+++ b/src/views/evaluations/TeacherEvaluations.vue
@@ -447,6 +447,16 @@ import ContentLoader from '@/components/common/ContentLoader.vue'
 import klassciService from '@/services/klassci'
 import evaluationService from '@/services/evaluation'
 import { readCache, writeCache } from '@/services/cache'
+// #28 : logique métier pure extraite (testée dans tests/unit/evaluations.test.js)
+import {
+  mergeWithOnlineVersions,
+  isExpiredWithoutOnline,
+  filterEvaluations,
+  computeEvaluationStats,
+  getStatusLabel,
+  getStatusTooltip,
+  getStatusBadgeClass
+} from '@/utils/evaluations'
 import {
   DocumentTextIcon,
   BookOpenIcon,
@@ -493,72 +503,28 @@ const filters = reactive({
 })
 
 
-// Merge KLASSCI evaluations with LMS online versions
-const evaluationsWithOnline = computed(() => {
-  return evaluationsKlassci.value.map(evaluation => ({
-    ...evaluation,
-    online_version: evaluationsLMS.value.find(e => e.klassci_evaluation_id === evaluation.id),
-    has_online: evaluationsLMS.value.some(e => e.klassci_evaluation_id === evaluation.id)
-  }))
-})
+// Fusion KLASSCI + versions LMS en ligne (logique pure extraite, #28)
+const evaluationsWithOnline = computed(() =>
+  mergeWithOnlineVersions(evaluationsKlassci.value, evaluationsLMS.value)
+)
 
-// Check if an evaluation is expired and without online version
-function isExpiredWithoutOnline(evaluation) {
-  if (evaluation.has_online) return false
-  // Check window status (KLASSCI programmation)
-  const window = evaluation.programmation?.window
-  if (window && !window.is_open && window.has_started) return true
-  // Check date_evaluation
-  const dateEval = evaluation.programmation?.date_evaluation || evaluation.date_evaluation
-  if (dateEval) {
-    const evalDate = new Date(dateEval)
-    return evalDate < new Date()
-  }
-  return false
-}
+// Nombre d'évaluations expirées sans version en ligne
+const expiredWithoutOnlineCount = computed(() =>
+  evaluationsWithOnline.value.filter(isExpiredWithoutOnline).length
+)
 
-// Count of expired evaluations without online version
-const expiredWithoutOnlineCount = computed(() => {
-  return evaluationsWithOnline.value.filter(e => isExpiredWithoutOnline(e)).length
-})
+// Évaluations filtrées (logique pure extraite, #28)
+const filteredEvaluations = computed(() =>
+  filterEvaluations(evaluationsWithOnline.value, {
+    hideExpired: hideExpired.value,
+    classe_id: filters.classe_id,
+    matiere_id: filters.matiere_id,
+    statut: filters.statut
+  })
+)
 
-// Filtered evaluations
-const filteredEvaluations = computed(() => {
-  let filtered = evaluationsWithOnline.value
-
-  // Hide expired without online version
-  if (hideExpired.value) {
-    filtered = filtered.filter(e => !isExpiredWithoutOnline(e))
-  }
-
-  // Filter by classe
-  if (filters.classe_id) {
-    filtered = filtered.filter(e => e.classe?.id == filters.classe_id)
-  }
-
-  // Filter by matiere
-  if (filters.matiere_id) {
-    filtered = filtered.filter(e => e.matiere?.id == filters.matiere_id)
-  }
-
-  // Filter by statut
-  if (filters.statut) {
-    filtered = filtered.filter(e => e.status === filters.statut)
-  }
-
-  return filtered
-})
-
-// Statistics
-const stats = computed(() => {
-  const all = evaluationsWithOnline.value
-  return {
-    total: all.length,
-    enCours: all.filter(e => e.programmation?.window?.is_open).length,
-    terminees: all.filter(e => e.status === 'terminee').length,
-    avecVersionEnLigne: all.filter(e => e.has_online).length
-  }
-})
+// Statistiques (logique pure extraite, #28)
+const stats = computed(() => computeEvaluationStats(evaluationsWithOnline.value))
 
 // Load all data with cache
 async function loadData() {
@@ -678,37 +644,8 @@ function resetFilters() {
   console.log('[FILTERS] Filtres réinitialisés')
 }
 
-// Get status badge class
-function getStatusBadgeClass(evaluation) {
-  const baseClass = 'status-badge'
-
-  if (evaluation.programmation?.window?.is_open) {
-    return `${baseClass} status-badge-active`
-  }
-
-  const statusClasses = {
-    'planifiee': `${baseClass} status-badge-planned`,
-    'en_cours': `${baseClass} status-badge-active`,
-    'terminee': `${baseClass} status-badge-finished`,
-    'brouillon': `${baseClass} status-badge-draft`
-  }
-
-  return statusClasses[evaluation.status] || `${baseClass} status-badge-default`
-}
-
-// Get status label
-function getStatusLabel(status) {
-  const labels = {
-    'planifiee': 'Planifiée',
-    'en_cours': 'En cours',
-    'terminee': 'Terminée',
-    'brouillon': 'Brouillon',
-    'draft': 'Brouillon',
-    'in_progress': 'En cours',
-    'completed': 'Terminée'
-  }
-  return labels[status] || status
-}
+// getStatusBadgeClass / getStatusLabel / getStatusTooltip : importés depuis
+// @/utils/evaluations (#28). getStatusIcon reste ici (mappe des composants Vue).
 
 // Get status icon
 function getStatusIcon(status) {
@@ -722,20 +659,6 @@ function getStatusIcon(status) {
     'completed': CheckCircleIcon
   }
   return icons[status] || DocumentTextIcon
-}
-
-// Get status tooltip
-function getStatusTooltip(status) {
-  const tooltips = {
-    'planifiee': 'Évaluation programmée dans le calendrier KLASSCI',
-    'en_cours': 'Fenêtre temporelle ouverte - Les étudiants peuvent composer',
-    'terminee': 'Fenêtre fermée - Composition terminée',
-    'brouillon': 'Évaluation en préparation, non encore programmée',
-    'draft': 'Évaluation en préparation, non encore programmée',
-    'in_progress': 'Fenêtre temporelle ouverte - Les étudiants peuvent composer',
-    'completed': 'Fenêtre fermée - Composition terminée'
-  }
-  return tooltips[status] || 'Statut de l\'évaluation'
 }
 
 // Format date

--- a/tests/unit/evaluations.test.js
+++ b/tests/unit/evaluations.test.js
@@ -1,0 +1,123 @@
+/**
+ * Tests de la logique métier pure des évaluations (#28 — décomposition
+ * TeacherEvaluations.vue, tranche 1). Parité comportementale avec la vue.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  mergeWithOnlineVersions,
+  isExpiredWithoutOnline,
+  filterEvaluations,
+  computeEvaluationStats,
+  getStatusLabel,
+  getStatusTooltip,
+  getStatusBadgeClass
+} from '@/utils/evaluations'
+
+describe('utils/evaluations — mergeWithOnlineVersions', () => {
+  it('associe la version LMS en ligne par klassci_evaluation_id', () => {
+    const klassci = [{ id: 1 }, { id: 2 }]
+    const lms = [{ id: 99, klassci_evaluation_id: 2 }]
+    const merged = mergeWithOnlineVersions(klassci, lms)
+    expect(merged[0]).toMatchObject({ id: 1, has_online: false })
+    expect(merged[0].online_version).toBeUndefined()
+    expect(merged[1]).toMatchObject({ id: 2, has_online: true })
+    expect(merged[1].online_version).toEqual({ id: 99, klassci_evaluation_id: 2 })
+  })
+
+  it('renvoie [] si pas de klassci', () => {
+    expect(mergeWithOnlineVersions([], [])).toEqual([])
+  })
+})
+
+describe('utils/evaluations — isExpiredWithoutOnline', () => {
+  it('false si version en ligne existe', () => {
+    expect(isExpiredWithoutOnline({ has_online: true, date_evaluation: '2000-01-01' })).toBe(false)
+  })
+
+  it('true si fenêtre fermée et démarrée, sans version en ligne', () => {
+    expect(isExpiredWithoutOnline({
+      has_online: false,
+      programmation: { window: { is_open: false, has_started: true } }
+    })).toBe(true)
+  })
+
+  it('true si date_evaluation passée', () => {
+    expect(isExpiredWithoutOnline({ has_online: false, date_evaluation: '2000-01-01' })).toBe(true)
+  })
+
+  it('false si date_evaluation future', () => {
+    expect(isExpiredWithoutOnline({ has_online: false, date_evaluation: '2999-01-01' })).toBe(false)
+  })
+
+  it('priorité à programmation.date_evaluation sur date_evaluation', () => {
+    expect(isExpiredWithoutOnline({
+      has_online: false,
+      programmation: { date_evaluation: '2999-01-01' },
+      date_evaluation: '2000-01-01'
+    })).toBe(false)
+  })
+
+  it('false si aucune info d\'expiration', () => {
+    expect(isExpiredWithoutOnline({ has_online: false })).toBe(false)
+  })
+})
+
+describe('utils/evaluations — filterEvaluations', () => {
+  const evals = [
+    { id: 1, has_online: true, status: 'en_cours', classe: { id: 10 }, matiere: { id: 20 } },
+    { id: 2, has_online: false, status: 'terminee', date_evaluation: '2000-01-01', classe: { id: 11 }, matiere: { id: 21 } },
+    { id: 3, has_online: true, status: 'planifiee', classe: { id: 10 }, matiere: { id: 21 } }
+  ]
+
+  it('masque les expirées sans version en ligne quand hideExpired', () => {
+    const out = filterEvaluations(evals, { hideExpired: true })
+    expect(out.map(e => e.id)).toEqual([1, 3])
+  })
+
+  it('garde tout si hideExpired=false', () => {
+    expect(filterEvaluations(evals, { hideExpired: false })).toHaveLength(3)
+  })
+
+  it('filtre par classe (comparaison souple)', () => {
+    const out = filterEvaluations(evals, { hideExpired: false, classe_id: '10' })
+    expect(out.map(e => e.id)).toEqual([1, 3])
+  })
+
+  it('filtre par matière et statut', () => {
+    expect(filterEvaluations(evals, { hideExpired: false, matiere_id: 21 }).map(e => e.id)).toEqual([2, 3])
+    expect(filterEvaluations(evals, { hideExpired: false, statut: 'terminee' }).map(e => e.id)).toEqual([2])
+  })
+})
+
+describe('utils/evaluations — computeEvaluationStats', () => {
+  it('compte total / enCours / terminees / avecVersionEnLigne', () => {
+    const evals = [
+      { has_online: true, status: 'en_cours', programmation: { window: { is_open: true } } },
+      { has_online: false, status: 'terminee' },
+      { has_online: true, status: 'planifiee' }
+    ]
+    expect(computeEvaluationStats(evals)).toEqual({
+      total: 3, enCours: 1, terminees: 1, avecVersionEnLigne: 2
+    })
+  })
+})
+
+describe('utils/evaluations — mappers de statut', () => {
+  it('getStatusLabel mappe + fallback brut', () => {
+    expect(getStatusLabel('en_cours')).toBe('En cours')
+    expect(getStatusLabel('completed')).toBe('Terminée')
+    expect(getStatusLabel('inconnu')).toBe('inconnu')
+  })
+
+  it('getStatusTooltip a un fallback', () => {
+    expect(getStatusTooltip('planifiee')).toContain('KLASSCI')
+    expect(getStatusTooltip('xxx')).toBe("Statut de l'évaluation")
+  })
+
+  it('getStatusBadgeClass : fenêtre ouverte → active', () => {
+    expect(getStatusBadgeClass({ programmation: { window: { is_open: true } }, status: 'terminee' }))
+      .toBe('status-badge status-badge-active')
+    expect(getStatusBadgeClass({ status: 'terminee' })).toBe('status-badge status-badge-finished')
+    expect(getStatusBadgeClass({ status: 'xxx' })).toBe('status-badge status-badge-default')
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `TeacherEvaluations.vue` (tranche 1/3)

Premier god-component du TIER 2 (1877 l., ~11 responsabilités). Décomposition incrémentale, gardée par les tests. Spec : `.claude/specs/god-teacher-evaluations/`.

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/evaluations.js`** (132 l.) — fonctions **pures** extraites : `mergeWithOnlineVersions`, `isExpiredWithoutOnline`, `filterEvaluations`, `computeEvaluationStats`, `getStatusLabel` / `getStatusTooltip` / `getStatusBadgeClass`.
- ✅ **`tests/unit/evaluations.test.js`** — 16 cas (happy path + limites : pas de version en ligne, fenêtre fermée/démarrée, date passée/future, priorité `programmation`, statuts inconnus).
- ♻️ La vue importe le module et délègue ; doublons inline supprimés (**1877 → 1800 l.**).
- **Parité comportementale** : sorties identiques à l'inline (build + tests verts).

### Suite (réf #28, même vue)
- **Tranche 2** : composable `useTeacherEvaluations` (fetch + cache + état).
- **Tranche 3** : sous-composants à slots (table, cartes stats, filtres, modale création).

### Hors périmètre (dette tracée)
- `getStatusIcon` reste dans la vue (mappe des composants Vue).
- `formatDate` non touché → `formatDateTime` (#23-FE-1).
- La vue reste un god-component (1800 l.) tant que les tranches 2-3 ne sont pas livrées.

### Vérifications
- ✅ `npm run test` → 180/180
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)