### PR TITLE
fix(visio): réparer la sortie visio à la fermeture d'onglet (Beacon)

### DIFF
--- a/src/composables/useVisioParticipation.js
+++ b/src/composables/useVisioParticipation.js
@@ -1,8 +1,7 @@
 import { ref, onBeforeUnmount } from 'vue'
 import lmsService from '@/services/lms'
-import { useAuthStore } from '@/stores/auth'
-import { apiOrigin } from '@/constants/http'
 import { useVisioHeartbeat } from '@/composables/useVisioHeartbeat'
+import { sendVisioLeaveBeacon } from '@/services/visioLeave'
 
 /**
  * Composable pour gérer la participation à une visioconférence
@@ -122,46 +121,9 @@ export function useVisioParticipation(seanceId) {
     }
   }
 
-  /**
-   * Envoyer leaveVisio avec Beacon API
-   * Garanti l'envoi même si l'onglet se ferme
-   * @returns {Promise<boolean>} true si envoyé avec succès
-   */
-  const sendLeaveVisioBeacon = async () => {
-    try {
-      const apiUrl = `${apiOrigin()}/api/seances/${seanceId}/leave-visio`
-      const token = useAuthStore().token
-
-      if (!token) {
-        console.warn('[useVisioParticipation] Pas de token, impossible d\'envoyer Beacon')
-        return false
-      }
-
-      // Utiliser Beacon API si disponible
-      if (navigator.sendBeacon) {
-        // Créer les données pour Beacon
-        const formData = new FormData()
-        formData.append('_token', token)
-
-        // Envoyer le Beacon
-        const success = navigator.sendBeacon(apiUrl, formData)
-
-        if (success) {
-          console.log('[useVisioParticipation] 📡 Beacon envoyé pour leaveVisio')
-          return true
-        } else {
-          console.warn('[useVisioParticipation] Beacon échoué, fallback sur fetch')
-          return false
-        }
-      }
-
-      return false
-
-    } catch (error) {
-      console.error('[useVisioParticipation] Erreur Beacon:', error)
-      return false
-    }
-  }
+  // sendLeaveVisioBeacon : déplacé dans @/services/visioLeave (fix Beacon).
+  // fetch keepalive + Bearer vers la vraie route POST /api/lms/seances/:id/leave.
+  const sendLeaveVisioBeacon = () => sendVisioLeaveBeacon(seanceId)
 
   /**
    * Surveiller la fermeture de la fenêtre Jitsi

--- a/src/services/visioLeave.js
+++ b/src/services/visioLeave.js
@@ -1,0 +1,40 @@
+import { apiBaseUrl } from '@/constants/http'
+import { useAuthStore } from '@/stores/auth'
+
+/**
+ * Envoi fiable de la sortie de visio, y compris à la fermeture de l'onglet (#28 / fix Beacon).
+ *
+ * Historique : on utilisait `navigator.sendBeacon` vers `/api/seances/:id/leave-visio`
+ * — route inexistante ET incompatible avec l'auth `auth:sanctum` (Beacon ne peut
+ * pas poser de header Authorization → 401).
+ *
+ * Correctif : `fetch(..., { keepalive: true })` survit au déchargement de page
+ * (comme Beacon) tout en autorisant le header Bearer. Cible la VRAIE route
+ * backend : POST /api/lms/seances/{id}/leave (auth:sanctum).
+ *
+ * @param {number|string} seanceId
+ * @returns {Promise<boolean>} true si la requête a pu être émise
+ */
+export async function sendVisioLeaveBeacon(seanceId) {
+  const token = useAuthStore().token
+  if (!token) {
+    console.warn('[visioLeave] Pas de token, sortie visio non émise')
+    return false
+  }
+
+  try {
+    await fetch(`${apiBaseUrl()}/lms/seances/${seanceId}/leave`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      },
+      keepalive: true
+    })
+    return true
+  } catch (error) {
+    console.error('[visioLeave] Échec envoi sortie visio:', error)
+    return false
+  }
+}

--- a/src/stores/visio.js
+++ b/src/stores/visio.js
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import lmsService from '@/services/lms'
 import { useAuthStore } from '@/stores/auth'
 import { useVisioHeartbeat } from '@/composables/useVisioHeartbeat'
+import { sendVisioLeaveBeacon } from '@/services/visioLeave'
 
 /**
  * Store Pinia global pour gérer la participation aux visioconférences
@@ -121,7 +122,7 @@ export const useVisioStore = defineStore('visio', () => {
       stopHeartbeat()
 
       // 2. Envoyer leaveVisio avec Beacon API (garanti même si fermeture brutale)
-      const success = await sendLeaveVisioBeacon(seanceId)
+      const success = await sendVisioLeaveBeacon(seanceId)
 
       if (!success) {
         // Fallback sur requête normale si Beacon échoue
@@ -144,47 +145,8 @@ export const useVisioStore = defineStore('visio', () => {
     }
   }
 
-  /**
-   * Envoyer leaveVisio avec Beacon API
-   * Garanti l'envoi même si l'onglet se ferme
-   * @param {number} seanceId - ID de la séance
-   * @returns {Promise<boolean>} true si envoyé avec succès
-   */
-  const sendLeaveVisioBeacon = async (seanceId) => {
-    try {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/seances/${seanceId}/leave-visio`
-      const token = useAuthStore().token
-
-      if (!token) {
-        console.warn('[VisioStore] Pas de token, impossible d\'envoyer Beacon')
-        return false
-      }
-
-      // Utiliser Beacon API si disponible
-      if (navigator.sendBeacon) {
-        // Créer les données pour Beacon
-        const formData = new FormData()
-        formData.append('_token', token)
-
-        // Envoyer le Beacon
-        const success = navigator.sendBeacon(apiUrl, formData)
-
-        if (success) {
-          console.log('[VisioStore] 📡 Beacon envoyé pour leaveVisio')
-          return true
-        } else {
-          console.warn('[VisioStore] Beacon échoué, fallback sur fetch')
-          return false
-        }
-      }
-
-      return false
-
-    } catch (error) {
-      console.error('[VisioStore] Erreur Beacon:', error)
-      return false
-    }
-  }
+  // sendLeaveVisioBeacon : déplacé dans @/services/visioLeave (fix Beacon).
+  // fetch keepalive + Bearer vers la vraie route POST /api/lms/seances/:id/leave.
 
   /**
    * Surveiller la fermeture de la fenêtre Jitsi
@@ -287,7 +249,7 @@ export const useVisioStore = defineStore('visio', () => {
   const handleBeforeUnload = () => {
     if (isInVisio.value && activeSeanceId.value) {
       // Utiliser Beacon pour garantir l'envoi
-      sendLeaveVisioBeacon(activeSeanceId.value)
+      sendVisioLeaveBeacon(activeSeanceId.value)
     }
   }
 

--- a/tests/unit/visioLeave.test.js
+++ b/tests/unit/visioLeave.test.js
@@ -1,0 +1,44 @@
+/**
+ * Tests du service de sortie visio fiable (fix Beacon).
+ * Vérifie l'URL réelle (/api/lms/seances/:id/leave), l'auth Bearer + keepalive,
+ * et le comportement sans token / sur échec réseau.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const { tokenRef } = vi.hoisted(() => ({ tokenRef: { value: 'TOK' } }))
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => ({ token: tokenRef.value }) }))
+vi.mock('@/constants/http', () => ({ apiBaseUrl: () => 'http://api.test/api' }))
+
+import { sendVisioLeaveBeacon } from '@/services/visioLeave'
+
+describe('services/visioLeave (fix Beacon)', () => {
+  beforeEach(() => {
+    tokenRef.value = 'TOK'
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true }))
+  })
+
+  it('POST sur la vraie route /api/lms/seances/:id/leave avec Bearer + keepalive', async () => {
+    const ok = await sendVisioLeaveBeacon(42)
+    expect(ok).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://api.test/api/lms/seances/42/leave',
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+        headers: expect.objectContaining({ Authorization: 'Bearer TOK' })
+      })
+    )
+  })
+
+  it('false sans token (pas d\'appel réseau)', async () => {
+    tokenRef.value = null
+    const ok = await sendVisioLeaveBeacon(1)
+    expect(ok).toBe(false)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('false si fetch échoue', async () => {
+    global.fetch = vi.fn(() => Promise.reject(new Error('network')))
+    expect(await sendVisioLeaveBeacon(1)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Fix — sortie visio à la fermeture d'onglet (Beacon cassé)

Bug repéré pendant #26 (dédup heartbeat). La sortie de visio via `navigator.sendBeacon` était **doublement cassée** dans `stores/visio.js` et `composables/useVisioParticipation.js` :

1. **Mauvais chemin** : `/api/seances/:id/leave-visio` (composable) — route inexistante ; et **double `/api`** via `${VITE_API_URL}/api/...` (store).
2. **Auth incompatible** : `sendBeacon` ne peut pas poser de header `Authorization`. La vraie route `POST /api/lms/seances/{id}/leave` est `auth:sanctum` → renvoyait **401**.

### Vérification backend
Route réelle confirmée : `routes/api.php:600` → `POST /seances/{seanceId}/leave` (name `lms.seances.leave`), groupe `prefix('lms')` + `middleware('auth:sanctum')` ⇒ `POST /api/lms/seances/{id}/leave`, Bearer requis.

### Correctif
- ➕ **`src/services/visioLeave.js`** : `sendVisioLeaveBeacon(seanceId)` utilisant **`fetch(..., { keepalive: true })`** — survit au déchargement de page (comme Beacon) **et** autorise le header `Bearer` — vers la vraie route.
- ♻️ Store et composable délèguent au service (**dédup** de la logique au passage). Imports `apiOrigin`/`useAuthStore` devenus inutiles retirés du composable.
- ✅ **`tests/unit/visioLeave.test.js`** — 3 cas (URL+Bearer+keepalive, sans token, échec réseau).

### Vérifications
- ✅ `npm run test` → 261/261
- ✅ `npm run test:contract` → 28/28
- ✅ `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)