### PR TITLE
refactor(enseignants): logique pure de AdminEnseignants — #28

### DIFF
--- a/.claude/specs/god-admin-enseignants/requirements.md
+++ b/.claude/specs/god-admin-enseignants/requirements.md
@@ -1,0 +1,26 @@
+# Requirements — Décomposition `AdminEnseignants.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/views/admin/AdminEnseignants.vue` : **1283 lignes**, `<script setup>`.
+Logique pure : stats (`totalMatieres`/`totalClasses`/`enseignantsActifs`),
+`getEnseignantClassesCount` (avec fallback matières), `getEnseignantUniqueClasses`.
+La vue utilise déjà `getInitials` de `utils/formatters` (#23). Le reste = fetch +
+template/CSS.
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — logique pure → `src/utils/enseignants.js` (TDD).
+- **Tranche 2 (éventuelle)** — sous-composants (carte enseignant, modale détails).
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/enseignants.js` :
+  `computeEnseignantsStats(enseignants)`, `getEnseignantClassesCount(enseignant)`,
+  `getEnseignantUniqueClasses(enseignant)` (pures).
+- WHEN mêmes entrées, THE SYSTEM SHALL produire les mêmes sorties (priorité
+  statistiques backend, fallback matières, robustesse non-array).
+- THE SYSTEM SHALL couvrir ces fonctions par des tests.
+- WHEN la vue est refactorée, THE SYSTEM SHALL déléguer ses computeds/méthodes au module.

--- a/src/utils/enseignants.js
+++ b/src/utils/enseignants.js
@@ -1,0 +1,54 @@
+/**
+ * Logique métier PURE des enseignants (#28).
+ *
+ * Extraite de `views/admin/AdminEnseignants.vue` (god-component) : comptage des
+ * classes (avec fallback depuis les matières), classes uniques, et statistiques
+ * globales. Fonctions pures → testables.
+ */
+
+/**
+ * Nombre de classes d'un enseignant.
+ * Priorité aux statistiques backend, sinon dérivé des classes des matières.
+ * @param {Object} enseignant
+ * @returns {number}
+ */
+export function getEnseignantClassesCount(enseignant) {
+  if (enseignant.statistiques?.total_classes) {
+    return enseignant.statistiques.total_classes
+  }
+  const classesSet = new Set()
+  enseignant.matieres?.forEach((matiere) => {
+    matiere.classes?.forEach((classe) => classesSet.add(classe.id))
+  })
+  return classesSet.size
+}
+
+/**
+ * Liste des classes uniques d'un enseignant (dérivée de ses matières).
+ * @param {Object} enseignant
+ * @returns {Array<Object>}
+ */
+export function getEnseignantUniqueClasses(enseignant) {
+  if (!enseignant || !enseignant.matieres) return []
+  const classesMap = new Map()
+  enseignant.matieres.forEach((matiere) => {
+    matiere.classes?.forEach((classe) => {
+      if (!classesMap.has(classe.id)) classesMap.set(classe.id, classe)
+    })
+  })
+  return Array.from(classesMap.values())
+}
+
+/**
+ * Statistiques globales d'une liste d'enseignants.
+ * @param {Array<Object>} enseignants
+ * @returns {{ totalMatieres:number, totalClasses:number, actifs:number }}
+ */
+export function computeEnseignantsStats(enseignants) {
+  const list = Array.isArray(enseignants) ? enseignants : []
+  return {
+    totalMatieres: list.reduce((sum, ens) => sum + (ens.matieres?.length || 0), 0),
+    totalClasses: list.reduce((sum, ens) => sum + getEnseignantClassesCount(ens), 0),
+    actifs: list.filter((ens) => ens.matieres?.length > 0 || ens.classes?.length > 0).length
+  }
+}

--- a/src/views/admin/AdminEnseignants.vue
+++ b/src/views/admin/AdminEnseignants.vue
@@ -313,65 +313,25 @@ import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
 import klassciService from '@/services/klassci'
 import { readCache, writeCache, clearCache } from '@/services/cache'
+// #28 : logique métier pure extraite (testée dans tests/unit/enseignants.test.js)
+import {
+  computeEnseignantsStats,
+  getEnseignantClassesCount,
+  getEnseignantUniqueClasses
+} from '@/utils/enseignants'
 
 const enseignants = ref([])
 const loading = ref(true)
 const error = ref(null)
 const selectedEnseignant = ref(null)
 
-// Computed stats
-const totalMatieres = computed(() => {
-  const list = Array.isArray(enseignants.value) ? enseignants.value : []
-  return list.reduce((sum, ens) => sum + (ens.matieres?.length || 0), 0)
-})
+// Computed stats — délégués à la logique pure extraite (#28)
+const stats = computed(() => computeEnseignantsStats(enseignants.value))
+const totalMatieres = computed(() => stats.value.totalMatieres)
+const totalClasses = computed(() => stats.value.totalClasses)
+const enseignantsActifs = computed(() => stats.value.actifs)
 
-const totalClasses = computed(() => {
-  const list = Array.isArray(enseignants.value) ? enseignants.value : []
-  return list.reduce((sum, ens) => {
-    if (ens.statistiques?.total_classes) {
-      return sum + ens.statistiques.total_classes
-    }
-    const classesSet = new Set()
-    ens.matieres?.forEach(matiere => {
-      matiere.classes?.forEach(classe => classesSet.add(classe.id))
-    })
-    return sum + classesSet.size
-  }, 0)
-})
-
-const enseignantsActifs = computed(() => {
-  const list = Array.isArray(enseignants.value) ? enseignants.value : []
-  return list.filter(ens => ens.matieres?.length > 0 || ens.classes?.length > 0).length
-})
-
-// Get classes count for an enseignant
-function getEnseignantClassesCount(enseignant) {
-  if (enseignant.statistiques?.total_classes) {
-    return enseignant.statistiques.total_classes
-  }
-  // Fallback: extraire classes uniques depuis les matieres
-  const classesSet = new Set()
-  enseignant.matieres?.forEach(matiere => {
-    matiere.classes?.forEach(classe => classesSet.add(classe.id))
-  })
-  return classesSet.size
-}
-
-// Get unique classes list from enseignant's matieres
-function getEnseignantUniqueClasses(enseignant) {
-  if (!enseignant || !enseignant.matieres) return []
-
-  const classesMap = new Map()
-  enseignant.matieres.forEach(matiere => {
-    matiere.classes?.forEach(classe => {
-      if (!classesMap.has(classe.id)) {
-        classesMap.set(classe.id, classe)
-      }
-    })
-  })
-
-  return Array.from(classesMap.values())
-}
+// getEnseignantClassesCount / getEnseignantUniqueClasses : importés depuis @/utils/enseignants (#28).
 
 // Load enseignants from API
 async function loadEnseignants(forceReload = false) {

--- a/tests/unit/enseignants.test.js
+++ b/tests/unit/enseignants.test.js
@@ -1,0 +1,57 @@
+/**
+ * Tests de la logique pure des enseignants (#28 — AdminEnseignants.vue).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  getEnseignantClassesCount,
+  getEnseignantUniqueClasses,
+  computeEnseignantsStats
+} from '@/utils/enseignants'
+
+describe('utils/enseignants — getEnseignantClassesCount', () => {
+  it('priorité aux statistiques backend', () => {
+    expect(getEnseignantClassesCount({ statistiques: { total_classes: 5 } })).toBe(5)
+  })
+  it('fallback : classes uniques des matières', () => {
+    const ens = {
+      matieres: [
+        { classes: [{ id: 1 }, { id: 2 }] },
+        { classes: [{ id: 2 }, { id: 3 }] }
+      ]
+    }
+    expect(getEnseignantClassesCount(ens)).toBe(3)
+  })
+  it('0 si aucune classe', () => {
+    expect(getEnseignantClassesCount({})).toBe(0)
+  })
+})
+
+describe('utils/enseignants — getEnseignantUniqueClasses', () => {
+  it('dédoublonne par id', () => {
+    const ens = {
+      matieres: [
+        { classes: [{ id: 1, nom: 'A' }, { id: 2, nom: 'B' }] },
+        { classes: [{ id: 1, nom: 'A' }] }
+      ]
+    }
+    expect(getEnseignantUniqueClasses(ens).map(c => c.id)).toEqual([1, 2])
+  })
+  it('[] si pas de matières', () => {
+    expect(getEnseignantUniqueClasses({})).toEqual([])
+    expect(getEnseignantUniqueClasses(null)).toEqual([])
+  })
+})
+
+describe('utils/enseignants — computeEnseignantsStats', () => {
+  it('totalMatieres / totalClasses / actifs', () => {
+    const list = [
+      { matieres: [{ classes: [{ id: 1 }] }, { classes: [{ id: 2 }] }] },
+      { statistiques: { total_classes: 3 }, matieres: [{}] },
+      { matieres: [], classes: [] } // inactif
+    ]
+    expect(computeEnseignantsStats(list)).toEqual({ totalMatieres: 3, totalClasses: 5, actifs: 2 })
+  })
+  it('robuste si entrée non-array', () => {
+    expect(computeEnseignantsStats(null)).toEqual({ totalMatieres: 0, totalClasses: 0, actifs: 0 })
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `AdminEnseignants.vue` (tranche 1)

7ᵉ god-component du TIER 2 (1283 l.).

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/enseignants.js`** : `computeEnseignantsStats`, `getEnseignantClassesCount` (priorité stats backend, fallback classes des matières), `getEnseignantUniqueClasses` (dédup par id) — pures.
- ✅ **`tests/unit/enseignants.test.js`** — 7 cas.
- ♻️ La vue dérive ses 3 computeds (`totalMatieres`/`totalClasses`/`enseignantsActifs`) d'un `stats` unique + importe les 2 méthodes. **1283 → 1243 l.**

### Vérifications
- ✅ `npm run test` → 235/235
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)