### PR TITLE
refactor(evaluations): composable useTeacherEvaluations — #28 (2/3)

### DIFF
--- a/src/composables/useTeacherEvaluations.js
+++ b/src/composables/useTeacherEvaluations.js
@@ -1,0 +1,168 @@
+import { ref, reactive, computed } from 'vue'
+import klassciService from '@/services/klassci'
+import evaluationService from '@/services/evaluation'
+import { readCache, writeCache } from '@/services/cache'
+import {
+  mergeWithOnlineVersions,
+  isExpiredWithoutOnline,
+  filterEvaluations,
+  computeEvaluationStats
+} from '@/utils/evaluations'
+
+/**
+ * Composable de données des évaluations enseignant (#28, tranche 2).
+ *
+ * Encapsule le chargement (KLASSCI + LMS, avec cache classes/matières),
+ * l'état réactif, les filtres et les valeurs dérivées (fusion, filtrage,
+ * stats — calculées via les fonctions pures de `@/utils/evaluations`).
+ * Extrait du god-component `TeacherEvaluations.vue`.
+ */
+export function useTeacherEvaluations() {
+  // État
+  const evaluationsKlassci = ref([])
+  const evaluationsLMS = ref([])
+  const classes = ref([])
+  const matieres = ref([])
+  const loading = ref(true)
+  const error = ref(null)
+  const hideExpired = ref(true) // masquer par défaut les expirées sans version en ligne
+
+  const filters = reactive({
+    classe_id: '',
+    matiere_id: '',
+    statut: ''
+  })
+
+  // Dérivés (logique pure)
+  const evaluationsWithOnline = computed(() =>
+    mergeWithOnlineVersions(evaluationsKlassci.value, evaluationsLMS.value)
+  )
+  const expiredWithoutOnlineCount = computed(() =>
+    evaluationsWithOnline.value.filter(isExpiredWithoutOnline).length
+  )
+  const filteredEvaluations = computed(() =>
+    filterEvaluations(evaluationsWithOnline.value, {
+      hideExpired: hideExpired.value,
+      classe_id: filters.classe_id,
+      matiere_id: filters.matiere_id,
+      statut: filters.statut
+    })
+  )
+  const stats = computed(() => computeEvaluationStats(evaluationsWithOnline.value))
+
+  // Chargements
+  async function loadClasses() {
+    const cached = readCache('teacher_classes')
+    if (cached !== null) {
+      classes.value = cached
+      return
+    }
+    try {
+      const data = await klassciService.getClasses()
+      classes.value = Array.isArray(data) ? data : []
+      writeCache('teacher_classes', classes.value)
+    } catch (err) {
+      console.error('[ERREUR] Chargement classes:', err)
+    }
+  }
+
+  async function loadMatieres() {
+    const cached = readCache('teacher_matieres')
+    if (cached !== null) {
+      matieres.value = cached
+      return
+    }
+    try {
+      const data = await klassciService.getMatieres()
+      matieres.value = Array.isArray(data) ? data : []
+      writeCache('teacher_matieres', matieres.value)
+    } catch (err) {
+      console.error('[ERREUR] Chargement matières:', err)
+    }
+  }
+
+  async function loadEvaluationsKlassci() {
+    try {
+      const result = await klassciService.getEvaluations(filters)
+      if (result.success) {
+        evaluationsKlassci.value = result.data
+      }
+    } catch (err) {
+      console.error('[ERREUR] Chargement évaluations KLASSCI, fallback dashboard:', err)
+      // Fallback : dashboard enseignant
+      try {
+        const dashboard = await klassciService.getTeacherDashboard()
+        if (dashboard && dashboard.evaluations) {
+          evaluationsKlassci.value = dashboard.evaluations
+        }
+      } catch (dashboardError) {
+        console.error('[ERREUR] Fallback dashboard:', dashboardError)
+      }
+    }
+  }
+
+  async function loadEvaluationsLMS() {
+    try {
+      const result = await evaluationService.getEvaluations()
+      if (result.success) {
+        evaluationsLMS.value = result.data.map((e) => ({
+          ...e,
+          questions_count: e.questions?.length || 0,
+          submissions_count: e.submissions?.length || 0
+        }))
+      }
+    } catch (err) {
+      console.warn('[INFO] Aucune évaluation LMS (normal si aucune créée):', err.message)
+      evaluationsLMS.value = []
+    }
+  }
+
+  async function loadData() {
+    loading.value = true
+    error.value = null
+    try {
+      await Promise.all([loadClasses(), loadMatieres()])
+      await Promise.all([loadEvaluationsKlassci(), loadEvaluationsLMS()])
+    } catch (err) {
+      console.error('[ERREUR] Chargement données:', err)
+      error.value = 'Impossible de charger les évaluations. Veuillez réessayer.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function applyFilters() {
+    // Les filtres sont réactifs ; filteredEvaluations se recalcule seul.
+  }
+
+  function resetFilters() {
+    filters.classe_id = ''
+    filters.matiere_id = ''
+    filters.statut = ''
+  }
+
+  return {
+    // état
+    evaluationsKlassci,
+    evaluationsLMS,
+    classes,
+    matieres,
+    loading,
+    error,
+    hideExpired,
+    filters,
+    // dérivés
+    evaluationsWithOnline,
+    expiredWithoutOnlineCount,
+    filteredEvaluations,
+    stats,
+    // actions de données
+    loadData,
+    loadClasses,
+    loadMatieres,
+    loadEvaluationsKlassci,
+    loadEvaluationsLMS,
+    applyFilters,
+    resetFilters
+  }
+}

--- a/src/views/evaluations/TeacherEvaluations.vue
+++ b/src/views/evaluations/TeacherEvaluations.vue
@@ -440,23 +440,14 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, onMounted } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
-import klassciService from '@/services/klassci'
 import evaluationService from '@/services/evaluation'
-import { readCache, writeCache } from '@/services/cache'
-// #28 : logique métier pure extraite (testée dans tests/unit/evaluations.test.js)
-import {
-  mergeWithOnlineVersions,
-  isExpiredWithoutOnline,
-  filterEvaluations,
-  computeEvaluationStats,
-  getStatusLabel,
-  getStatusTooltip,
-  getStatusBadgeClass
-} from '@/utils/evaluations'
+// #28 : données déléguées au composable ; mappers de statut purs pour le template
+import { useTeacherEvaluations } from '@/composables/useTeacherEvaluations'
+import { getStatusLabel, getStatusTooltip, getStatusBadgeClass } from '@/utils/evaluations'
 import {
   DocumentTextIcon,
   BookOpenIcon,
@@ -478,171 +469,34 @@ import {
 
 const router = useRouter()
 
-const evaluationsKlassci = ref([])
-const evaluationsLMS = ref([])
-const classes = ref([])
-const matieres = ref([])
-const loading = ref(true)
-const error = ref(null)
+// Données, filtres & dérivés délégués au composable (#28, tranche 2)
+const {
+  evaluationsLMS,
+  classes,
+  matieres,
+  loading,
+  error,
+  hideExpired,
+  filters,
+  expiredWithoutOnlineCount,
+  filteredEvaluations,
+  stats,
+  loadData,
+  loadEvaluationsLMS,
+  applyFilters,
+  resetFilters
+} = useTeacherEvaluations()
+
+// État UI local aux actions (modale de création de version en ligne)
 const syncing = ref(null)
 const showCreateModal = ref(false)
 const selectedEvaluation = ref(null)
 const creating = ref(false)
-const hideExpired = ref(true) // Par défaut, masquer les évaluations expirées sans version en ligne
 const onlineForm = reactive({
   type: 'qcm',
   duree_minutes: 60,
   description: ''
 })
-
-// Filters
-const filters = reactive({
-  classe_id: '',
-  matiere_id: '',
-  statut: ''
-})
-
-
-// Fusion KLASSCI + versions LMS en ligne (logique pure extraite, #28)
-const evaluationsWithOnline = computed(() =>
-  mergeWithOnlineVersions(evaluationsKlassci.value, evaluationsLMS.value)
-)
-
-// Nombre d'évaluations expirées sans version en ligne
-const expiredWithoutOnlineCount = computed(() =>
-  evaluationsWithOnline.value.filter(isExpiredWithoutOnline).length
-)
-
-// Évaluations filtrées (logique pure extraite, #28)
-const filteredEvaluations = computed(() =>
-  filterEvaluations(evaluationsWithOnline.value, {
-    hideExpired: hideExpired.value,
-    classe_id: filters.classe_id,
-    matiere_id: filters.matiere_id,
-    statut: filters.statut
-  })
-)
-
-// Statistiques (logique pure extraite, #28)
-const stats = computed(() => computeEvaluationStats(evaluationsWithOnline.value))
-
-// Load all data with cache
-async function loadData() {
-  loading.value = true
-  error.value = null
-
-  try {
-    // Load classes and matieres in parallel
-    await Promise.all([
-      loadClasses(),
-      loadMatieres()
-    ])
-
-    // Load evaluations
-    await Promise.all([
-      loadEvaluationsKlassci(),
-      loadEvaluationsLMS()
-    ])
-
-    console.log('[SUCCESS] Données chargées')
-  } catch (err) {
-    console.error('[ERREUR] Chargement données:', err)
-    error.value = 'Impossible de charger les évaluations. Veuillez réessayer.'
-  } finally {
-    loading.value = false
-  }
-}
-
-// Load classes with cache
-async function loadClasses() {
-  const cachedData = readCache('teacher_classes')
-  if (cachedData !== null) {
-    classes.value = cachedData
-    return
-  }
-
-  try {
-    const classesData = await klassciService.getClasses()
-    classes.value = Array.isArray(classesData) ? classesData : []
-
-    writeCache('teacher_classes', classes.value)
-  } catch (err) {
-    console.error('[ERREUR] Chargement classes:', err)
-  }
-}
-
-// Load matieres with cache
-async function loadMatieres() {
-  const cachedData = readCache('teacher_matieres')
-  if (cachedData !== null) {
-    matieres.value = cachedData
-    return
-  }
-
-  try {
-    const matieresData = await klassciService.getMatieres()
-    matieres.value = Array.isArray(matieresData) ? matieresData : []
-
-    writeCache('teacher_matieres', matieres.value)
-  } catch (err) {
-    console.error('[ERREUR] Chargement matières:', err)
-  }
-}
-
-// Load KLASSCI evaluations
-async function loadEvaluationsKlassci() {
-  try {
-    const result = await klassciService.getEvaluations(filters)
-    if (result.success) {
-      evaluationsKlassci.value = result.data
-      console.log('[SUCCESS] Évaluations KLASSCI:', evaluationsKlassci.value.length)
-    }
-  } catch (err) {
-    console.error('[ERREUR] Chargement évaluations KLASSCI, utilisation du dashboard:', err)
-
-    // Fallback: use dashboard
-    try {
-      const dashboard = await klassciService.getTeacherDashboard()
-      if (dashboard && dashboard.evaluations) {
-        evaluationsKlassci.value = dashboard.evaluations
-        console.log('[SUCCESS] Évaluations depuis dashboard:', evaluationsKlassci.value.length)
-      }
-    } catch (dashboardError) {
-      console.error('[ERREUR] Fallback dashboard:', dashboardError)
-    }
-  }
-}
-
-// Load LMS evaluations
-async function loadEvaluationsLMS() {
-  try {
-    const result = await evaluationService.getEvaluations()
-    if (result.success) {
-      evaluationsLMS.value = result.data.map(e => ({
-        ...e,
-        questions_count: e.questions?.length || 0,
-        submissions_count: e.submissions?.length || 0
-      }))
-      console.log('[SUCCESS] Évaluations LMS:', evaluationsLMS.value.length)
-    }
-  } catch (err) {
-    console.warn('[INFO] Aucune évaluation LMS (normal si aucune créée):', err.message)
-    evaluationsLMS.value = []
-  }
-}
-
-// Apply filters
-function applyFilters() {
-  console.log('[FILTERS] Filtres appliqués:', filters)
-}
-
-// Reset filters
-function resetFilters() {
-  filters.classe_id = ''
-  filters.matiere_id = ''
-  filters.statut = ''
-  console.log('[FILTERS] Filtres réinitialisés')
-}
 
 // getStatusBadgeClass / getStatusLabel / getStatusTooltip : importés depuis
 // @/utils/evaluations (#28). getStatusIcon reste ici (mappe des composants Vue).


### PR DESCRIPTION
## #28 — Décomposition `TeacherEvaluations.vue` (tranche 2/3)

Suite de #44. Extraction de la couche **données** dans un composable.

### Changements
- ➕ **`src/composables/useTeacherEvaluations.js`** (168 l.) : état réactif, `filters`, chargements (KLASSCI + LMS, cache classes/matières, fallback dashboard) et valeurs dérivées (`evaluationsWithOnline`, `filteredEvaluations`, `stats`, `expiredWithoutOnlineCount`) calculées via les fonctions pures de `@/utils/evaluations` (#44).
- ♻️ La vue consomme le composable par destructuration ; fetch + état + dérivés retirés. Mappers de statut conservés (usage template). **1800 → 1654 l.**
- **Comportement préservé** : mêmes appels, même cache, mêmes dérivés. Les actions (create/sync/publish/delete) restent dans la vue et appellent `loadEvaluationsLMS()` du composable.

### Cumul décomposition
1877 → **1654 l.** (−223). Reste la **tranche 3** : sous-composants à slots (table, cartes stats, barre de filtres, modale création) — c'est elle qui ramènera la vue sous un seuil raisonnable.

### Vérifications
- ✅ `npm run test` → 180/180
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)