### PR TITLE
refactor(matieres): logique pure de AdminMatieres — #28

### DIFF
--- a/.claude/specs/god-admin-matieres/requirements.md
+++ b/.claude/specs/god-admin-matieres/requirements.md
@@ -1,0 +1,27 @@
+# Requirements — Décomposition `AdminMatieres.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/views/admin/AdminMatieres.vue` : **1434 lignes**, `<script setup>`.
+L'issue #28 signalait un « computed de ~100 lignes » → c'est
+`filteredNiveauxWithMatieres` (regroupement par niveau). Logique pure identifiée :
+`filteredMatieres` (filtrage), `filteredNiveauxWithMatieres` (regroupement+totaux),
+`stats`, `getMatiereFilieres`, `getMatiereNiveaux`.
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — logique pure → `src/utils/matieres.js` (TDD). Zéro risque.
+- **Tranche 2 (éventuelle)** — sous-composants (table matières, modales niveau/matière).
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/matieres.js` des fonctions pures :
+  `filterMatieres`, `groupMatieresByNiveau`, `computeMatieresStats`,
+  `getMatiereFilieres`, `getMatiereNiveaux`.
+- WHEN mêmes entrées, THE SYSTEM SHALL produire les mêmes sorties (tri/groupes
+  « non défini » / « sans niveau » en fin de liste préservés).
+- THE SYSTEM SHALL couvrir ces fonctions par des tests (filtres, regroupement,
+  fallback, totaux, unicité filières/niveaux).
+- WHEN la vue est refactorée, THE SYSTEM SHALL déléguer ses computeds/méthodes au module.

--- a/src/utils/matieres.js
+++ b/src/utils/matieres.js
@@ -1,0 +1,157 @@
+/**
+ * Logique métier PURE de gestion des matières (#28).
+ *
+ * Extraite de `views/admin/AdminMatieres.vue` (god-component) : filtrage,
+ * regroupement par niveau (ex-computed de ~90 lignes), statistiques et
+ * extraction des filières/niveaux uniques. Fonctions pures → testables.
+ */
+
+/**
+ * Filtre les matières par recherche texte, filière et niveau.
+ * @param {Array<Object>} matieres
+ * @param {{ search?: string, filiere_id?: string|number, niveau_id?: string|number }} filters
+ * @returns {Array<Object>}
+ */
+export function filterMatieres(matieres = [], filters = {}) {
+  let result = matieres
+
+  if (filters.search) {
+    const search = filters.search.toLowerCase()
+    result = result.filter((m) =>
+      (m.nom?.toLowerCase() || '').includes(search) ||
+      (m.code?.toLowerCase() || '').includes(search) ||
+      (m.description?.toLowerCase() || '').includes(search)
+    )
+  }
+
+  if (filters.filiere_id) {
+    result = result.filter(
+      (m) => m.combinaisons?.length && m.combinaisons.some((c) => c.filiere?.id == filters.filiere_id)
+    )
+  }
+
+  if (filters.niveau_id) {
+    result = result.filter(
+      (m) => m.combinaisons?.length && m.combinaisons.some((c) => c.niveau?.id == filters.niveau_id)
+    )
+  }
+
+  return result
+}
+
+/**
+ * Regroupe les matières filtrées par niveau (avec totaux heures/séances).
+ * Les groupes « non défini » / « sans niveau » sont placés en fin de liste.
+ * @param {Array<Object>} filteredMatieres
+ * @param {Array<Object>} niveaux - structure académique (fallback si aucune matière)
+ * @returns {Array<{ niveau: Object, matieres: Array, totalHeures: number, totalSeances: number }>}
+ */
+export function groupMatieresByNiveau(filteredMatieres = [], niveaux = []) {
+  // Pas de matières → grouper par niveaux disponibles
+  if (filteredMatieres.length === 0 && niveaux.length > 0) {
+    return niveaux.map((niveau) => ({ niveau, matieres: [], totalHeures: 0, totalSeances: 0 }))
+  }
+
+  const niveauxMap = new Map()
+
+  filteredMatieres.forEach((matiere) => {
+    if (matiere.combinaisons && matiere.combinaisons.length > 0) {
+      const hasValidNiveau = matiere.combinaisons.some((c) => c.niveau?.id || c.niveau?.code)
+
+      if (hasValidNiveau) {
+        const uniqueNiveaux = new Set()
+        matiere.combinaisons.forEach((combi) => {
+          if (combi.niveau?.id) uniqueNiveaux.add(combi.niveau.id)
+        })
+
+        uniqueNiveaux.forEach((niveauId) => {
+          if (!niveauxMap.has(niveauId)) {
+            const niveau = matiere.combinaisons.find((c) => c.niveau?.id === niveauId)?.niveau
+            if (niveau) niveauxMap.set(niveauId, { niveau, matieres: [] })
+          }
+          if (niveauxMap.has(niveauId)) {
+            niveauxMap.get(niveauId).matieres.push(matiere)
+          }
+        })
+      } else {
+        // Combinaisons vides → « Niveau non défini »
+        if (!niveauxMap.has('undefined')) {
+          niveauxMap.set('undefined', {
+            niveau: { id: 'undefined', nom: 'Niveau non défini', code: 'N/A' },
+            matieres: []
+          })
+        }
+        niveauxMap.get('undefined').matieres.push(matiere)
+      }
+    } else {
+      // Aucune combinaison → « Sans niveau »
+      if (!niveauxMap.has('none')) {
+        niveauxMap.set('none', {
+          niveau: { id: 'none', nom: 'Sans niveau', code: 'N/A' },
+          matieres: []
+        })
+      }
+      niveauxMap.get('none').matieres.push(matiere)
+    }
+  })
+
+  const result = Array.from(niveauxMap.values()).map((group) => ({
+    ...group,
+    totalHeures: group.matieres.reduce((sum, m) => sum + (m.heures_total || 0), 0),
+    totalSeances: group.matieres.reduce((sum, m) => sum + (m.nb_seances_programmees || 0), 0)
+  }))
+
+  // « undefined » / « none » en fin, le reste trié par code
+  result.sort((a, b) => {
+    const aId = a.niveau.id
+    const bId = b.niveau.id
+    if (aId === 'undefined' || aId === 'none') return 1
+    if (bId === 'undefined' || bId === 'none') return -1
+    return (a.niveau.code || '').localeCompare(b.niveau.code || '')
+  })
+
+  return result
+}
+
+/**
+ * Statistiques globales des matières.
+ * @param {Array<Object>} matieres
+ * @returns {{ total:number, totalHeures:number, totalSeances:number }}
+ */
+export function computeMatieresStats(matieres = []) {
+  return {
+    total: matieres.length,
+    totalHeures: matieres.reduce((sum, m) => sum + (m.heures_total || 0), 0),
+    totalSeances: matieres.reduce((sum, m) => sum + (m.nb_seances_programmees || 0), 0)
+  }
+}
+
+/**
+ * Noms (ou codes) de filières uniques d'une matière.
+ * @param {Object} matiere
+ * @returns {Array<string>}
+ */
+export function getMatiereFilieres(matiere) {
+  if (!matiere.combinaisons || matiere.combinaisons.length === 0) return []
+  const unique = new Set()
+  matiere.combinaisons.forEach((combi) => {
+    if (combi.filiere?.nom) unique.add(combi.filiere.nom)
+    else if (combi.filiere?.code) unique.add(combi.filiere.code)
+  })
+  return Array.from(unique)
+}
+
+/**
+ * Noms (ou codes) de niveaux uniques d'une matière.
+ * @param {Object} matiere
+ * @returns {Array<string>}
+ */
+export function getMatiereNiveaux(matiere) {
+  if (!matiere.combinaisons || matiere.combinaisons.length === 0) return []
+  const unique = new Set()
+  matiere.combinaisons.forEach((combi) => {
+    if (combi.niveau?.nom) unique.add(combi.niveau.nom)
+    else if (combi.niveau?.code) unique.add(combi.niveau.code)
+  })
+  return Array.from(unique)
+}

--- a/src/views/admin/AdminMatieres.vue
+++ b/src/views/admin/AdminMatieres.vue
@@ -328,6 +328,14 @@ import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import { klassciService } from '@/services/klassci'
 import { readCache, writeCache, clearCache } from '@/services/cache'
+// #28 : logique métier pure extraite (testée dans tests/unit/matieres.test.js)
+import {
+  filterMatieres,
+  groupMatieresByNiveau,
+  computeMatieresStats,
+  getMatiereFilieres,
+  getMatiereNiveaux
+} from '@/utils/matieres'
 import {
   BookOpenIcon,
   AcademicCapIcon,
@@ -359,173 +367,16 @@ const showMatiereModal = ref(false)
 const selectedMatiere = ref(null)
 
 
-// Computed: Filtered matieres
-const filteredMatieres = computed(() => {
-  let result = matieres.value
+// Computeds délégués à la logique pure extraite (#28)
+const filteredMatieres = computed(() => filterMatieres(matieres.value, filters.value))
 
-  // Filter by search
-  if (filters.value.search) {
-    const search = filters.value.search.toLowerCase()
-    result = result.filter(m =>
-      (m.nom?.toLowerCase() || '').includes(search) ||
-      (m.code?.toLowerCase() || '').includes(search) ||
-      (m.description?.toLowerCase() || '').includes(search)
-    )
-  }
+const filteredNiveauxWithMatieres = computed(() =>
+  groupMatieresByNiveau(filteredMatieres.value, niveaux.value)
+)
 
-  // Filter by filiere
-  if (filters.value.filiere_id) {
-    result = result.filter(m => {
-      if (!m.combinaisons || m.combinaisons.length === 0) return false
-      return m.combinaisons.some(c => c.filiere?.id == filters.value.filiere_id)
-    })
-  }
+const stats = computed(() => computeMatieresStats(matieres.value))
 
-  // Filter by niveau
-  if (filters.value.niveau_id) {
-    result = result.filter(m => {
-      if (!m.combinaisons || m.combinaisons.length === 0) return false
-      return m.combinaisons.some(c => c.niveau?.id == filters.value.niveau_id)
-    })
-  }
-
-  return result
-})
-
-// Computed: Niveaux with matieres
-const filteredNiveauxWithMatieres = computed(() => {
-  // Si pas de matières, grouper par niveaux disponibles dans structure
-  if (filteredMatieres.value.length === 0 && niveaux.value.length > 0) {
-    return niveaux.value.map(niveau => ({
-      niveau: niveau,
-      matieres: [],
-      totalHeures: 0,
-      totalSeances: 0
-    }))
-  }
-
-  // Group matieres by niveau
-  const niveauxMap = new Map()
-
-  filteredMatieres.value.forEach(matiere => {
-    // Si la matière a des combinaisons (même avec objets vides)
-    if (matiere.combinaisons && matiere.combinaisons.length > 0) {
-      // Vérifier si les combinaisons contiennent des niveaux valides
-      const hasValidNiveau = matiere.combinaisons.some(c => c.niveau?.id || c.niveau?.code)
-
-      if (hasValidNiveau) {
-        // Récupérer les niveaux uniques avec données valides
-        const uniqueNiveaux = new Set()
-        matiere.combinaisons.forEach(combi => {
-          if (combi.niveau?.id) {
-            uniqueNiveaux.add(combi.niveau.id)
-          }
-        })
-
-        // Ajouter la matière à chaque groupe de niveau
-        uniqueNiveaux.forEach(niveauId => {
-          if (!niveauxMap.has(niveauId)) {
-            const niveau = matiere.combinaisons.find(c => c.niveau?.id === niveauId)?.niveau
-            if (niveau) {
-              niveauxMap.set(niveauId, {
-                niveau: niveau,
-                matieres: []
-              })
-            }
-          }
-          if (niveauxMap.has(niveauId)) {
-            niveauxMap.get(niveauId).matieres.push(matiere)
-          }
-        })
-      } else {
-        // Les combinaisons existent mais sont vides → groupe "Niveau non défini"
-        if (!niveauxMap.has('undefined')) {
-          niveauxMap.set('undefined', {
-            niveau: { id: 'undefined', nom: 'Niveau non défini', code: 'N/A' },
-            matieres: []
-          })
-        }
-        niveauxMap.get('undefined').matieres.push(matiere)
-      }
-    } else {
-      // Pas de combinaisons → groupe "Sans niveau"
-      if (!niveauxMap.has('none')) {
-        niveauxMap.set('none', {
-          niveau: { id: 'none', nom: 'Sans niveau', code: 'N/A' },
-          matieres: []
-        })
-      }
-      niveauxMap.get('none').matieres.push(matiere)
-    }
-  })
-
-  // Convert to array and add stats
-  const result = Array.from(niveauxMap.values()).map(group => {
-    const totalHeures = group.matieres.reduce((sum, m) => sum + (m.heures_total || 0), 0)
-    const totalSeances = group.matieres.reduce((sum, m) => sum + (m.nb_seances_programmees || 0), 0)
-
-    return {
-      ...group,
-      totalHeures,
-      totalSeances
-    }
-  })
-
-  // Sort: undefined/none at the end, others by code
-  result.sort((a, b) => {
-    const aId = a.niveau.id
-    const bId = b.niveau.id
-
-    if (aId === 'undefined' || aId === 'none') return 1
-    if (bId === 'undefined' || bId === 'none') return -1
-    return (a.niveau.code || '').localeCompare(b.niveau.code || '')
-  })
-
-  return result
-})
-
-// Computed: Statistics
-const stats = computed(() => {
-  return {
-    total: matieres.value.length,
-    totalHeures: matieres.value.reduce((sum, m) => sum + (m.heures_total || 0), 0),
-    totalSeances: matieres.value.reduce((sum, m) => sum + (m.nb_seances_programmees || 0), 0)
-  }
-})
-
-// Get matiere filieres (unique)
-function getMatiereFilieres(matiere) {
-  if (!matiere.combinaisons || matiere.combinaisons.length === 0) return []
-
-  const uniqueFilieres = new Set()
-  matiere.combinaisons.forEach(combi => {
-    // Priorité: nom > code
-    if (combi.filiere?.nom) {
-      uniqueFilieres.add(combi.filiere.nom)
-    } else if (combi.filiere?.code) {
-      uniqueFilieres.add(combi.filiere.code)
-    }
-  })
-
-  return Array.from(uniqueFilieres)
-}
-
-// Get matiere niveaux (unique)
-function getMatiereNiveaux(matiere) {
-  if (!matiere.combinaisons || matiere.combinaisons.length === 0) return []
-
-  const uniqueNiveaux = new Set()
-  matiere.combinaisons.forEach(combi => {
-    // Priorité: nom > code
-    if (combi.niveau?.nom) {
-      uniqueNiveaux.add(combi.niveau.nom)
-    } else if (combi.niveau?.code) {
-      uniqueNiveaux.add(combi.niveau.code)
-    }
-  })
-
-  return Array.from(uniqueNiveaux)
-}
+// getMatiereFilieres / getMatiereNiveaux : importés depuis @/utils/matieres (#28).
 
 // View niveau details (open modal)
 function viewNiveauDetails(niveauGroup) {

--- a/tests/unit/matieres.test.js
+++ b/tests/unit/matieres.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests de la logique pure des matières (#28 — décomposition AdminMatieres.vue).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  filterMatieres,
+  groupMatieresByNiveau,
+  computeMatieresStats,
+  getMatiereFilieres,
+  getMatiereNiveaux
+} from '@/utils/matieres'
+
+const M = (over = {}) => ({ nom: 'Maths', code: 'MAT', description: '', combinaisons: [], ...over })
+
+describe('utils/matieres — filterMatieres', () => {
+  const data = [
+    M({ nom: 'Algèbre', code: 'ALG' }),
+    M({ nom: 'Physique', code: 'PHY', combinaisons: [{ filiere: { id: 1 }, niveau: { id: 10 } }] })
+  ]
+  it('recherche sur nom/code/description', () => {
+    expect(filterMatieres(data, { search: 'alg' }).map(m => m.code)).toEqual(['ALG'])
+    expect(filterMatieres(data, { search: 'phy' })).toHaveLength(1)
+  })
+  it('filtre par filiere (comparaison souple)', () => {
+    expect(filterMatieres(data, { filiere_id: '1' }).map(m => m.code)).toEqual(['PHY'])
+  })
+  it('filtre par niveau', () => {
+    expect(filterMatieres(data, { niveau_id: 10 }).map(m => m.code)).toEqual(['PHY'])
+  })
+  it('sans filtre : tout', () => {
+    expect(filterMatieres(data, {})).toHaveLength(2)
+  })
+})
+
+describe('utils/matieres — groupMatieresByNiveau', () => {
+  it('fallback : groupe vide par niveau si aucune matière', () => {
+    const res = groupMatieresByNiveau([], [{ id: 1, nom: 'L1' }])
+    expect(res).toHaveLength(1)
+    expect(res[0]).toMatchObject({ matieres: [], totalHeures: 0, totalSeances: 0 })
+  })
+  it('regroupe par niveau valide avec totaux', () => {
+    const matieres = [
+      M({ code: 'A', heures_total: 10, nb_seances_programmees: 2, combinaisons: [{ niveau: { id: 1, code: 'L1' } }] }),
+      M({ code: 'B', heures_total: 5, nb_seances_programmees: 1, combinaisons: [{ niveau: { id: 1, code: 'L1' } }] })
+    ]
+    const res = groupMatieresByNiveau(matieres, [])
+    expect(res).toHaveLength(1)
+    expect(res[0].matieres).toHaveLength(2)
+    expect(res[0].totalHeures).toBe(15)
+    expect(res[0].totalSeances).toBe(3)
+  })
+  it('matière sans combinaison → groupe « Sans niveau » en fin', () => {
+    const matieres = [
+      M({ code: 'A', combinaisons: [{ niveau: { id: 1, code: 'L1' } }] }),
+      M({ code: 'B', combinaisons: [] })
+    ]
+    const res = groupMatieresByNiveau(matieres, [])
+    expect(res[res.length - 1].niveau.nom).toBe('Sans niveau')
+  })
+})
+
+describe('utils/matieres — computeMatieresStats', () => {
+  it('total / heures / séances', () => {
+    const data = [
+      M({ heures_total: 10, nb_seances_programmees: 2 }),
+      M({ heures_total: 20, nb_seances_programmees: 3 })
+    ]
+    expect(computeMatieresStats(data)).toEqual({ total: 2, totalHeures: 30, totalSeances: 5 })
+  })
+})
+
+describe('utils/matieres — getMatiereFilieres / getMatiereNiveaux', () => {
+  it('filières uniques (nom prioritaire sur code)', () => {
+    const m = M({ combinaisons: [{ filiere: { nom: 'Info' } }, { filiere: { code: 'INF' } }, { filiere: { nom: 'Info' } }] })
+    expect(getMatiereFilieres(m)).toEqual(['Info', 'INF'])
+  })
+  it('niveaux uniques', () => {
+    const m = M({ combinaisons: [{ niveau: { nom: 'L1' } }, { niveau: { nom: 'L1' } }] })
+    expect(getMatiereNiveaux(m)).toEqual(['L1'])
+  })
+  it('vide si pas de combinaisons', () => {
+    expect(getMatiereFilieres(M())).toEqual([])
+    expect(getMatiereNiveaux(M())).toEqual([])
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `AdminMatieres.vue` (tranche 1)

5ᵉ god-component du TIER 2 (1434 l.). L'issue #28 signalait un « computed de ~100 lignes » → c'est `filteredNiveauxWithMatieres` (regroupement par niveau), désormais extrait et testé.

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/matieres.js`** : `filterMatieres`, `groupMatieresByNiveau` (ex-computed ~90 l.), `computeMatieresStats`, `getMatiereFilieres`, `getMatiereNiveaux` — toutes pures.
- ✅ **`tests/unit/matieres.test.js`** — 11 cas (filtres recherche/filière/niveau, regroupement + fallback + totaux, groupes « sans niveau » en fin, unicité).
- ♻️ La vue délègue ses 3 computeds + 2 méthodes au module. **1434 → 1285 l.**
- Parité comportementale (tri/groupes identiques).

### Vérifications
- ✅ `npm run test` → 222/222
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)