### PR TITLE
refactor(seances): logique pure de TeacherSeances — #28

### DIFF
--- a/.claude/specs/god-teacher-seances/requirements.md
+++ b/.claude/specs/god-teacher-seances/requirements.md
@@ -1,0 +1,25 @@
+# Requirements — Décomposition `TeacherSeances.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/views/TeacherSeances.vue` : **1354 lignes**, `<script setup>`. Logique pure :
+`filteredSeances` (filtrage matière/statut visio/période) et `stats` (par statut
+visio). `formatDate`/`formatTime` dupliquent `utils/formatters` (#23, dette).
+Le reste = fetch + handlers visio (activate/start/join/end) + template/CSS.
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — logique pure → `src/utils/seances.js` (TDD).
+- **Tranche 2 (éventuelle)** — sous-composants (carte séance, filtres) ; les
+  handlers visio s'appuient déjà sur le composable `useVisioParticipation`.
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/seances.js` : `filterSeances(seances, filters)`
+  et `computeSeancesStats(seances)` (pures).
+- WHEN mêmes entrées, THE SYSTEM SHALL produire les mêmes sorties.
+- THE SYSTEM SHALL couvrir ces fonctions par des tests (matière, statut visio,
+  « none », période, stats par statut).
+- WHEN la vue est refactorée, THE SYSTEM SHALL déléguer ses computeds au module.

--- a/src/utils/seances.js
+++ b/src/utils/seances.js
@@ -1,0 +1,68 @@
+/**
+ * Logique métier PURE des séances enseignant (#28).
+ *
+ * Extraite de `views/TeacherSeances.vue` (god-component) : filtrage
+ * (matière / statut visio / période) et statistiques. Fonctions pures.
+ */
+
+/**
+ * Filtre une liste de séances.
+ * @param {Array<Object>} seances
+ * @param {{ matiere_id?: string|number, visio_status?: string, period?: 'all'|'today'|'week'|'month' }} filters
+ * @returns {Array<Object>}
+ */
+export function filterSeances(seances = [], filters = {}) {
+  let filtered = seances
+
+  if (filters.matiere_id) {
+    filtered = filtered.filter((s) => s.matiere?.id == filters.matiere_id)
+  }
+
+  if (filters.visio_status) {
+    if (filters.visio_status === 'none') {
+      filtered = filtered.filter((s) => !s.visio || !s.visio.enabled)
+    } else {
+      filtered = filtered.filter((s) => s.visio?.status === filters.visio_status)
+    }
+  }
+
+  if (filters.period && filters.period !== 'all') {
+    const now = new Date()
+    filtered = filtered.filter((s) => {
+      if (!s.programmation?.date) return false
+      const seanceDate = new Date(s.programmation.date)
+
+      if (filters.period === 'today') {
+        return seanceDate.toDateString() === now.toDateString()
+      }
+      if (filters.period === 'week') {
+        const weekStart = new Date(now)
+        weekStart.setDate(now.getDate() - now.getDay())
+        const weekEnd = new Date(weekStart)
+        weekEnd.setDate(weekStart.getDate() + 7)
+        return seanceDate >= weekStart && seanceDate < weekEnd
+      }
+      if (filters.period === 'month') {
+        return seanceDate.getMonth() === now.getMonth() &&
+          seanceDate.getFullYear() === now.getFullYear()
+      }
+      return true
+    })
+  }
+
+  return filtered
+}
+
+/**
+ * Statistiques des séances par statut visio.
+ * @param {Array<Object>} seances
+ * @returns {{ total:number, active:number, scheduled:number, finished:number }}
+ */
+export function computeSeancesStats(seances = []) {
+  return {
+    total: seances.length,
+    active: seances.filter((s) => s.visio?.status === 'active').length,
+    scheduled: seances.filter((s) => s.visio?.status === 'programmee').length,
+    finished: seances.filter((s) => s.visio?.status === 'terminee').length
+  }
+}

--- a/src/views/TeacherSeances.vue
+++ b/src/views/TeacherSeances.vue
@@ -346,6 +346,8 @@ import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
 import { readCache, writeCache, clearCache } from '@/services/cache'
 import { buildJitsiUrl } from '@/constants/visio'
+// #28 : logique métier pure extraite (testée dans tests/unit/seances.test.js)
+import { filterSeances, computeSeancesStats } from '@/utils/seances'
 
 const seances = ref([])
 const matieres = ref([])
@@ -369,59 +371,10 @@ const filters = reactive({
 })
 
 
-// Computed - Filtered seances
-const filteredSeances = computed(() => {
-  let filtered = seances.value
+// Computeds délégués à la logique pure extraite (#28)
+const filteredSeances = computed(() => filterSeances(seances.value, filters))
 
-  // Filter by matière
-  if (filters.matiere_id) {
-    filtered = filtered.filter(s => s.matiere?.id == filters.matiere_id)
-  }
-
-  // Filter by visio status
-  if (filters.visio_status) {
-    if (filters.visio_status === 'none') {
-      filtered = filtered.filter(s => !s.visio || !s.visio.enabled)
-    } else {
-      filtered = filtered.filter(s => s.visio?.status === filters.visio_status)
-    }
-  }
-
-  // Filter by period
-  if (filters.period !== 'all') {
-    const now = new Date()
-    filtered = filtered.filter(s => {
-      if (!s.programmation?.date) return false
-      const seanceDate = new Date(s.programmation.date)
-
-      if (filters.period === 'today') {
-        return seanceDate.toDateString() === now.toDateString()
-      } else if (filters.period === 'week') {
-        const weekStart = new Date(now)
-        weekStart.setDate(now.getDate() - now.getDay())
-        const weekEnd = new Date(weekStart)
-        weekEnd.setDate(weekStart.getDate() + 7)
-        return seanceDate >= weekStart && seanceDate < weekEnd
-      } else if (filters.period === 'month') {
-        return seanceDate.getMonth() === now.getMonth() &&
-               seanceDate.getFullYear() === now.getFullYear()
-      }
-      return true
-    })
-  }
-
-  return filtered
-})
-
-// Computed - Statistics
-const stats = computed(() => {
-  return {
-    total: seances.value.length,
-    active: seances.value.filter(s => s.visio?.status === 'active').length,
-    scheduled: seances.value.filter(s => s.visio?.status === 'programmee').length,
-    finished: seances.value.filter(s => s.visio?.status === 'terminee').length
-  }
-})
+const stats = computed(() => computeSeancesStats(seances.value))
 
 // Load seances with cache
 async function loadSeances() {

--- a/tests/unit/seances.test.js
+++ b/tests/unit/seances.test.js
@@ -1,0 +1,49 @@
+/**
+ * Tests de la logique pure des séances (#28 — décomposition TeacherSeances.vue).
+ */
+import { describe, it, expect } from 'vitest'
+import { filterSeances, computeSeancesStats } from '@/utils/seances'
+
+const S = (over = {}) => ({ matiere: { id: 1 }, visio: { enabled: true, status: 'programmee' }, ...over })
+
+describe('utils/seances — filterSeances', () => {
+  const data = [
+    S({ matiere: { id: 1 }, visio: { enabled: true, status: 'active' } }),
+    S({ matiere: { id: 2 }, visio: { enabled: true, status: 'programmee' } }),
+    S({ matiere: { id: 2 }, visio: null })
+  ]
+  it('filtre par matière (comparaison souple)', () => {
+    expect(filterSeances(data, { matiere_id: '2' })).toHaveLength(2)
+  })
+  it('filtre par statut visio', () => {
+    expect(filterSeances(data, { visio_status: 'active' })).toHaveLength(1)
+  })
+  it('statut "none" = sans visio activée', () => {
+    expect(filterSeances(data, { visio_status: 'none' })).toHaveLength(1)
+  })
+  it('period "all" ou absente : pas de filtre temporel', () => {
+    expect(filterSeances(data, { period: 'all' })).toHaveLength(3)
+    expect(filterSeances(data, {})).toHaveLength(3)
+  })
+  it('period "today" garde la séance du jour, exclut une date passée', () => {
+    const today = new Date().toISOString()
+    const seances = [
+      S({ programmation: { date: today } }),
+      S({ programmation: { date: '2000-01-01' } }),
+      S({ programmation: {} }) // pas de date → exclue
+    ]
+    expect(filterSeances(seances, { period: 'today' })).toHaveLength(1)
+  })
+})
+
+describe('utils/seances — computeSeancesStats', () => {
+  it('compte par statut visio', () => {
+    const data = [
+      S({ visio: { status: 'active' } }),
+      S({ visio: { status: 'programmee' } }),
+      S({ visio: { status: 'terminee' } }),
+      S({ visio: { status: 'active' } })
+    ]
+    expect(computeSeancesStats(data)).toEqual({ total: 4, active: 2, scheduled: 1, finished: 1 })
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `TeacherSeances.vue` (tranche 1)

6ᵉ god-component du TIER 2 (1354 l.).

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/seances.js`** : `filterSeances` (matière / statut visio / `none` / période today-week-month) + `computeSeancesStats` (par statut visio) — pures.
- ✅ **`tests/unit/seances.test.js`** — 6 cas.
- ♻️ La vue délègue ses 2 computeds au module. **1354 → 1307 l.**

### Dette tracée
`formatDate`/`formatTime` dupliquent `utils/formatters` (#23). Sous-composants (carte séance, filtres) → tranche 2 éventuelle.

### Vérifications
- ✅ `npm run test` → 228/228
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)