### PR TITLE
refactor(lessons): logique pure de StudentLessonView — #28

### DIFF
--- a/.claude/specs/god-student-lesson-view/requirements.md
+++ b/.claude/specs/god-student-lesson-view/requirements.md
@@ -1,0 +1,28 @@
+# Requirements — Décomposition `StudentLessonView.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+> (Vue canonique unifiée en #26 ; reste en Options API → conversion `<script setup>` = #27.)
+
+## Investigation (vérifié 2026-06-18)
+
+`src/views/student/StudentLessonView.vue` : **1547 lignes**, Options API.
+Logique pure : `getEmbedUrl` (YouTube/Vimeo), `getSlideUrl`/`getPdfUrl` (storage),
+mappers `getContentTypeLabel`/`getContentTypeIcon`, `isContentEmpty`. Le reste =
+chargement + navigation chapitres + progression + template/CSS.
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — logique pure → `src/utils/lessonContent.js` (TDD).
+- **Tranche 2 (éventuelle)** — sous-composants (visionneuse chapitre : vidéo/slides/PDF, sidebar chapitres).
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/lessonContent.js` :
+  `getVideoEmbedUrl`, `getSlideUrl`, `getPdfUrl`, `getContentTypeLabel`,
+  `getContentTypeIcon`, `isChapterContentEmpty(chapter, hasQuiz)`.
+- WHEN mêmes entrées, THE SYSTEM SHALL produire les mêmes sorties (le cas `quiz`
+  de `isContentEmpty` reçoit `hasQuiz` au lieu de lire l'état du composant).
+- THE SYSTEM SHALL couvrir ces fonctions par des tests (embed YT/Vimeo, URLs
+  storage absolues/relatives, mappers, vide par type).
+- WHEN la vue est refactorée, THE SYSTEM SHALL déléguer ses méthodes au module
+  (imports aliasés) et retirer l'import `apiOrigin` devenu inutile.

--- a/src/utils/lessonContent.js
+++ b/src/utils/lessonContent.js
@@ -1,0 +1,95 @@
+/**
+ * Logique pure du contenu de leçon côté étudiant (#28).
+ *
+ * Extraite de `views/student/StudentLessonView.vue` (god-component) : URL
+ * d'embed vidéo, URLs de média (slides/PDF via storage), mappers de type, et
+ * test de chapitre vide. Fonctions pures (URLs storage : dépendent de apiOrigin).
+ */
+import { apiOrigin } from '@/constants/http'
+
+/**
+ * URL d'embed YouTube/Vimeo à partir d'une URL vidéo, ou null.
+ * @param {string} url
+ * @returns {string|null}
+ */
+export function getVideoEmbedUrl(url) {
+  if (!url) return null
+  const ytMatch = url.match(/(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/)
+  if (ytMatch) return `https://www.youtube.com/embed/${ytMatch[1]}?rel=0`
+  const vimeoMatch = url.match(/vimeo\.com\/(\d+)/)
+  if (vimeoMatch) return `https://player.vimeo.com/video/${vimeoMatch[1]}`
+  return null
+}
+
+/**
+ * URL d'une slide (absolue telle quelle, sinon préfixée par le storage backend).
+ * @param {string} slide
+ * @returns {string}
+ */
+export function getSlideUrl(slide) {
+  if (!slide) return ''
+  if (slide.startsWith('http')) return slide
+  return `${apiOrigin()}/storage/${slide}`
+}
+
+/**
+ * URL du PDF d'un chapitre (pdf_url ou file_converted_path).
+ * @param {Object} chapter
+ * @returns {string}
+ */
+export function getPdfUrl(chapter) {
+  const path = chapter.pdf_url || chapter.file_converted_path
+  if (!path) return ''
+  if (path.startsWith('http')) return path
+  return `${apiOrigin()}/storage/${path}`
+}
+
+const CONTENT_TYPE_LABELS = {
+  text: 'Texte',
+  video: 'Vidéo',
+  powerpoint: 'Présentation',
+  word: 'Document',
+  pdf: 'PDF',
+  link: 'Lien externe',
+  quiz: 'Quiz'
+}
+
+const CONTENT_TYPE_ICONS = {
+  text: 'fa fa-file-text-o',
+  video: 'fa fa-play-circle',
+  powerpoint: 'fa fa-file-powerpoint-o',
+  word: 'fa fa-file-word-o',
+  pdf: 'fa fa-file-pdf-o',
+  link: 'fa fa-link',
+  quiz: 'fa fa-question-circle'
+}
+
+/** Libellé du type de contenu (côté étudiant ; fallback : type brut). */
+export function getContentTypeLabel(type) {
+  return CONTENT_TYPE_LABELS[type] || type
+}
+
+/** Icône FontAwesome du type de contenu (fallback : fichier générique). */
+export function getContentTypeIcon(type) {
+  return CONTENT_TYPE_ICONS[type] || 'fa fa-file-o'
+}
+
+/**
+ * Un chapitre est-il vide (selon son type de contenu) ?
+ * @param {Object} chapter
+ * @param {boolean} hasQuiz - existe-t-il un quiz pour le chapitre (type quiz) ?
+ * @returns {boolean}
+ */
+export function isChapterContentEmpty(chapter, hasQuiz = false) {
+  if (!chapter) return true
+  switch (chapter.content_type) {
+    case 'text': return !chapter.content
+    case 'video': return !chapter.video_url
+    case 'powerpoint': return !chapter.slides_images || chapter.slides_images.length === 0
+    case 'word': return !chapter.content
+    case 'pdf': return !chapter.pdf_url && !chapter.file_converted_path
+    case 'link': return !chapter.external_link
+    case 'quiz': return !hasQuiz
+    default: return true
+  }
+}

--- a/src/views/student/StudentLessonView.vue
+++ b/src/views/student/StudentLessonView.vue
@@ -282,7 +282,15 @@ import lessonService from '@/services/lesson'
 import chapterProgressService from '@/services/chapterProgress'
 import api from '@/services/api'
 import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
-import { apiOrigin } from '@/constants/http'
+// #28 : logique pure extraite (testée dans tests/unit/lessonContent.test.js)
+import {
+  getVideoEmbedUrl,
+  getSlideUrl as slideUrl,
+  getPdfUrl as pdfUrl,
+  getContentTypeLabel as contentTypeLabel,
+  getContentTypeIcon as contentTypeIcon,
+  isChapterContentEmpty
+} from '@/utils/lessonContent'
 
 export default {
   name: 'StudentLessonView',
@@ -511,71 +519,29 @@ export default {
 
     // ==================== CONTENT HELPERS ====================
 
+    // #28 : logique pure déléguée à utils/lessonContent
     getEmbedUrl(url) {
-      if (!url) return null
-      // YouTube
-      const ytMatch = url.match(/(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/)
-      if (ytMatch) return `https://www.youtube.com/embed/${ytMatch[1]}?rel=0`
-      // Vimeo
-      const vimeoMatch = url.match(/vimeo\.com\/(\d+)/)
-      if (vimeoMatch) return `https://player.vimeo.com/video/${vimeoMatch[1]}`
-      return null
+      return getVideoEmbedUrl(url)
     },
 
     getSlideUrl(slide) {
-      if (!slide) return ''
-      if (slide.startsWith('http')) return slide
-      // Relative path — prepend API base URL
-      const baseUrl = apiOrigin()
-      return `${baseUrl}/storage/${slide}`
+      return slideUrl(slide)
     },
 
     getPdfUrl(chapter) {
-      const path = chapter.pdf_url || chapter.file_converted_path
-      if (!path) return ''
-      if (path.startsWith('http')) return path
-      const baseUrl = apiOrigin()
-      return `${baseUrl}/storage/${path}`
+      return pdfUrl(chapter)
     },
 
     getContentTypeLabel(type) {
-      const labels = {
-        text: 'Texte',
-        video: 'Vidéo',
-        powerpoint: 'Présentation',
-        word: 'Document',
-        pdf: 'PDF',
-        link: 'Lien externe',
-        quiz: 'Quiz'
-      }
-      return labels[type] || type
+      return contentTypeLabel(type)
     },
 
     getContentTypeIcon(type) {
-      const icons = {
-        text: 'fa fa-file-text-o',
-        video: 'fa fa-play-circle',
-        powerpoint: 'fa fa-file-powerpoint-o',
-        word: 'fa fa-file-word-o',
-        pdf: 'fa fa-file-pdf-o',
-        link: 'fa fa-link',
-        quiz: 'fa fa-question-circle'
-      }
-      return icons[type] || 'fa fa-file-o'
+      return contentTypeIcon(type)
     },
 
     isContentEmpty(chapter) {
-      if (!chapter) return true
-      switch (chapter.content_type) {
-        case 'text': return !chapter.content
-        case 'video': return !chapter.video_url
-        case 'powerpoint': return !chapter.slides_images || chapter.slides_images.length === 0
-        case 'word': return !chapter.content
-        case 'pdf': return !chapter.pdf_url && !chapter.file_converted_path
-        case 'link': return !chapter.external_link
-        case 'quiz': return !this.chapterQuiz
-        default: return true
-      }
+      return isChapterContentEmpty(chapter, !!this.chapterQuiz)
     },
 
     async onQuizCompleted(resultData) {

--- a/tests/unit/lessonContent.test.js
+++ b/tests/unit/lessonContent.test.js
@@ -1,0 +1,71 @@
+/**
+ * Tests de la logique pure du contenu de leçon (#28 — StudentLessonView.vue).
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/constants/http', () => ({ apiOrigin: () => 'http://api.test' }))
+
+import {
+  getVideoEmbedUrl,
+  getSlideUrl,
+  getPdfUrl,
+  getContentTypeLabel,
+  getContentTypeIcon,
+  isChapterContentEmpty
+} from '@/utils/lessonContent'
+
+describe('utils/lessonContent — getVideoEmbedUrl', () => {
+  it('YouTube (watch / youtu.be) → embed', () => {
+    expect(getVideoEmbedUrl('https://www.youtube.com/watch?v=abc123DEF45')).toBe('https://www.youtube.com/embed/abc123DEF45?rel=0')
+    expect(getVideoEmbedUrl('https://youtu.be/abc123DEF45')).toBe('https://www.youtube.com/embed/abc123DEF45?rel=0')
+  })
+  it('Vimeo → player', () => {
+    expect(getVideoEmbedUrl('https://vimeo.com/123456')).toBe('https://player.vimeo.com/video/123456')
+  })
+  it('null si vide ou non reconnu', () => {
+    expect(getVideoEmbedUrl('')).toBeNull()
+    expect(getVideoEmbedUrl('https://example.com/x')).toBeNull()
+  })
+})
+
+describe('utils/lessonContent — getSlideUrl / getPdfUrl', () => {
+  it('slide absolue inchangée, relative préfixée storage', () => {
+    expect(getSlideUrl('https://cdn/x.png')).toBe('https://cdn/x.png')
+    expect(getSlideUrl('slides/x.png')).toBe('http://api.test/storage/slides/x.png')
+    expect(getSlideUrl('')).toBe('')
+  })
+  it('pdf : pdf_url prioritaire, fallback file_converted_path, sinon vide', () => {
+    expect(getPdfUrl({ pdf_url: 'https://cdn/a.pdf' })).toBe('https://cdn/a.pdf')
+    expect(getPdfUrl({ file_converted_path: 'docs/a.pdf' })).toBe('http://api.test/storage/docs/a.pdf')
+    expect(getPdfUrl({})).toBe('')
+  })
+})
+
+describe('utils/lessonContent — mappers de type', () => {
+  it('label + fallback', () => {
+    expect(getContentTypeLabel('video')).toBe('Vidéo')
+    expect(getContentTypeLabel('inconnu')).toBe('inconnu')
+  })
+  it('icône + fallback', () => {
+    expect(getContentTypeIcon('pdf')).toBe('fa fa-file-pdf-o')
+    expect(getContentTypeIcon('inconnu')).toBe('fa fa-file-o')
+  })
+})
+
+describe('utils/lessonContent — isChapterContentEmpty', () => {
+  it('true si pas de chapitre', () => {
+    expect(isChapterContentEmpty(null)).toBe(true)
+  })
+  it('par type de contenu', () => {
+    expect(isChapterContentEmpty({ content_type: 'text', content: '' })).toBe(true)
+    expect(isChapterContentEmpty({ content_type: 'text', content: 'x' })).toBe(false)
+    expect(isChapterContentEmpty({ content_type: 'video', video_url: 'u' })).toBe(false)
+    expect(isChapterContentEmpty({ content_type: 'powerpoint', slides_images: [] })).toBe(true)
+    expect(isChapterContentEmpty({ content_type: 'pdf', pdf_url: null, file_converted_path: 'p' })).toBe(false)
+    expect(isChapterContentEmpty({ content_type: 'link', external_link: '' })).toBe(true)
+  })
+  it('quiz : dépend de hasQuiz', () => {
+    expect(isChapterContentEmpty({ content_type: 'quiz' }, false)).toBe(true)
+    expect(isChapterContentEmpty({ content_type: 'quiz' }, true)).toBe(false)
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `StudentLessonView.vue` (tranche 1)

9ᵉ god-component du TIER 2 (1547 l., Options API — vue canonique unifiée en #26).

### Tranche 1 — logique métier pure (zéro risque UI)
- ➕ **`src/utils/lessonContent.js`** : `getVideoEmbedUrl` (YouTube/Vimeo), `getSlideUrl` / `getPdfUrl` (storage), `getContentTypeLabel` / `getContentTypeIcon`, `isChapterContentEmpty(chapter, hasQuiz)`.
- ✅ **`tests/unit/lessonContent.test.js`** — 10 cas.
- ♻️ La vue délègue ses 6 méthodes (imports aliasés) ; import `apiOrigin` retiré (0 usage résiduel). **1547 → 1513 l.**

**Note** : le cas `quiz` d'`isContentEmpty` lisait l'état du composant (`this.chapterQuiz`) → désormais passé en paramètre `hasQuiz`, rendant la fonction pure.

### Vérifications
- ✅ `npm run test` → 253/253
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)