### PR TITLE
refactor(calendar): logique pure de UniversalCalendar — #28

### DIFF
--- a/.claude/specs/god-universal-calendar/requirements.md
+++ b/.claude/specs/god-universal-calendar/requirements.md
@@ -1,0 +1,29 @@
+# Requirements — Décomposition `UniversalCalendar.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/components/calendar/UniversalCalendar.vue` : **1613 lignes**, `<script setup>`,
+~10 responsabilités. Logique pure identifiée (fichier:ligne, avant extraction) :
+`determineSeanceColor` (:512), `determineEvaluationColor` (:534),
+`isEvaluationUrgent` (:541), `getDateRangeStart`/`getDateRangeEnd` (:555/:571).
+Fetch (`loadEvents`/`loadSeances`/`loadEvaluations`/`loadFilterOptions`),
+options FullCalendar, et handlers de navigation restent dans le composant.
+
+## Stratégie (tranches TDD)
+
+- **Tranche 1 (cette PR)** — logique pure → `src/utils/calendar.js` (TDD). Zéro risque UI.
+- **Tranche 2 (éventuelle)** — composable de données (loadEvents + filtres + état)
+  et/ou sous-composants (barre de filtres, légende).
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/calendar.js` des fonctions **pures** :
+  `determineSeanceColor(seance)`, `determineEvaluationColor(evaluation)`,
+  `isEvaluationUrgent(evaluation)`, `getDateRangeStart(preset)`, `getDateRangeEnd(preset)`.
+- WHEN mêmes entrées qu'aujourd'hui, THE SYSTEM SHALL produire les mêmes sorties.
+- THE SYSTEM SHALL couvrir chaque fonction par des tests (couleurs par statut,
+  urgence < 24 h / passée / invalide / sans date, présets de plage).
+- WHEN le composant est refactoré, THE SYSTEM SHALL importer ces fonctions et
+  passer `dateRangePreset.value` aux bornes, sans changer le comportement.

--- a/src/components/calendar/UniversalCalendar.vue
+++ b/src/components/calendar/UniversalCalendar.vue
@@ -195,6 +195,14 @@ import { lmsService } from '@/services/lms'
 import evaluationService from '@/services/evaluation'
 import EventDetailModal from './EventDetailModal.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
+// #28 : logique métier pure extraite (testée dans tests/unit/calendar.test.js)
+import {
+  determineSeanceColor,
+  determineEvaluationColor,
+  isEvaluationUrgent,
+  getDateRangeStart,
+  getDateRangeEnd
+} from '@/utils/calendar'
 
 const props = defineProps({
   userRole: {
@@ -372,8 +380,8 @@ async function loadSeances(forceRefresh = false) {
       case 'coordinator':
       case 'admin':
         response = await lmsService.getUpcomingSeances({
-          date_debut: getDateRangeStart(),
-          date_fin: getDateRangeEnd(),
+          date_debut: getDateRangeStart(dateRangePreset.value),
+          date_fin: getDateRangeEnd(dateRangePreset.value),
           refresh: forceRefresh
         })
         break
@@ -420,8 +428,8 @@ async function loadEvaluations() {
       case 'coordinator':
       case 'admin':
         response = await evaluationService.getEvaluations({
-          date_debut: getDateRangeStart(),
-          date_fin: getDateRangeEnd()
+          date_debut: getDateRangeStart(dateRangePreset.value),
+          date_fin: getDateRangeEnd(dateRangePreset.value)
         })
         break
     }
@@ -506,95 +514,6 @@ async function loadFilterOptions() {
     enseignants.value = Array.from(allEnseignants.values()).sort((a, b) => a.nom.localeCompare(b.nom))
   } catch (error) {
     console.error('Erreur chargement options de filtres:', error)
-  }
-}
-
-function determineSeanceColor(seance) {
-  const visioStatus = seance.visio?.status
-
-  // Vert vif si visio active (en cours)
-  if (visioStatus === 'active') {
-    return '#10b981'
-  }
-
-  // Bleu si visio programmée (en attente de démarrage)
-  if (visioStatus === 'programmee') {
-    return '#3b82f6'
-  }
-
-  // Gris si visio terminée
-  if (visioStatus === 'terminee') {
-    return '#6b7280'
-  }
-
-  // Bleu LMS par défaut
-  return '#2563eb'
-}
-
-function determineEvaluationColor(evaluation) {
-  if (isEvaluationUrgent(evaluation)) {
-    return '#ef4444' // Rouge urgent
-  }
-  return '#ea580c' // LMS orange pour évaluations // Orange LMS
-}
-
-function isEvaluationUrgent(evaluation) {
-  const dateStr = evaluation.programmation?.date_evaluation || evaluation.date_evaluation
-  if (!dateStr) return false // Pas de date = pas urgent
-
-  const now = new Date()
-  const evalDate = new Date(dateStr)
-
-  // Verification que la date est valide
-  if (isNaN(evalDate.getTime())) return false
-
-  const hoursDiff = (evalDate - now) / (1000 * 60 * 60)
-  return hoursDiff < 24 && hoursDiff > 0
-}
-
-function getDateRangeStart() {
-  const now = new Date()
-  switch (dateRangePreset.value) {
-    case 'today':
-      return now.toISOString().split('T')[0]
-    case 'week':
-      const startOfWeek = new Date(now)
-      startOfWeek.setDate(now.getDate() - now.getDay() + 1)
-      return startOfWeek.toISOString().split('T')[0]
-    case 'month':
-      return new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0]
-    default:
-      return now.toISOString().split('T')[0]
-  }
-}
-
-function getDateRangeEnd() {
-  const now = new Date()
-  switch (dateRangePreset.value) {
-    case 'today':
-      return now.toISOString().split('T')[0]
-    case 'week':
-      const endOfWeek = new Date(now)
-      endOfWeek.setDate(now.getDate() + (7 - now.getDay()))
-      return endOfWeek.toISOString().split('T')[0]
-    case 'month':
-      return new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split('T')[0]
-    case '7days':
-      const in7Days = new Date(now)
-      in7Days.setDate(now.getDate() + 7)
-      return in7Days.toISOString().split('T')[0]
-    case '30days':
-      const in30Days = new Date(now)
-      in30Days.setDate(now.getDate() + 30)
-      return in30Days.toISOString().split('T')[0]
-    case '90days':
-      const in90Days = new Date(now)
-      in90Days.setDate(now.getDate() + 90)
-      return in90Days.toISOString().split('T')[0]
-    default:
-      const in30DaysDefault = new Date(now)
-      in30DaysDefault.setDate(now.getDate() + 30)
-      return in30DaysDefault.toISOString().split('T')[0]
   }
 }
 

--- a/src/utils/calendar.js
+++ b/src/utils/calendar.js
@@ -1,0 +1,119 @@
+/**
+ * Logique métier PURE du calendrier unifié (#28).
+ *
+ * Extraite de `components/calendar/UniversalCalendar.vue` (god-component) :
+ * couleurs d'événements (séances/évaluations), urgence d'évaluation, et bornes
+ * de date par préréglage. Fonctions pures → testables et réutilisables.
+ */
+
+const COLORS = {
+  visioActive: '#10b981',
+  visioProgrammee: '#3b82f6',
+  visioTerminee: '#6b7280',
+  seanceDefault: '#2563eb',
+  evaluationUrgent: '#ef4444',
+  evaluation: '#ea580c'
+}
+
+/** Convertit une Date en `YYYY-MM-DD`. */
+function toIsoDate(date) {
+  return date.toISOString().split('T')[0]
+}
+
+/**
+ * Couleur d'une séance selon le statut visio.
+ * @param {Object} seance
+ * @returns {string} code couleur hex
+ */
+export function determineSeanceColor(seance) {
+  switch (seance.visio?.status) {
+    case 'active':
+      return COLORS.visioActive
+    case 'programmee':
+      return COLORS.visioProgrammee
+    case 'terminee':
+      return COLORS.visioTerminee
+    default:
+      return COLORS.seanceDefault
+  }
+}
+
+/**
+ * Une évaluation est-elle urgente (commence dans moins de 24 h, future) ?
+ * @param {Object} evaluation
+ * @returns {boolean}
+ */
+export function isEvaluationUrgent(evaluation) {
+  const dateStr = evaluation.programmation?.date_evaluation || evaluation.date_evaluation
+  if (!dateStr) return false
+
+  const evalDate = new Date(dateStr)
+  if (isNaN(evalDate.getTime())) return false
+
+  const hoursDiff = (evalDate - new Date()) / (1000 * 60 * 60)
+  return hoursDiff < 24 && hoursDiff > 0
+}
+
+/**
+ * Couleur d'une évaluation (rouge si urgente, orange sinon).
+ * @param {Object} evaluation
+ * @returns {string}
+ */
+export function determineEvaluationColor(evaluation) {
+  return isEvaluationUrgent(evaluation) ? COLORS.evaluationUrgent : COLORS.evaluation
+}
+
+/**
+ * Date de début (YYYY-MM-DD) pour un préréglage de plage.
+ * @param {'today'|'week'|'month'|string} preset
+ * @returns {string}
+ */
+export function getDateRangeStart(preset) {
+  const now = new Date()
+  switch (preset) {
+    case 'today':
+      return toIsoDate(now)
+    case 'week': {
+      const startOfWeek = new Date(now)
+      startOfWeek.setDate(now.getDate() - now.getDay() + 1)
+      return toIsoDate(startOfWeek)
+    }
+    case 'month':
+      return toIsoDate(new Date(now.getFullYear(), now.getMonth(), 1))
+    default:
+      return toIsoDate(now)
+  }
+}
+
+/**
+ * Date de fin (YYYY-MM-DD) pour un préréglage de plage.
+ * @param {'today'|'week'|'month'|'7days'|'30days'|'90days'|string} preset
+ * @returns {string}
+ */
+export function getDateRangeEnd(preset) {
+  const now = new Date()
+  const inDays = (n) => {
+    const d = new Date(now)
+    d.setDate(now.getDate() + n)
+    return toIsoDate(d)
+  }
+  switch (preset) {
+    case 'today':
+      return toIsoDate(now)
+    case 'week': {
+      const endOfWeek = new Date(now)
+      endOfWeek.setDate(now.getDate() + (7 - now.getDay()))
+      return toIsoDate(endOfWeek)
+    }
+    case 'month':
+      return toIsoDate(new Date(now.getFullYear(), now.getMonth() + 1, 0))
+    case '7days':
+      return inDays(7)
+    case '30days':
+      return inDays(30)
+    case '90days':
+      return inDays(90)
+    default:
+      return inDays(30)
+  }
+}

--- a/tests/unit/calendar.test.js
+++ b/tests/unit/calendar.test.js
@@ -1,0 +1,74 @@
+/**
+ * Tests de la logique métier pure du calendrier (#28 — décomposition
+ * UniversalCalendar.vue, tranche 1). Couleurs, urgence, bornes de date.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  determineSeanceColor,
+  determineEvaluationColor,
+  isEvaluationUrgent,
+  getDateRangeStart,
+  getDateRangeEnd
+} from '@/utils/calendar'
+
+describe('utils/calendar — determineSeanceColor', () => {
+  it('mappe le statut visio vers la couleur', () => {
+    expect(determineSeanceColor({ visio: { status: 'active' } })).toBe('#10b981')
+    expect(determineSeanceColor({ visio: { status: 'programmee' } })).toBe('#3b82f6')
+    expect(determineSeanceColor({ visio: { status: 'terminee' } })).toBe('#6b7280')
+  })
+  it('couleur LMS par défaut si pas de visio', () => {
+    expect(determineSeanceColor({})).toBe('#2563eb')
+    expect(determineSeanceColor({ visio: { status: 'inconnu' } })).toBe('#2563eb')
+  })
+})
+
+describe('utils/calendar — isEvaluationUrgent', () => {
+  it('false sans date', () => {
+    expect(isEvaluationUrgent({})).toBe(false)
+  })
+  it('false si date invalide', () => {
+    expect(isEvaluationUrgent({ date_evaluation: 'pas-une-date' })).toBe(false)
+  })
+  it('true si < 24 h dans le futur', () => {
+    const inOneHour = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    expect(isEvaluationUrgent({ date_evaluation: inOneHour })).toBe(true)
+  })
+  it('false si > 24 h', () => {
+    const inTwoDays = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString()
+    expect(isEvaluationUrgent({ date_evaluation: inTwoDays })).toBe(false)
+  })
+  it('false si déjà passée', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    expect(isEvaluationUrgent({ date_evaluation: yesterday })).toBe(false)
+  })
+  it('priorité à programmation.date_evaluation', () => {
+    const soon = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    expect(isEvaluationUrgent({ programmation: { date_evaluation: soon }, date_evaluation: '2000-01-01' })).toBe(true)
+  })
+})
+
+describe('utils/calendar — determineEvaluationColor', () => {
+  it('rouge si urgent, orange sinon', () => {
+    const soon = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    expect(determineEvaluationColor({ date_evaluation: soon })).toBe('#ef4444')
+    expect(determineEvaluationColor({})).toBe('#ea580c')
+  })
+})
+
+describe('utils/calendar — bornes de date', () => {
+  const isoRe = /^\d{4}-\d{2}-\d{2}$/
+  it('start : today/week/month/défaut au format YYYY-MM-DD', () => {
+    for (const p of ['today', 'week', 'month', 'autre']) {
+      expect(getDateRangeStart(p)).toMatch(isoRe)
+    }
+  })
+  it('end : tous les présets au format YYYY-MM-DD', () => {
+    for (const p of ['today', 'week', 'month', '7days', '30days', '90days', 'defaut']) {
+      expect(getDateRangeEnd(p)).toMatch(isoRe)
+    }
+  })
+  it('end 30days > today', () => {
+    expect(getDateRangeEnd('30days') > getDateRangeEnd('today')).toBe(true)
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `UniversalCalendar.vue` (tranche 1)

3ᵉ god-component du TIER 2 (1613 l., ~10 responsabilités). Spec : `.claude/specs/god-universal-calendar/`.

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/calendar.js`** : fonctions pures — `determineSeanceColor` (statut visio → couleur), `determineEvaluationColor`, `isEvaluationUrgent` (< 24 h, future), `getDateRangeStart` / `getDateRangeEnd` (présets `today`/`week`/`month`/`7days`/`30days`/`90days`).
- ✅ **`tests/unit/calendar.test.js`** — 12 cas (couleurs par statut, urgence future/passée/invalide/sans date/priorité `programmation`, présets de plage).
- ♻️ Le composant importe le module ; défs locales retirées, call-sites de date reçoivent `dateRangePreset.value`. **1613 → 1532 l.**
- Parité comportementale (mêmes sorties).

### Vérifications
- ✅ `npm run test` → 206/206
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)