### PR TITLE
refactor(lessons): extraire LessonChapterSidebar de StudentLessonView — #28 (T2)

### DIFF
--- a/src/components/lessons/LessonChapterSidebar.vue
+++ b/src/components/lessons/LessonChapterSidebar.vue
@@ -1,0 +1,244 @@
+<template>
+  <aside class="chapter-sidebar" :class="{ collapsed }">
+    <div class="sidebar-header">
+      <h2 class="sidebar-title">Sommaire</h2>
+      <button @click="$emit('toggle')" class="btn-toggle-sidebar">
+        <i :class="collapsed ? 'fa fa-chevron-right' : 'fa fa-chevron-left'"></i>
+      </button>
+    </div>
+
+    <!-- Lesson Meta -->
+    <div class="sidebar-meta" v-if="lesson">
+      <div class="meta-row" v-if="lesson.enseignant">
+        <i class="fa fa-user"></i>
+        <span>{{ lesson.enseignant.name || lesson.enseignant }}</span>
+      </div>
+      <div class="meta-row" v-if="lesson.matiere">
+        <i class="fa fa-book"></i>
+        <span>{{ lesson.matiere.name || lesson.matiere.libelle || lesson.matiere }}</span>
+      </div>
+      <div class="meta-row" v-if="lesson.duree_estimee_minutes">
+        <i class="fa fa-clock-o"></i>
+        <span>{{ lesson.duree_estimee_minutes }} min</span>
+      </div>
+    </div>
+
+    <!-- Chapter List -->
+    <nav class="chapter-list">
+      <button
+        v-for="(chapter, index) in chapters"
+        :key="chapter.id"
+        class="chapter-nav-item"
+        :class="{
+          active: activeChapterIndex === index,
+          completed: isChapterCompleted(chapter.id)
+        }"
+        @click="$emit('select', index)"
+      >
+        <div class="chapter-status-icon">
+          <i v-if="isChapterCompleted(chapter.id)" class="fa fa-check-circle"></i>
+          <span v-else class="chapter-number">{{ index + 1 }}</span>
+        </div>
+        <div class="chapter-nav-info">
+          <span class="chapter-nav-title">{{ chapter.title }}</span>
+          <span class="chapter-nav-type">{{ getContentTypeLabel(chapter.content_type) }}</span>
+        </div>
+      </button>
+    </nav>
+  </aside>
+</template>
+
+<script setup>
+/**
+ * Sidebar de navigation des chapitres d'une leçon (#28, tranche 2).
+ * Sous-composant de présentation extrait de StudentLessonView.vue.
+ * Émet select (index) / toggle ; l'état (collapsed, chapitre actif) reste au parent.
+ */
+import { getContentTypeLabel } from '@/utils/lessonContent'
+
+const props = defineProps({
+  lesson: { type: Object, default: null },
+  chapters: { type: Array, default: () => [] },
+  activeChapterIndex: { type: Number, default: 0 },
+  // Set des ids de chapitres complétés
+  completedChapters: { type: Object, default: () => new Set() },
+  collapsed: { type: Boolean, default: false }
+})
+
+defineEmits(['select', 'toggle'])
+
+function isChapterCompleted(chapterId) {
+  return props.completedChapters.has(chapterId)
+}
+</script>
+
+<style scoped>
+.chapter-sidebar {
+  width: 300px;
+  background: var(--card-bg, #1e293b);
+  border-right: 1px solid var(--border-primary, #334155);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex-shrink: 0;
+  transition: width 0.3s ease, transform 0.3s ease;
+}
+
+.chapter-sidebar.collapsed {
+  width: 0;
+  overflow: hidden;
+  border-right: none;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-primary, #334155);
+}
+
+.sidebar-title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--text-primary, #e2e8f0);
+}
+
+.btn-toggle-sidebar {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary, #94a3b8);
+  cursor: pointer;
+  padding: 0.25rem;
+  font-size: 1rem;
+}
+
+.sidebar-meta {
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border-primary, #334155);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.meta-row i {
+  width: 1rem;
+  text-align: center;
+  color: #3b82f6;
+}
+
+/* Chapter navigation items */
+.chapter-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+}
+
+.chapter-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1.25rem;
+  background: transparent;
+  border: none;
+  border-left: 3px solid transparent;
+  color: var(--text-secondary, #94a3b8);
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s;
+}
+
+.chapter-nav-item:hover {
+  background: rgba(59, 130, 246, 0.05);
+  color: var(--text-primary, #e2e8f0);
+}
+
+.chapter-nav-item.active {
+  background: rgba(59, 130, 246, 0.1);
+  border-left-color: #3b82f6;
+  color: var(--text-primary, #e2e8f0);
+}
+
+.chapter-nav-item.completed .chapter-status-icon {
+  color: #10b981;
+}
+
+.chapter-status-icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--bg-secondary, #334155);
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.chapter-nav-item.active .chapter-status-icon {
+  background: #3b82f6;
+  color: white;
+}
+
+.chapter-nav-item.completed .chapter-status-icon {
+  background: rgba(16, 185, 129, 0.15);
+}
+
+.chapter-nav-item.completed .chapter-status-icon i {
+  font-size: 1rem;
+}
+
+.chapter-number {
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.chapter-nav-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.chapter-nav-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chapter-nav-type {
+  font-size: 0.7rem;
+  opacity: 0.6;
+  margin-top: 2px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .chapter-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 50;
+    width: 280px;
+    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.3);
+  }
+
+  .chapter-sidebar.collapsed {
+    transform: translateX(-100%);
+    width: 280px;
+  }
+}
+</style>

--- a/src/views/student/StudentLessonView.vue
+++ b/src/views/student/StudentLessonView.vue
@@ -21,54 +21,16 @@
 
     <!-- Main Content Area -->
     <div class="lesson-body">
-      <!-- Sidebar: Chapter Navigation -->
-      <aside class="chapter-sidebar" :class="{ collapsed: sidebarCollapsed }">
-        <div class="sidebar-header">
-          <h2 class="sidebar-title">Sommaire</h2>
-          <button @click="sidebarCollapsed = !sidebarCollapsed" class="btn-toggle-sidebar">
-            <i :class="sidebarCollapsed ? 'fa fa-chevron-right' : 'fa fa-chevron-left'"></i>
-          </button>
-        </div>
-
-        <!-- Lesson Meta -->
-        <div class="sidebar-meta" v-if="lesson">
-          <div class="meta-row" v-if="lesson.enseignant">
-            <i class="fa fa-user"></i>
-            <span>{{ lesson.enseignant.name || lesson.enseignant }}</span>
-          </div>
-          <div class="meta-row" v-if="lesson.matiere">
-            <i class="fa fa-book"></i>
-            <span>{{ lesson.matiere.name || lesson.matiere.libelle || lesson.matiere }}</span>
-          </div>
-          <div class="meta-row" v-if="lesson.duree_estimee_minutes">
-            <i class="fa fa-clock-o"></i>
-            <span>{{ lesson.duree_estimee_minutes }} min</span>
-          </div>
-        </div>
-
-        <!-- Chapter List -->
-        <nav class="chapter-list">
-          <button
-            v-for="(chapter, index) in chapters"
-            :key="chapter.id"
-            class="chapter-nav-item"
-            :class="{
-              active: activeChapterIndex === index,
-              completed: isChapterCompleted(chapter.id)
-            }"
-            @click="setActiveChapter(index)"
-          >
-            <div class="chapter-status-icon">
-              <i v-if="isChapterCompleted(chapter.id)" class="fa fa-check-circle"></i>
-              <span v-else class="chapter-number">{{ index + 1 }}</span>
-            </div>
-            <div class="chapter-nav-info">
-              <span class="chapter-nav-title">{{ chapter.title }}</span>
-              <span class="chapter-nav-type">{{ getContentTypeLabel(chapter.content_type) }}</span>
-            </div>
-          </button>
-        </nav>
-      </aside>
+      <!-- Sidebar: Chapter Navigation (#28 : extrait en sous-composant) -->
+      <LessonChapterSidebar
+        :lesson="lesson"
+        :chapters="chapters"
+        :active-chapter-index="activeChapterIndex"
+        :completed-chapters="completedChapters"
+        :collapsed="sidebarCollapsed"
+        @select="setActiveChapter"
+        @toggle="sidebarCollapsed = !sidebarCollapsed"
+      />
 
       <!-- Mobile sidebar toggle -->
       <button v-if="sidebarCollapsed" @click="sidebarCollapsed = false" class="btn-open-sidebar-mobile">
@@ -246,6 +208,7 @@ import chapterProgressService from '@/services/chapterProgress'
 import api from '@/services/api'
 import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
 import SlidesViewer from '@/components/lessons/SlidesViewer.vue'
+import LessonChapterSidebar from '@/components/lessons/LessonChapterSidebar.vue'
 // #28 : logique pure extraite (testée dans tests/unit/lessonContent.test.js)
 // (getSlideUrl + navigation slides déplacés dans SlidesViewer)
 import {
@@ -258,7 +221,7 @@ import {
 
 export default {
   name: 'StudentLessonView',
-  components: { KnowledgeCheckPlayer, SlidesViewer },
+  components: { KnowledgeCheckPlayer, SlidesViewer, LessonChapterSidebar },
 
   data() {
     return {
@@ -613,158 +576,6 @@ export default {
   display: flex;
   flex: 1;
   overflow: hidden;
-}
-
-/* ==================== SIDEBAR ==================== */
-.chapter-sidebar {
-  width: 300px;
-  background: var(--card-bg, #1e293b);
-  border-right: 1px solid var(--border-primary, #334155);
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  flex-shrink: 0;
-  transition: width 0.3s ease, transform 0.3s ease;
-}
-
-.chapter-sidebar.collapsed {
-  width: 0;
-  overflow: hidden;
-  border-right: none;
-}
-
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border-primary, #334155);
-}
-
-.sidebar-title {
-  font-size: 1rem;
-  font-weight: 700;
-  margin: 0;
-  color: var(--text-primary, #e2e8f0);
-}
-
-.btn-toggle-sidebar {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary, #94a3b8);
-  cursor: pointer;
-  padding: 0.25rem;
-  font-size: 1rem;
-}
-
-.sidebar-meta {
-  padding: 0.75rem 1.25rem;
-  border-bottom: 1px solid var(--border-primary, #334155);
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.meta-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.8rem;
-  color: var(--text-secondary, #94a3b8);
-}
-
-.meta-row i {
-  width: 1rem;
-  text-align: center;
-  color: #3b82f6;
-}
-
-/* Chapter navigation items */
-.chapter-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 0.5rem 0;
-}
-
-.chapter-nav-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  width: 100%;
-  padding: 0.75rem 1.25rem;
-  background: transparent;
-  border: none;
-  border-left: 3px solid transparent;
-  color: var(--text-secondary, #94a3b8);
-  cursor: pointer;
-  text-align: left;
-  transition: all 0.2s;
-}
-
-.chapter-nav-item:hover {
-  background: rgba(59, 130, 246, 0.05);
-  color: var(--text-primary, #e2e8f0);
-}
-
-.chapter-nav-item.active {
-  background: rgba(59, 130, 246, 0.1);
-  border-left-color: #3b82f6;
-  color: var(--text-primary, #e2e8f0);
-}
-
-.chapter-nav-item.completed .chapter-status-icon {
-  color: #10b981;
-}
-
-.chapter-status-icon {
-  width: 1.75rem;
-  height: 1.75rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: var(--bg-secondary, #334155);
-  flex-shrink: 0;
-  font-size: 0.75rem;
-  font-weight: 700;
-}
-
-.chapter-nav-item.active .chapter-status-icon {
-  background: #3b82f6;
-  color: white;
-}
-
-.chapter-nav-item.completed .chapter-status-icon {
-  background: rgba(16, 185, 129, 0.15);
-}
-
-.chapter-nav-item.completed .chapter-status-icon i {
-  font-size: 1rem;
-}
-
-.chapter-number {
-  font-size: 0.75rem;
-  font-weight: 700;
-}
-
-.chapter-nav-info {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.chapter-nav-title {
-  font-size: 0.875rem;
-  font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.chapter-nav-type {
-  font-size: 0.7rem;
-  opacity: 0.6;
-  margin-top: 2px;
 }
 
 /* ==================== MAIN CONTENT ==================== */
@@ -1304,21 +1115,6 @@ export default {
 
   .progress-bar-top {
     width: 60px;
-  }
-
-  .chapter-sidebar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    z-index: 50;
-    width: 280px;
-    box-shadow: 4px 0 20px rgba(0, 0, 0, 0.3);
-  }
-
-  .chapter-sidebar.collapsed {
-    transform: translateX(-100%);
-    width: 280px;
   }
 
   .btn-open-sidebar-mobile {


### PR DESCRIPTION
## #28 — `StudentLessonView.vue` tranche 2 (suite)

Suite de #63 (SlidesViewer). Extraction de la **sidebar de navigation des chapitres**.

### Changements
- ➕ **`src/components/lessons/LessonChapterSidebar.vue`** (`<script setup>`) : sidebar « Sommaire » (méta leçon + liste de navigation des chapitres avec état actif/complété). Props `lesson` / `chapters` / `activeChapterIndex` / `completedChapters` / `collapsed` ; émet `select` (index) / `toggle`. `getContentTypeLabel` via `utils/lessonContent`. CSS scopée (+ responsive) copiée à l'identique.
- ♻️ La vue utilise `<LessonChapterSidebar>` ; `<aside>` + CSS sidebar (~150 l. + responsive) retirés. **1345 → 1141 l.** `getContentTypeLabel`/`isChapterCompleted` restent au parent (encore utilisés : badge d'en-tête + bouton « marquer terminé »).

**Cumul `StudentLessonView`** : 1547 → 1141 l. (**−26 %**).

### Vérifications
- ✅ `npm run build` → OK · ✅ `npm run test` → 261/261 · ✅ `npm run test:contract` → 28/28
- (jsdom logue « navigation to another Document » — avertissement d'environnement bénin, non lié)

> Parité visuelle : CSS déplacée à l'identique + build vert, QA manuelle recommandée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)