### PR TITLE
refactor(matieres): extraire l'onglet Évaluations de MatiereDetails — #28 (T2)

### DIFF
--- a/src/components/matieres/MatiereEvaluationsTab.vue
+++ b/src/components/matieres/MatiereEvaluationsTab.vue
@@ -1,0 +1,82 @@
+<template>
+  <div>
+    <div v-if="evaluations && evaluations.length > 0" class="space-y-4">
+      <div
+        v-for="evaluation in evaluations"
+        :key="evaluation.id"
+        class="border border-gray-200 rounded-lg p-4 hover:shadow-md transition cursor-pointer"
+        @click="$emit('view-evaluation', evaluation)"
+      >
+        <div class="flex justify-between items-start">
+          <div class="flex-1">
+            <h3 class="text-lg font-semibold text-gray-900">{{ evaluation.titre }}</h3>
+
+            <div class="flex items-center gap-4 mt-2 text-sm text-gray-600">
+              <span class="flex items-center gap-1">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {{ formatDate(evaluation.programmation?.date_evaluation) }}
+              </span>
+              <span class="flex items-center gap-1">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {{ evaluation.duree_minutes }} min
+              </span>
+              <span class="flex items-center gap-1">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+                Coef: {{ evaluation.programmation?.coefficient || 1 }}
+              </span>
+            </div>
+
+            <!-- Fenêtre temporelle -->
+            <div v-if="evaluation.programmation?.window" class="mt-2">
+              <span :class="['px-2 py-1 text-xs rounded', getEvaluationStatusClass(evaluation.programmation.window)]">
+                {{ getEvaluationStatusLabel(evaluation.programmation.window) }}
+              </span>
+            </div>
+          </div>
+
+          <button class="text-blue-600 hover:text-blue-800">
+            →
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="text-center py-12 text-gray-500">
+      <p>Aucune évaluation programmée pour cette matière</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Onglet « Évaluations » des détails matière (#28, tranche 2).
+ * Sous-composant de présentation extrait de MatiereDetails.vue.
+ * Émet view-evaluation ; la logique reste au parent. (Markup Tailwind, pas de CSS.)
+ */
+import { getEvaluationStatusClass, getEvaluationStatusLabel } from '@/utils/matiereDetails'
+
+defineProps({
+  evaluations: { type: Array, default: () => [] }
+})
+
+defineEmits(['view-evaluation'])
+
+// Formatter local (copie exacte ; dédup vers utils/formatters = dette #23).
+function formatDate(date) {
+  if (!date) return 'Non défini'
+  const dateObj = new Date(date)
+  if (isNaN(dateObj.getTime())) return 'Date invalide'
+  return dateObj.toLocaleDateString('fr-FR', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+}
+</script>

--- a/src/views/matieres/MatiereDetails.vue
+++ b/src/views/matieres/MatiereDetails.vue
@@ -224,63 +224,12 @@
           />
         </div>
 
-        <!-- Onglet Évaluations -->
+        <!-- Onglet Évaluations (#28 : extrait en sous-composant) -->
         <div v-if="activeTab === 'evaluations'">
-          <div v-if="evaluations && evaluations.length > 0" class="space-y-4">
-            <div
-              v-for="evaluation in evaluations"
-              :key="evaluation.id"
-              class="border border-gray-200 rounded-lg p-4 hover:shadow-md transition cursor-pointer"
-              @click="viewEvaluation(evaluation)"
-            >
-              <div class="flex justify-between items-start">
-                <div class="flex-1">
-                  <h3 class="text-lg font-semibold text-gray-900">{{ evaluation.titre }}</h3>
-
-                  <div class="flex items-center gap-4 mt-2 text-sm text-gray-600">
-                    <span class="flex items-center gap-1">
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                      </svg>
-                      {{ formatDate(evaluation.programmation?.date_evaluation) }}
-                    </span>
-                    <span class="flex items-center gap-1">
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      {{ evaluation.duree_minutes }} min
-                    </span>
-                    <span class="flex items-center gap-1">
-                      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                      </svg>
-                      Coef: {{ evaluation.programmation?.coefficient || 1 }}
-                    </span>
-                  </div>
-
-                  <!-- Fenêtre temporelle -->
-                  <div v-if="evaluation.programmation?.window" class="mt-2">
-                    <span
-                      :class="[
-                        'px-2 py-1 text-xs rounded',
-                        getEvaluationStatusClass(evaluation.programmation.window)
-                      ]"
-                    >
-                      {{ getEvaluationStatusLabel(evaluation.programmation.window) }}
-                    </span>
-                  </div>
-                </div>
-
-                <button class="text-blue-600 hover:text-blue-800">
-                  →
-                </button>
-              </div>
-            </div>
-          </div>
-
-          <div v-else class="text-center py-12 text-gray-500">
-            <p>Aucune évaluation programmée pour cette matière</p>
-          </div>
+          <MatiereEvaluationsTab
+            :evaluations="evaluations"
+            @view-evaluation="viewEvaluation"
+          />
         </div>
 
         <!-- Onglet Classes -->
@@ -452,13 +401,10 @@ import lmsService from '@/services/lms'
 import lessonService from '@/services/lesson'
 import LessonCard from '@/components/lessons/LessonCard.vue'
 import MatiereSeancesTab from '@/components/matieres/MatiereSeancesTab.vue'
+import MatiereEvaluationsTab from '@/components/matieres/MatiereEvaluationsTab.vue'
 import { auth } from '@/services/api'
-// #28 : logique métier pure extraite (testée dans tests/unit/matiereDetails.test.js)
-// (statut séance + durée déplacés dans MatiereSeancesTab ; ici on garde l'évaluation)
-import {
-  getEvaluationStatusClass as evaluationStatusClass,
-  getEvaluationStatusLabel as evaluationStatusLabel
-} from '@/utils/matiereDetails'
+// #28 : la logique pure (statut séance/éval, durée, formatage) vit désormais
+// dans les onglets extraits (MatiereSeancesTab / MatiereEvaluationsTab).
 
 export default {
   name: 'MatiereDetails',
@@ -466,7 +412,8 @@ export default {
     DashboardLayout,
     ContentLoader,
     LessonCard,
-    MatiereSeancesTab
+    MatiereSeancesTab,
+    MatiereEvaluationsTab
   },
 
   data() {
@@ -771,28 +718,8 @@ export default {
       this.$router.push({ name: 'classe-details', params: { id: classeId } })
     },
 
-    formatDate(date) {
-      if (!date) return 'Non défini'
-      const dateObj = new Date(date)
-      if (isNaN(dateObj.getTime())) return 'Date invalide'
-      return dateObj.toLocaleDateString('fr-FR', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-      })
-    },
-
-    // calculateDuration / formatTime / getSeanceStatusClass/Label : déplacés dans
-    // MatiereSeancesTab (#28).
-
-    getEvaluationStatusClass(window) {
-      return evaluationStatusClass(window)
-    },
-
-    getEvaluationStatusLabel(window) {
-      return evaluationStatusLabel(window)
-    }
+    // formatDate / calculateDuration / formatTime / statuts séance & évaluation :
+    // déplacés dans les onglets extraits MatiereSeancesTab / MatiereEvaluationsTab (#28).
   }
 }
 </script>


### PR DESCRIPTION
## #28 — `MatiereDetails.vue` tranche 2 (suite)

Suite de #60 (onglet Séances). Extraction de l'onglet « Évaluations ».

### Changements
- ➕ **`src/components/matieres/MatiereEvaluationsTab.vue`** (`<script setup>`) : onglet « Évaluations » (liste + statut de la fenêtre temporelle). Props `evaluations` ; émet `view-evaluation`. **Markup Tailwind → aucune CSS scopée à migrer.**
- ♻️ La vue utilise `<MatiereEvaluationsTab>` ; markup retiré + nettoyage des symboles devenus morts (`formatDate`, `getEvaluationStatusClass`/`Label` + import util `matiereDetails`). **1334 → 1261 l.**
- `viewEvaluation` (handler existant) reste au parent.

**Cumul `MatiereDetails`** : 1454 → 1261 l. (−13 %).

### Vérifications
- ✅ `npm run build` → OK · ✅ `npm run test` → 261/261 · ✅ `npm run test:contract` → 28/28

> Restent : onglets « Classes » et « Leçons » + modale création leçon (mêmes patterns Tailwind, faible risque). QA manuelle recommandée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)