### PR TITLE
refactor(attendance): logique pure de SeanceAttendanceHistory — #28 (1/3)

### DIFF
--- a/.claude/specs/god-seance-attendance-history/requirements.md
+++ b/.claude/specs/god-seance-attendance-history/requirements.md
@@ -1,0 +1,38 @@
+# Requirements — Décomposition `SeanceAttendanceHistory.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1 (≤ 300 l/fichier). 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/views/attendance/SeanceAttendanceHistory.vue` : **1708 lignes**, Options API
+(`export default {}`), template 1-322, script 324-719, styles ≈ 990 l.
+~12 responsabilités (issue #28).
+
+| Catégorie | Éléments (fichier:ligne) |
+|---|---|
+| **Logique métier PURE** | seuils de présence `getRateClass` 80/60 % (:685), mappers `getStatusBadgeClass` (:691) / `getStatusClass` (:710) / `getStatusLabel` (:714), bornes de période `getPeriodDates` (:409) |
+| Formatage (dette #23) | `formatDate`/`formatTime`/`formatDateInput`/`formatDuration`/`getInitials` — dupliquent `utils/formatters.js` |
+| Fetch (composable cible) | `loadSeances` (:378), `openSeanceById` (:467), `viewAttendances` (:504) |
+| Export (service cible) | `exportPDF` (:531), `exportExcel` (:580) — fetch blob + téléchargement dans la vue |
+| Actions / UI | `deleteSeance`, `selectPeriod`, `applyCustomDates`, `debouncedSearch`, `clearSearch`, `changePage`, `closeModal` |
+| Template (sous-composants) | tableau des séances, modale de détail des présences, barre de filtres/période |
+
+## Stratégie (tranches TDD)
+
+- **Tranche 1 (cette PR)** — logique métier pure → `src/utils/attendance.js` (TDD). Zéro risque UI.
+- **Tranche 2** — service d'export (`exportAttendancePdf`/`Excel`) + composable de données.
+- **Tranche 3** — sous-composants (tableau, modale, filtres).
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/attendance.js` des fonctions **pures** :
+  `getAttendanceRateClass(rate)`, `getAttendanceStatusBadgeClass(level)`,
+  `getConnectionStatusClass(status)`, `getConnectionStatusLabel(status)`,
+  `getPeriodDates(period, customDates)`.
+- WHEN mêmes entrées qu'aujourd'hui, THE SYSTEM SHALL produire **les mêmes sorties**.
+- THE SYSTEM SHALL couvrir chaque fonction par des tests (seuils limites 80/60, mappers, périodes today/week/month/custom/inconnue).
+- WHEN la vue est refactorée, THE SYSTEM SHALL déléguer ses méthodes à l'util sans changer le rendu.
+
+### Hors périmètre (dette tracée)
+- Formatters dupliqués (`formatDate`…) → #23-FE-1, tranche ultérieure.
+- Export PDF/Excel + fetch → tranche 2. Sous-composants → tranche 3.

--- a/src/utils/attendance.js
+++ b/src/utils/attendance.js
@@ -1,0 +1,96 @@
+/**
+ * Logique métier PURE des présences (#28).
+ *
+ * Extraite de `views/attendance/SeanceAttendanceHistory.vue` (god-component) :
+ * seuils de taux de présence (80 / 60 %), mappers de statut, et calcul des
+ * bornes de période. Fonctions pures → testables et réutilisables.
+ */
+
+/** Convertit une Date en chaîne `YYYY-MM-DD` (local). */
+function toDateInput(date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Classe CSS d'un taux de présence selon les seuils projet (≥ 80 % / ≥ 60 %).
+ * @param {number} rate - pourcentage de présence
+ * @returns {'rate-high'|'rate-medium'|'rate-low'}
+ */
+export function getAttendanceRateClass(rate) {
+  if (rate >= 80) return 'rate-high'
+  if (rate >= 60) return 'rate-medium'
+  return 'rate-low'
+}
+
+/**
+ * Classe CSS du badge de statut de présence d'un participant.
+ * @param {string} statusLevel - present|partial|low|absent|ongoing
+ * @returns {string}
+ */
+export function getAttendanceStatusBadgeClass(statusLevel) {
+  const base = 'status-badge'
+  switch (statusLevel) {
+    case 'present':
+      return `${base} status-present`
+    case 'partial':
+      return `${base} status-partial`
+    case 'low':
+      return `${base} status-low`
+    case 'absent':
+      return `${base} status-absent`
+    case 'ongoing':
+      return `${base} status-ongoing`
+    default:
+      return base
+  }
+}
+
+/** Classe CSS de l'état de connexion (`connected` → en ligne). */
+export function getConnectionStatusClass(status) {
+  return status === 'connected' ? 'status-online' : 'status-offline'
+}
+
+/** Libellé de l'état de connexion (`connected` → « Connecté »). */
+export function getConnectionStatusLabel(status) {
+  return status === 'connected' ? 'Connecté' : 'Déconnecté'
+}
+
+/**
+ * Bornes de date `{ from, to }` (YYYY-MM-DD) pour une période donnée.
+ * @param {'today'|'week'|'month'|'custom'} period
+ * @param {{ from?: string, to?: string }} [customDates] - utilisé si period === 'custom'
+ * @returns {{ from?: string, to?: string }}
+ */
+export function getPeriodDates(period, customDates = {}) {
+  const now = new Date()
+  const dates = {}
+
+  switch (period) {
+    case 'today':
+      dates.from = toDateInput(now)
+      dates.to = toDateInput(now)
+      break
+    case 'week': {
+      const weekStart = new Date(now)
+      weekStart.setDate(now.getDate() - now.getDay())
+      dates.from = toDateInput(weekStart)
+      dates.to = toDateInput(now)
+      break
+    }
+    case 'month': {
+      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
+      dates.from = toDateInput(monthStart)
+      dates.to = toDateInput(now)
+      break
+    }
+    case 'custom':
+      dates.from = customDates.from
+      dates.to = customDates.to
+      break
+  }
+
+  return dates
+}

--- a/src/views/attendance/SeanceAttendanceHistory.vue
+++ b/src/views/attendance/SeanceAttendanceHistory.vue
@@ -327,6 +327,14 @@ import ContentLoader from '@/components/common/ContentLoader.vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
 import { apiBaseUrl } from '@/constants/http'
+// #28 : logique métier pure extraite (testée dans tests/unit/attendance.test.js)
+import {
+  getAttendanceRateClass,
+  getAttendanceStatusBadgeClass,
+  getConnectionStatusClass,
+  getConnectionStatusLabel,
+  getPeriodDates
+} from '@/utils/attendance'
 
 export default {
   name: 'SeanceAttendanceHistory',
@@ -407,32 +415,8 @@ export default {
     },
 
     getPeriodDates() {
-      const now = new Date()
-      const dates = {}
-
-      switch (this.selectedPeriod) {
-        case 'today':
-          dates.from = this.formatDateInput(now)
-          dates.to = this.formatDateInput(now)
-          break
-        case 'week':
-          const weekStart = new Date(now)
-          weekStart.setDate(now.getDate() - now.getDay())
-          dates.from = this.formatDateInput(weekStart)
-          dates.to = this.formatDateInput(now)
-          break
-        case 'month':
-          const monthStart = new Date(now.getFullYear(), now.getMonth(), 1)
-          dates.from = this.formatDateInput(monthStart)
-          dates.to = this.formatDateInput(now)
-          break
-        case 'custom':
-          dates.from = this.customDates.from
-          dates.to = this.customDates.to
-          break
-      }
-
-      return dates
+      // #28 : logique pure déléguée à utils/attendance
+      return getPeriodDates(this.selectedPeriod, this.customDates)
     },
 
     selectPeriod(period) {
@@ -682,37 +666,21 @@ export default {
         .substring(0, 2)
     },
 
+    // #28 : logique pure déléguée à utils/attendance
     getRateClass(rate) {
-      if (rate >= 80) return 'rate-high'
-      if (rate >= 60) return 'rate-medium'
-      return 'rate-low'
+      return getAttendanceRateClass(rate)
     },
 
     getStatusBadgeClass(statusLevel) {
-      const baseClass = 'status-badge'
-
-      switch (statusLevel) {
-        case 'present':
-          return `${baseClass} status-present`
-        case 'partial':
-          return `${baseClass} status-partial`
-        case 'low':
-          return `${baseClass} status-low`
-        case 'absent':
-          return `${baseClass} status-absent`
-        case 'ongoing':
-          return `${baseClass} status-ongoing`
-        default:
-          return baseClass
-      }
+      return getAttendanceStatusBadgeClass(statusLevel)
     },
 
     getStatusClass(status) {
-      return status === 'connected' ? 'status-online' : 'status-offline'
+      return getConnectionStatusClass(status)
     },
 
     getStatusLabel(status) {
-      return status === 'connected' ? 'Connecté' : 'Déconnecté'
+      return getConnectionStatusLabel(status)
     }
   }
 }

--- a/tests/unit/attendance.test.js
+++ b/tests/unit/attendance.test.js
@@ -1,0 +1,74 @@
+/**
+ * Tests de la logique métier pure des présences (#28 — décomposition
+ * SeanceAttendanceHistory.vue, tranche 1). Seuils 80/60 %, mappers, périodes.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  getAttendanceRateClass,
+  getAttendanceStatusBadgeClass,
+  getConnectionStatusClass,
+  getConnectionStatusLabel,
+  getPeriodDates
+} from '@/utils/attendance'
+
+describe('utils/attendance — getAttendanceRateClass (seuils 80/60)', () => {
+  it('≥ 80 → rate-high', () => {
+    expect(getAttendanceRateClass(80)).toBe('rate-high')
+    expect(getAttendanceRateClass(100)).toBe('rate-high')
+  })
+  it('≥ 60 et < 80 → rate-medium', () => {
+    expect(getAttendanceRateClass(60)).toBe('rate-medium')
+    expect(getAttendanceRateClass(79)).toBe('rate-medium')
+  })
+  it('< 60 → rate-low', () => {
+    expect(getAttendanceRateClass(59)).toBe('rate-low')
+    expect(getAttendanceRateClass(0)).toBe('rate-low')
+  })
+})
+
+describe('utils/attendance — getAttendanceStatusBadgeClass', () => {
+  it('mappe chaque niveau', () => {
+    expect(getAttendanceStatusBadgeClass('present')).toBe('status-badge status-present')
+    expect(getAttendanceStatusBadgeClass('partial')).toBe('status-badge status-partial')
+    expect(getAttendanceStatusBadgeClass('low')).toBe('status-badge status-low')
+    expect(getAttendanceStatusBadgeClass('absent')).toBe('status-badge status-absent')
+    expect(getAttendanceStatusBadgeClass('ongoing')).toBe('status-badge status-ongoing')
+  })
+  it('niveau inconnu → classe de base seule', () => {
+    expect(getAttendanceStatusBadgeClass('xxx')).toBe('status-badge')
+  })
+})
+
+describe('utils/attendance — état de connexion', () => {
+  it('connected → en ligne / Connecté', () => {
+    expect(getConnectionStatusClass('connected')).toBe('status-online')
+    expect(getConnectionStatusLabel('connected')).toBe('Connecté')
+  })
+  it('autre → hors ligne / Déconnecté', () => {
+    expect(getConnectionStatusClass('disconnected')).toBe('status-offline')
+    expect(getConnectionStatusLabel('')).toBe('Déconnecté')
+  })
+})
+
+describe('utils/attendance — getPeriodDates', () => {
+  it('custom : reprend les dates fournies', () => {
+    expect(getPeriodDates('custom', { from: '2026-01-01', to: '2026-01-31' }))
+      .toEqual({ from: '2026-01-01', to: '2026-01-31' })
+  })
+  it('today : from === to, format YYYY-MM-DD', () => {
+    const { from, to } = getPeriodDates('today')
+    expect(from).toBe(to)
+    expect(from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+  it('week/month : bornes valides YYYY-MM-DD, from <= to', () => {
+    for (const period of ['week', 'month']) {
+      const { from, to } = getPeriodDates(period)
+      expect(from).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(to).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(from <= to).toBe(true)
+    }
+  })
+  it('période inconnue : objet vide', () => {
+    expect(getPeriodDates('annee')).toEqual({})
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `SeanceAttendanceHistory.vue` (tranche 1/3)

2ᵉ god-component du TIER 2 (1708 l., ~12 responsabilités). Spec : `.claude/specs/god-seance-attendance-history/`.

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/attendance.js`** : fonctions pures — `getAttendanceRateClass` (**seuils projet 80 / 60 %**), `getAttendanceStatusBadgeClass`, `getConnectionStatusClass`, `getConnectionStatusLabel`, `getPeriodDates`.
- ✅ **`tests/unit/attendance.test.js`** — 11 cas (limites 80/60, mappers de statut, périodes today/week/month/custom/inconnue).
- ♻️ La vue délègue ses méthodes au module ; corps inline retirés (**1708 → 1676 l.**).
- Parité comportementale (mêmes sorties).

### Suite (réf #28, même vue)
- **Tranche 2** : service d'export PDF/Excel (`exportPDF`/`exportExcel` sortis de la vue) + composable de données.
- **Tranche 3** : sous-composants (tableau des séances, modale de détail, barre de filtres).

### Dette tracée
- Formatters dupliqués (`formatDate`/`formatTime`/`formatDuration`/`getInitials`) → #23-FE-1.
- La vue reste un god-component tant que tranches 2-3 ne sont pas livrées.

### Vérifications
- ✅ `npm run test` → 191/191
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)