### PR TITLE
refactor(chapters): logique pure de ChapterManager — #28

### DIFF
--- a/.claude/specs/god-chapter-manager/requirements.md
+++ b/.claude/specs/god-chapter-manager/requirements.md
@@ -1,0 +1,31 @@
+# Requirements — Décomposition `ChapterManager.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/components/lessons/ChapterManager.vue` : **1427 lignes**, Options API, ~10
+responsabilités. La surface de **logique pure** est mince (le gros du fichier est
+du CRUD chapitres/upload + knowledge-checks + template + CSS) :
+`getContentTypeLabel` (mapper), `getContentPreview` (troncature). `getQuizScoreBadge`
+délègue déjà à `knowledgeCheckService` ; `getAcceptedFileTypes` indexe la constante
+`ACCEPTED_FILE_TYPES` (#24).
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — extraire la logique pure restante → `src/utils/chapterContent.js` (TDD). Zéro risque.
+- **Tranche 2 (éventuelle)** — composable CRUD chapitres + upload (nécessite `setup()` ou conversion `<script setup>`), puis sous-composants (carte chapitre, éditeur). Plus gros levier mais plus de risque.
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/chapterContent.js` :
+  `getChapterContentTypeLabel(type)`, `getChapterContentPreview(content)` (pures).
+- WHEN mêmes entrées, THE SYSTEM SHALL produire les mêmes sorties (ellipsis `...`
+  conservé, distinct de `truncate`/formatters qui utilise `…`).
+- THE SYSTEM SHALL couvrir ces fonctions par des tests.
+- WHEN le composant est refactoré, THE SYSTEM SHALL déléguer ses méthodes au module.
+
+## Note
+
+Le plus gros gain pour ce fichier viendra de la tranche 2 (composable + sous-composants),
+pas de la tranche 1 (logique pure limitée).

--- a/src/components/lessons/ChapterManager.vue
+++ b/src/components/lessons/ChapterManager.vue
@@ -264,6 +264,8 @@ import KnowledgeCheckEditor from '@/components/lessons/KnowledgeCheckEditor.vue'
 import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
 import knowledgeCheckService from '@/services/knowledgeCheck'
 import { UPLOAD_CONFIG, ACCEPTED_FILE_TYPES } from '@/constants/upload'
+// #28 : logique pure extraite (testée dans tests/unit/chapterContent.test.js)
+import { getChapterContentTypeLabel, getChapterContentPreview } from '@/utils/chapterContent'
 
 export default {
   name: 'ChapterManager',
@@ -490,22 +492,13 @@ export default {
       return ACCEPTED_FILE_TYPES[contentType] || '*'
     },
 
+    // #28 : logique pure déléguée à utils/chapterContent
     getContentTypeLabel(type) {
-      const labels = {
-        text: 'Texte / Markdown',
-        video: 'Vidéo',
-        powerpoint: 'PowerPoint',
-        word: 'Document Word',
-        pdf: 'PDF',
-        link: 'Lien externe',
-        quiz: 'Quiz / Testez vos connaissances'
-      }
-      return labels[type] || type
+      return getChapterContentTypeLabel(type)
     },
 
     getContentPreview(content) {
-      if (!content) return ''
-      return content.length > 150 ? content.substring(0, 150) + '...' : content
+      return getChapterContentPreview(content)
     },
 
     // =====================

--- a/src/utils/chapterContent.js
+++ b/src/utils/chapterContent.js
@@ -1,0 +1,33 @@
+/**
+ * Logique pure du contenu de chapitre (#28).
+ *
+ * Extraite de `components/lessons/ChapterManager.vue` (god-component) :
+ * libellé du type de contenu et aperçu tronqué. Fonctions pures → testables.
+ */
+
+const CONTENT_TYPE_LABELS = {
+  text: 'Texte / Markdown',
+  video: 'Vidéo',
+  powerpoint: 'PowerPoint',
+  word: 'Document Word',
+  pdf: 'PDF',
+  link: 'Lien externe',
+  quiz: 'Quiz / Testez vos connaissances'
+}
+
+/** Libellé lisible d'un type de contenu de chapitre (fallback : le type brut). */
+export function getChapterContentTypeLabel(type) {
+  return CONTENT_TYPE_LABELS[type] || type
+}
+
+/**
+ * Aperçu tronqué d'un contenu (150 caractères + « ... »).
+ * NB : ellipsis `...` (3 points) volontairement distinct de `truncate`
+ * (utils/formatters, ellipsis `…`) pour préserver l'affichage existant.
+ * @param {string} content
+ * @returns {string}
+ */
+export function getChapterContentPreview(content) {
+  if (!content) return ''
+  return content.length > 150 ? content.substring(0, 150) + '...' : content
+}

--- a/tests/unit/chapterContent.test.js
+++ b/tests/unit/chapterContent.test.js
@@ -1,0 +1,33 @@
+/**
+ * Tests de la logique pure du contenu de chapitre (#28 — ChapterManager.vue).
+ */
+import { describe, it, expect } from 'vitest'
+import { getChapterContentTypeLabel, getChapterContentPreview } from '@/utils/chapterContent'
+
+describe('utils/chapterContent — getChapterContentTypeLabel', () => {
+  it('mappe les types connus', () => {
+    expect(getChapterContentTypeLabel('text')).toBe('Texte / Markdown')
+    expect(getChapterContentTypeLabel('pdf')).toBe('PDF')
+    expect(getChapterContentTypeLabel('quiz')).toBe('Quiz / Testez vos connaissances')
+  })
+  it('fallback : type brut si inconnu', () => {
+    expect(getChapterContentTypeLabel('audio')).toBe('audio')
+  })
+})
+
+describe('utils/chapterContent — getChapterContentPreview', () => {
+  it('vide si pas de contenu', () => {
+    expect(getChapterContentPreview('')).toBe('')
+    expect(getChapterContentPreview(null)).toBe('')
+  })
+  it('renvoie tel quel si <= 150 caractères', () => {
+    const short = 'a'.repeat(150)
+    expect(getChapterContentPreview(short)).toBe(short)
+  })
+  it('tronque à 150 + "..." si plus long', () => {
+    const long = 'a'.repeat(200)
+    const out = getChapterContentPreview(long)
+    expect(out).toBe('a'.repeat(150) + '...')
+    expect(out.endsWith('...')).toBe(true)
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `ChapterManager.vue` (tranche 1)

4ᵉ god-component du TIER 2 (1427 l.). Surface de **logique pure limitée** (le reste = CRUD chapitres/upload + knowledge-checks + template/CSS).

### Tranche 1 — logique pure (zéro risque)
- ➕ **`src/utils/chapterContent.js`** : `getChapterContentTypeLabel` (mapper), `getChapterContentPreview` (troncature 150 + `...`, ellipsis volontairement distinct de `truncate`/formatters qui utilise `…`).
- ✅ **`tests/unit/chapterContent.test.js`** — 5 cas.
- ♻️ Le composant délègue `getContentTypeLabel`/`getContentPreview` au module.

### Honnêteté
Extraction volontairement petite. Le gros gain pour ce fichier viendra d'une **tranche 2** (composable CRUD chapitres + upload, puis sous-composants) — plus risquée (Options API → `setup()`), notée dans le spec.

### Vérifications
- ✅ `npm run test` → 211/211
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)