### PR TITLE
refactor(matieres): logique pure de MatiereDetails — #28

### DIFF
--- a/.claude/specs/god-matiere-details/requirements.md
+++ b/.claude/specs/god-matiere-details/requirements.md
@@ -1,0 +1,27 @@
+# Requirements — Décomposition `MatiereDetails.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/views/matieres/MatiereDetails.vue` : **1454 lignes**, Options API.
+Logique pure : `calculateDuration` (durée séance), mappers de statut séance
+(`getSeanceStatusClass`/`Label`) et fenêtre d'évaluation
+(`getEvaluationStatusClass`/`Label`). `formatDate`/`formatTime` dupliquent
+`utils/formatters` (#23, dette). Le reste = fetch + onglets + template/CSS.
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — logique pure → `src/utils/matiereDetails.js` (TDD).
+- **Tranche 2 (éventuelle)** — sous-composants (onglets : leçons, séances, évaluations).
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/matiereDetails.js` :
+  `calculateSeanceDuration`, `getSeanceStatusClass`, `getSeanceStatusLabel`,
+  `getEvaluationStatusClass`, `getEvaluationStatusLabel` (pures).
+- WHEN mêmes entrées, THE SYSTEM SHALL produire les mêmes sorties.
+- THE SYSTEM SHALL couvrir ces fonctions par des tests (durée, statuts séance
+  à venir/terminé/passé, statuts fenêtre éval).
+- WHEN la vue est refactorée, THE SYSTEM SHALL déléguer ses méthodes au module
+  (imports aliasés pour éviter les collisions de noms).

--- a/src/utils/matiereDetails.js
+++ b/src/utils/matiereDetails.js
@@ -1,0 +1,73 @@
+/**
+ * Logique métier PURE des détails d'une matière (#28).
+ *
+ * Extraite de `views/matieres/MatiereDetails.vue` (god-component) : durée d'une
+ * séance et mappers de statut (séance / fenêtre d'évaluation). Fonctions pures.
+ */
+
+/**
+ * Durée d'une séance en minutes, depuis programmation.heure_debut/fin (ISO 8601).
+ * @param {Object} seance
+ * @returns {number} minutes (0 si données manquantes/invalides)
+ */
+export function calculateSeanceDuration(seance) {
+  if (!seance.programmation?.heure_debut || !seance.programmation?.heure_fin) return 0
+  const debut = new Date(seance.programmation.heure_debut)
+  const fin = new Date(seance.programmation.heure_fin)
+  if (isNaN(debut.getTime()) || isNaN(fin.getTime())) return 0
+  return Math.round((fin - debut) / 60000)
+}
+
+/**
+ * Classe CSS de statut d'une séance (à venir / en cours / terminé / passé).
+ * @param {Object} seance - { date_seance, heure_debut, heure_fin, statut }
+ * @returns {string}
+ */
+export function getSeanceStatusClass(seance) {
+  const now = new Date()
+  const seanceDate = new Date(`${seance.date_seance} ${seance.heure_debut}`)
+  const seanceEnd = new Date(`${seance.date_seance} ${seance.heure_fin}`)
+
+  if (now < seanceDate) return 'bg-orange-100 text-orange-700'
+  if (now >= seanceDate && now <= seanceEnd) return 'bg-green-100 text-green-700'
+  if (seance.statut === 'realise') return 'bg-blue-100 text-blue-700'
+  return 'bg-gray-100 text-gray-700'
+}
+
+/**
+ * Libellé de statut d'une séance.
+ * @param {Object} seance
+ * @returns {string}
+ */
+export function getSeanceStatusLabel(seance) {
+  const now = new Date()
+  const seanceDate = new Date(`${seance.date_seance} ${seance.heure_debut}`)
+  const seanceEnd = new Date(`${seance.date_seance} ${seance.heure_fin}`)
+
+  if (now < seanceDate) return 'À venir'
+  if (now >= seanceDate && now <= seanceEnd) return 'En cours'
+  if (seance.statut === 'realise') return 'Terminé'
+  return 'Passé'
+}
+
+/**
+ * Classe CSS de statut d'une fenêtre d'évaluation.
+ * @param {{ has_started:boolean, is_open:boolean }} window
+ * @returns {string}
+ */
+export function getEvaluationStatusClass(window) {
+  if (!window.has_started) return 'bg-orange-100 text-orange-700'
+  if (window.is_open) return 'bg-green-100 text-green-700'
+  return 'bg-gray-100 text-gray-700'
+}
+
+/**
+ * Libellé de statut d'une fenêtre d'évaluation.
+ * @param {{ has_started:boolean, is_open:boolean }} window
+ * @returns {string}
+ */
+export function getEvaluationStatusLabel(window) {
+  if (!window.has_started) return 'Pas encore ouverte'
+  if (window.is_open) return 'Ouverte'
+  return 'Fermée'
+}

--- a/src/views/matieres/MatiereDetails.vue
+++ b/src/views/matieres/MatiereDetails.vue
@@ -537,6 +537,14 @@ import lessonService from '@/services/lesson'
 import VisioManager from '@/components/visio/VisioManager.vue'
 import LessonCard from '@/components/lessons/LessonCard.vue'
 import { auth } from '@/services/api'
+// #28 : logique métier pure extraite (testée dans tests/unit/matiereDetails.test.js)
+import {
+  calculateSeanceDuration,
+  getSeanceStatusClass as seanceStatusClass,
+  getSeanceStatusLabel as seanceStatusLabel,
+  getEvaluationStatusClass as evaluationStatusClass,
+  getEvaluationStatusLabel as evaluationStatusLabel
+} from '@/utils/matiereDetails'
 
 export default {
   name: 'MatiereDetails',
@@ -861,13 +869,9 @@ export default {
       })
     },
 
+    // #28 : logique pure déléguée à utils/matiereDetails
     calculateDuration(seance) {
-      // Utiliser programmation.heure_debut/fin (ISO 8601)
-      if (!seance.programmation?.heure_debut || !seance.programmation?.heure_fin) return 0
-      const debut = new Date(seance.programmation.heure_debut)
-      const fin = new Date(seance.programmation.heure_fin)
-      if (isNaN(debut.getTime()) || isNaN(fin.getTime())) return 0
-      return Math.round((fin - debut) / 60000) // millisecondes → minutes
+      return calculateSeanceDuration(seance)
     },
 
     formatTime(isoTimestamp) {
@@ -881,37 +885,19 @@ export default {
     },
 
     getSeanceStatusClass(seance) {
-      const now = new Date()
-      const seanceDate = new Date(`${seance.date_seance} ${seance.heure_debut}`)
-      const seanceEnd = new Date(`${seance.date_seance} ${seance.heure_fin}`)
-
-      if (now < seanceDate) return 'bg-orange-100 text-orange-700'
-      if (now >= seanceDate && now <= seanceEnd) return 'bg-green-100 text-green-700'
-      if (seance.statut === 'realise') return 'bg-blue-100 text-blue-700'
-      return 'bg-gray-100 text-gray-700'
+      return seanceStatusClass(seance)
     },
 
     getSeanceStatusLabel(seance) {
-      const now = new Date()
-      const seanceDate = new Date(`${seance.date_seance} ${seance.heure_debut}`)
-      const seanceEnd = new Date(`${seance.date_seance} ${seance.heure_fin}`)
-
-      if (now < seanceDate) return 'À venir'
-      if (now >= seanceDate && now <= seanceEnd) return 'En cours'
-      if (seance.statut === 'realise') return 'Terminé'
-      return 'Passé'
+      return seanceStatusLabel(seance)
     },
 
     getEvaluationStatusClass(window) {
-      if (!window.has_started) return 'bg-orange-100 text-orange-700'
-      if (window.is_open) return 'bg-green-100 text-green-700'
-      return 'bg-gray-100 text-gray-700'
+      return evaluationStatusClass(window)
     },
 
     getEvaluationStatusLabel(window) {
-      if (!window.has_started) return 'Pas encore ouverte'
-      if (window.is_open) return 'Ouverte'
-      return 'Fermée'
+      return evaluationStatusLabel(window)
     }
   }
 }

--- a/tests/unit/matiereDetails.test.js
+++ b/tests/unit/matiereDetails.test.js
@@ -1,0 +1,58 @@
+/**
+ * Tests de la logique pure des détails de matière (#28 — MatiereDetails.vue).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  calculateSeanceDuration,
+  getSeanceStatusClass,
+  getSeanceStatusLabel,
+  getEvaluationStatusClass,
+  getEvaluationStatusLabel
+} from '@/utils/matiereDetails'
+
+describe('utils/matiereDetails — calculateSeanceDuration', () => {
+  it('calcule la durée en minutes', () => {
+    expect(calculateSeanceDuration({
+      programmation: { heure_debut: '2026-06-18T10:00:00', heure_fin: '2026-06-18T11:30:00' }
+    })).toBe(90)
+  })
+  it('0 si données manquantes ou invalides', () => {
+    expect(calculateSeanceDuration({})).toBe(0)
+    expect(calculateSeanceDuration({ programmation: { heure_debut: 'x', heure_fin: 'y' } })).toBe(0)
+  })
+})
+
+describe('utils/matiereDetails — statut séance', () => {
+  const dateOnly = (d) => d.toISOString().split('T')[0]
+  it('à venir si dans le futur', () => {
+    const tomorrow = dateOnly(new Date(Date.now() + 86400000))
+    const s = { date_seance: tomorrow, heure_debut: '10:00', heure_fin: '11:00' }
+    expect(getSeanceStatusLabel(s)).toBe('À venir')
+    expect(getSeanceStatusClass(s)).toContain('orange')
+  })
+  it('terminé si passé et réalisé', () => {
+    const yesterday = dateOnly(new Date(Date.now() - 86400000))
+    const s = { date_seance: yesterday, heure_debut: '10:00', heure_fin: '11:00', statut: 'realise' }
+    expect(getSeanceStatusLabel(s)).toBe('Terminé')
+  })
+  it('passé sinon', () => {
+    const yesterday = dateOnly(new Date(Date.now() - 86400000))
+    const s = { date_seance: yesterday, heure_debut: '10:00', heure_fin: '11:00' }
+    expect(getSeanceStatusLabel(s)).toBe('Passé')
+  })
+})
+
+describe('utils/matiereDetails — statut évaluation', () => {
+  it('pas encore ouverte', () => {
+    expect(getEvaluationStatusLabel({ has_started: false })).toBe('Pas encore ouverte')
+    expect(getEvaluationStatusClass({ has_started: false })).toContain('orange')
+  })
+  it('ouverte', () => {
+    expect(getEvaluationStatusLabel({ has_started: true, is_open: true })).toBe('Ouverte')
+    expect(getEvaluationStatusClass({ has_started: true, is_open: true })).toContain('green')
+  })
+  it('fermée', () => {
+    expect(getEvaluationStatusLabel({ has_started: true, is_open: false })).toBe('Fermée')
+    expect(getEvaluationStatusClass({ has_started: true, is_open: false })).toContain('gray')
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `MatiereDetails.vue` (tranche 1)

8ᵉ god-component du TIER 2 (1454 l., Options API).

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/matiereDetails.js`** : `calculateSeanceDuration`, `getSeanceStatusClass`/`getSeanceStatusLabel` (à venir / en cours / terminé / passé), `getEvaluationStatusClass`/`getEvaluationStatusLabel` (pas ouverte / ouverte / fermée) — pures.
- ✅ **`tests/unit/matiereDetails.test.js`** — 8 cas.
- ♻️ La vue délègue ses 5 méthodes au module (imports aliasés pour éviter les collisions de noms). **1454 → 1440 l.**

### Dette tracée
`formatDate`/`formatTime` dupliquent `utils/formatters` (#23). Sous-composants d'onglets (leçons/séances/évaluations) → tranche 2 éventuelle.

### Vérifications
- ✅ `npm run test` → 243/243
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)