### PR TITLE
refactor(attendance): service d'export présences — #28 (2/3)

### DIFF
--- a/src/services/attendanceExport.js
+++ b/src/services/attendanceExport.js
@@ -1,0 +1,68 @@
+import { apiBaseUrl } from '@/constants/http'
+import { useAuthStore } from '@/stores/auth'
+
+/**
+ * Service d'export des présences d'une séance (#28).
+ *
+ * Mutualise le téléchargement PDF/Excel qui était dupliqué à l'identique dans
+ * SeanceAttendanceHistory.vue (fetch authentifié + blob + ancre de
+ * téléchargement). Le endpoint backend renvoie un fichier binaire ; on ne peut
+ * donc pas passer par l'intercepteur axios habituel (réponse blob + header
+ * Accept spécifique), d'où le `fetch` direct avec Bearer.
+ */
+
+/**
+ * Télécharge un export binaire de présences et déclenche la sauvegarde fichier.
+ * @param {number|string} seanceId - id KLASSCI de la séance
+ * @param {{ format: string, accept: string, extension: string, errorLabel: string }} opts
+ */
+async function downloadPresenceExport(seanceId, { format, accept, extension, errorLabel }) {
+  const url = `${apiBaseUrl()}/lms/seances/${seanceId}/export/presences/${format}`
+  const token = useAuthStore().token
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: accept
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(errorLabel)
+  }
+
+  const blob = await response.blob()
+  const downloadUrl = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = downloadUrl
+  a.download = `presences_seance_${seanceId}_${new Date().toISOString().split('T')[0]}.${extension}`
+  document.body.appendChild(a)
+  a.click()
+  window.URL.revokeObjectURL(downloadUrl)
+  document.body.removeChild(a)
+}
+
+export const attendanceExportService = {
+  /** Exporte les présences en PDF. */
+  exportPdf(seanceId) {
+    return downloadPresenceExport(seanceId, {
+      format: 'pdf',
+      accept: 'application/pdf',
+      extension: 'pdf',
+      errorLabel: 'Erreur lors du téléchargement du PDF'
+    })
+  },
+
+  /** Exporte les présences en Excel (.xlsx). */
+  exportExcel(seanceId) {
+    return downloadPresenceExport(seanceId, {
+      format: 'excel',
+      accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      extension: 'xlsx',
+      errorLabel: 'Erreur lors du téléchargement du fichier Excel'
+    })
+  }
+}
+
+export default attendanceExportService

--- a/src/views/attendance/SeanceAttendanceHistory.vue
+++ b/src/views/attendance/SeanceAttendanceHistory.vue
@@ -325,8 +325,7 @@
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import lmsService from '@/services/lms'
-import { useAuthStore } from '@/stores/auth'
-import { apiBaseUrl } from '@/constants/http'
+import attendanceExportService from '@/services/attendanceExport'
 // #28 : logique métier pure extraite (testée dans tests/unit/attendance.test.js)
 import {
   getAttendanceRateClass,
@@ -512,44 +511,12 @@ export default {
     /**
      * Exporter la liste de présence en PDF
      */
+    // #28 : téléchargement (fetch + blob) délégué à attendanceExportService.
     async exportPDF() {
       if (this.exporting || !this.selectedSeance) return
-
       this.exporting = true
       try {
-        console.log('[SeanceHistory] Export PDF de la séance', this.selectedSeance.klassci_seance_id)
-
-        const API_URL = apiBaseUrl()
-        const token = useAuthStore().token
-
-        // Créer l'URL de téléchargement
-        const url = `${API_URL}/lms/seances/${this.selectedSeance.klassci_seance_id}/export/presences/pdf`
-
-        // Télécharger le fichier
-        const response = await fetch(url, {
-          method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Accept': 'application/pdf'
-          }
-        })
-
-        if (!response.ok) {
-          throw new Error('Erreur lors du téléchargement du PDF')
-        }
-
-        // Créer un blob et télécharger
-        const blob = await response.blob()
-        const downloadUrl = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = downloadUrl
-        a.download = `presences_seance_${this.selectedSeance.klassci_seance_id}_${new Date().toISOString().split('T')[0]}.pdf`
-        document.body.appendChild(a)
-        a.click()
-        window.URL.revokeObjectURL(downloadUrl)
-        document.body.removeChild(a)
-
-        console.log('[SeanceHistory] ✅ PDF téléchargé avec succès')
+        await attendanceExportService.exportPdf(this.selectedSeance.klassci_seance_id)
       } catch (error) {
         console.error('[SeanceHistory] Erreur export PDF:', error)
         this.$toast?.error('Erreur lors de l\'export PDF : ' + error.message)
@@ -558,47 +525,11 @@ export default {
       }
     },
 
-    /**
-     * Exporter la liste de présence en Excel
-     */
     async exportExcel() {
       if (this.exporting || !this.selectedSeance) return
-
       this.exporting = true
       try {
-        console.log('[SeanceHistory] Export Excel de la séance', this.selectedSeance.klassci_seance_id)
-
-        const API_URL = apiBaseUrl()
-        const token = useAuthStore().token
-
-        // Créer l'URL de téléchargement
-        const url = `${API_URL}/lms/seances/${this.selectedSeance.klassci_seance_id}/export/presences/excel`
-
-        // Télécharger le fichier
-        const response = await fetch(url, {
-          method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Accept': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-          }
-        })
-
-        if (!response.ok) {
-          throw new Error('Erreur lors du téléchargement du fichier Excel')
-        }
-
-        // Créer un blob et télécharger
-        const blob = await response.blob()
-        const downloadUrl = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = downloadUrl
-        a.download = `presences_seance_${this.selectedSeance.klassci_seance_id}_${new Date().toISOString().split('T')[0]}.xlsx`
-        document.body.appendChild(a)
-        a.click()
-        window.URL.revokeObjectURL(downloadUrl)
-        document.body.removeChild(a)
-
-        console.log('[SeanceHistory] ✅ Excel téléchargé avec succès')
+        await attendanceExportService.exportExcel(this.selectedSeance.klassci_seance_id)
       } catch (error) {
         console.error('[SeanceHistory] Erreur export Excel:', error)
         this.$toast?.error('Erreur lors de l\'export Excel : ' + error.message)

--- a/tests/unit/attendanceExport.test.js
+++ b/tests/unit/attendanceExport.test.js
@@ -1,0 +1,47 @@
+/**
+ * Tests du service d'export des présences (#28, tranche 2).
+ * Vérifie l'URL et le header Accept par format, et la levée d'erreur sur échec.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => ({ token: 'TEST_TOKEN' }) }))
+vi.mock('@/constants/http', () => ({ apiBaseUrl: () => 'http://api.test/api' }))
+
+import attendanceExportService from '@/services/attendanceExport'
+
+describe('services/attendanceExport (#28)', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob(['x'])) })
+    )
+    window.URL.createObjectURL = vi.fn(() => 'blob:mock')
+    window.URL.revokeObjectURL = vi.fn()
+  })
+
+  it('exportPdf : appelle le bon endpoint avec Accept application/pdf + Bearer', async () => {
+    await attendanceExportService.exportPdf(42)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://api.test/api/lms/seances/42/export/presences/pdf',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer TEST_TOKEN',
+          Accept: 'application/pdf'
+        })
+      })
+    )
+  })
+
+  it('exportExcel : endpoint excel + Accept xlsx', async () => {
+    await attendanceExportService.exportExcel(7)
+    const [url, opts] = global.fetch.mock.calls[0]
+    expect(url).toBe('http://api.test/api/lms/seances/7/export/presences/excel')
+    expect(opts.headers.Accept).toContain('spreadsheetml.sheet')
+  })
+
+  it('lève l\'erreur libellée si la réponse n\'est pas ok', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false }))
+    await expect(attendanceExportService.exportPdf(1)).rejects.toThrow('Erreur lors du téléchargement du PDF')
+    await expect(attendanceExportService.exportExcel(1)).rejects.toThrow('Erreur lors du téléchargement du fichier Excel')
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `SeanceAttendanceHistory.vue` (tranche 2/3)

Suite de #47 (logique pure). Extraction de l'export PDF/Excel hors de la vue.

### Changements
- ➕ **`src/services/attendanceExport.js`** : `exportPdf` / `exportExcel` mutualisés. Les deux fonctions quasi identiques de la vue (≈ 45 l. chacune : `fetch` authentifié + blob + ancre de téléchargement) passent par un helper paramétré (format / Accept / extension / libellé d'erreur).
- ✅ **`tests/unit/attendanceExport.test.js`** — 3 cas (URL + Accept PDF, URL + Accept Excel, erreur libellée sur réponse non-ok).
- ♻️ La vue délègue `exportPDF`/`exportExcel` au service (conserve l'état `exporting` + le toast). Imports `apiBaseUrl`/`useAuthStore` retirés. **1676 → 1607 l.**
- **Comportement préservé** : mêmes endpoints, headers, noms de fichiers, messages d'erreur. Le `fetch` direct (réponse blob, hors intercepteur axios) est conservé.

### Suite (réf #28, même vue)
- **Tranche 3** : composable de données (`loadSeances`/`openSeanceById`/`viewAttendances` + pagination/filtres) puis sous-composants (tableau, modale de détail, filtres).

### Vérifications
- ✅ `npm run test` → 194/194
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)