### PR TITLE
refactor(editor): config extensions + stats de TipTapEditor — #28

### DIFF
--- a/.claude/specs/god-tiptap-editor/requirements.md
+++ b/.claude/specs/god-tiptap-editor/requirements.md
@@ -1,0 +1,33 @@
+# Requirements — Décomposition `TipTapEditor.vue` (#28)
+
+> TIER 2 — HIGH · `tier-2-god-components` · §1.1. 1 spec/vue.
+
+## Investigation (vérifié 2026-06-18)
+
+`src/components/common/TipTapEditor.vue` : **1679 lignes**. Profil **différent** des
+autres god-components : dominé par le **template** (barre d'outils ≈ 764 lignes) et
+les styles ; le script (~174 l.) est déjà propre (config d'extensions + handlers).
+Peu de logique métier pure : `wordCount`/`characterCount`, et la liste des
+extensions TipTap (config).
+
+## Stratégie (tranches)
+
+- **Tranche 1 (cette PR)** — extraire (a) stats de texte → `src/utils/textStats.js`
+  (TDD) et (b) config des extensions → `src/config/tiptapExtensions.js`
+  (séparation config / composant). Zéro risque.
+- **Tranche 2 (éventuelle)** — sous-composant `EditorToolbar` (la barre d'outils,
+  ~600 l. de template + CSS) : plus gros levier mais migration template/CSS risquée.
+
+## Exigences (tranche 1)
+
+- THE SYSTEM SHALL exposer dans `src/utils/textStats.js` : `countWords(text)`,
+  `countCharacters(text)` (pures, testées).
+- THE SYSTEM SHALL exposer dans `src/config/tiptapExtensions.js` :
+  `buildEditorExtensions(placeholder)` retournant la liste configurée.
+- WHEN le composant est refactoré, THE SYSTEM SHALL utiliser ces modules sans
+  changer le comportement de l'éditeur (build + tests verts).
+
+## Note
+
+Le plus gros gain (passer sous 300 l.) nécessite l'extraction de la toolbar en
+sous-composant (tranche 2), seule façon de réduire significativement template+CSS.

--- a/src/components/common/TipTapEditor.vue
+++ b/src/components/common/TipTapEditor.vue
@@ -765,24 +765,10 @@
 
 <script setup>
 import { useEditor, EditorContent } from '@tiptap/vue-3'
-import StarterKit from '@tiptap/starter-kit'
-import Placeholder from '@tiptap/extension-placeholder'
-import Link from '@tiptap/extension-link'
-import Underline from '@tiptap/extension-underline'
-import { TextAlign } from '@tiptap/extension-text-align'
-import { TextStyle } from '@tiptap/extension-text-style'
-import { Color } from '@tiptap/extension-color'
-import { Highlight } from '@tiptap/extension-highlight'
-import { FontFamily } from '@tiptap/extension-font-family'
-import { Table } from '@tiptap/extension-table'
-import { TableRow } from '@tiptap/extension-table-row'
-import { TableCell } from '@tiptap/extension-table-cell'
-import { TableHeader } from '@tiptap/extension-table-header'
-import { TaskList } from '@tiptap/extension-task-list'
-import { TaskItem } from '@tiptap/extension-task-item'
-import { Youtube } from '@tiptap/extension-youtube'
-import { Image } from '@tiptap/extension-image'
 import { watch, computed, ref, onMounted, onBeforeUnmount } from 'vue'
+// #28 : config des extensions + stats de texte extraites
+import { buildEditorExtensions } from '@/config/tiptapExtensions'
+import { countWords, countCharacters } from '@/utils/textStats'
 
 const props = defineProps({
   modelValue: {
@@ -801,52 +787,7 @@ const isFullscreen = ref(false)
 
 const editor = useEditor({
   content: props.modelValue,
-  extensions: [
-    StarterKit.configure({
-      heading: {
-        levels: [1, 2, 3]
-      },
-      // Note: StarterKit v3 might include some extensions by default
-      // If duplicates occur, disable them here
-    }),
-    Placeholder.configure({
-      placeholder: props.placeholder
-    }),
-    Link.configure({
-      openOnClick: false,
-      HTMLAttributes: {
-        class: 'editor-link'
-      }
-    }),
-    Underline,
-    TextAlign.configure({
-      types: ['heading', 'paragraph']
-    }),
-    TextStyle,
-    Color,
-    Highlight.configure({
-      multicolor: true
-    }),
-    FontFamily,
-    Table.configure({
-      resizable: true
-    }),
-    TableRow,
-    TableCell,
-    TableHeader,
-    TaskList,
-    TaskItem.configure({
-      nested: true
-    }),
-    Youtube.configure({
-      width: 640,
-      height: 480
-    }),
-    Image.configure({
-      inline: true,
-      allowBase64: true
-    })
-  ],
+  extensions: buildEditorExtensions(props.placeholder),
   editorProps: {
     attributes: {
       class: 'prose prose-sm max-w-none focus:outline-none'
@@ -925,18 +866,9 @@ const addYoutubeVideo = () => {
   }
 }
 
-// Word count
-const wordCount = computed(() => {
-  if (!editor.value) return 0
-  const text = editor.value.getText()
-  return text.trim().split(/\s+/).filter(word => word.length > 0).length
-})
-
-// Character count
-const characterCount = computed(() => {
-  if (!editor.value) return 0
-  return editor.value.getText().length
-})
+// Word / character count (logique pure extraite, #28)
+const wordCount = computed(() => (editor.value ? countWords(editor.value.getText()) : 0))
+const characterCount = computed(() => (editor.value ? countCharacters(editor.value.getText()) : 0))
 </script>
 
 <style scoped>

--- a/src/config/tiptapExtensions.js
+++ b/src/config/tiptapExtensions.js
@@ -1,0 +1,58 @@
+/**
+ * Configuration des extensions TipTap (#28).
+ *
+ * Extraite de `components/common/TipTapEditor.vue` : centralise la liste et la
+ * configuration des extensions de l'éditeur riche, pour alléger le composant et
+ * isoler la config (séparation config / présentation).
+ */
+import StarterKit from '@tiptap/starter-kit'
+import Placeholder from '@tiptap/extension-placeholder'
+import Link from '@tiptap/extension-link'
+import Underline from '@tiptap/extension-underline'
+import { TextAlign } from '@tiptap/extension-text-align'
+import { TextStyle } from '@tiptap/extension-text-style'
+import { Color } from '@tiptap/extension-color'
+import { Highlight } from '@tiptap/extension-highlight'
+import { FontFamily } from '@tiptap/extension-font-family'
+import { Table } from '@tiptap/extension-table'
+import { TableRow } from '@tiptap/extension-table-row'
+import { TableCell } from '@tiptap/extension-table-cell'
+import { TableHeader } from '@tiptap/extension-table-header'
+import { TaskList } from '@tiptap/extension-task-list'
+import { TaskItem } from '@tiptap/extension-task-item'
+import { Youtube } from '@tiptap/extension-youtube'
+import { Image } from '@tiptap/extension-image'
+
+/**
+ * Construit la liste d'extensions de l'éditeur.
+ * @param {string} placeholder - texte indicatif quand l'éditeur est vide
+ * @returns {Array} extensions TipTap configurées
+ */
+export function buildEditorExtensions(placeholder) {
+  return [
+    StarterKit.configure({
+      heading: {
+        levels: [1, 2, 3]
+      }
+    }),
+    Placeholder.configure({ placeholder }),
+    Link.configure({
+      openOnClick: false,
+      HTMLAttributes: { class: 'editor-link' }
+    }),
+    Underline,
+    TextAlign.configure({ types: ['heading', 'paragraph'] }),
+    TextStyle,
+    Color,
+    Highlight.configure({ multicolor: true }),
+    FontFamily,
+    Table.configure({ resizable: true }),
+    TableRow,
+    TableCell,
+    TableHeader,
+    TaskList,
+    TaskItem.configure({ nested: true }),
+    Youtube.configure({ width: 640, height: 480 }),
+    Image.configure({ inline: true, allowBase64: true })
+  ]
+}

--- a/src/utils/textStats.js
+++ b/src/utils/textStats.js
@@ -1,0 +1,25 @@
+/**
+ * Statistiques de texte PURES (#28).
+ *
+ * Extraites de `components/common/TipTapEditor.vue` (god-component) :
+ * comptage de mots et de caractères. Fonctions pures → testables.
+ */
+
+/**
+ * Nombre de mots (séparés par des espaces) dans un texte.
+ * @param {string} text
+ * @returns {number}
+ */
+export function countWords(text) {
+  if (!text) return 0
+  return text.trim().split(/\s+/).filter((word) => word.length > 0).length
+}
+
+/**
+ * Nombre de caractères d'un texte.
+ * @param {string} text
+ * @returns {number}
+ */
+export function countCharacters(text) {
+  return text ? text.length : 0
+}

--- a/tests/unit/textStats.test.js
+++ b/tests/unit/textStats.test.js
@@ -1,0 +1,29 @@
+/**
+ * Tests des statistiques de texte (#28 — TipTapEditor.vue).
+ */
+import { describe, it, expect } from 'vitest'
+import { countWords, countCharacters } from '@/utils/textStats'
+
+describe('utils/textStats — countWords', () => {
+  it('compte les mots séparés par des espaces', () => {
+    expect(countWords('bonjour le monde')).toBe(3)
+  })
+  it('ignore les espaces multiples et bords', () => {
+    expect(countWords('  un   deux  ')).toBe(2)
+  })
+  it('0 si vide', () => {
+    expect(countWords('')).toBe(0)
+    expect(countWords('   ')).toBe(0)
+    expect(countWords(null)).toBe(0)
+  })
+})
+
+describe('utils/textStats — countCharacters', () => {
+  it('compte les caractères', () => {
+    expect(countCharacters('abc')).toBe(3)
+  })
+  it('0 si vide ou null', () => {
+    expect(countCharacters('')).toBe(0)
+    expect(countCharacters(null)).toBe(0)
+  })
+})


### PR DESCRIPTION
## #28 — Décomposition `TipTapEditor.vue` (tranche 1) — 10ᵉ god-component

Profil **différent** des autres : dominé par le **template** (barre d'outils ≈ 764 l.) et les styles ; peu de logique métier. Approche adaptée.

### Tranche 1 — config + stats (zéro risque)
- ➕ **`src/utils/textStats.js`** : `countWords`, `countCharacters` (pures, testées).
- ➕ **`src/config/tiptapExtensions.js`** : `buildEditorExtensions(placeholder)` — sépare la config des 17 extensions TipTap du composant.
- ✅ **`tests/unit/textStats.test.js`** — 5 cas.
- ♻️ Le composant utilise la factory d'extensions + délègue ses stats. **1679 → 1611 l.**

### Honnêteté
Le gros gain (passer sous 300 l.) nécessite l'extraction de la **toolbar en sous-composant** (~600 l. template + CSS) → **tranche 2**, migration risquée notée dans le spec.

### Vérifications
- ✅ `npm run test` → 258/258
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)