### PR TITLE
refactor(formatters): converger les date/heure à parité exacte — #23-FE-1

### DIFF
--- a/.claude/specs/formatters-convergence/requirements.md
+++ b/.claude/specs/formatters-convergence/requirements.md
@@ -1,0 +1,41 @@
+# Convergence des formatters (#23-FE-1) — constat & stratégie
+
+## Constat (vérifié 2026-06-19)
+
+L'audit listait des dizaines de `formatDate`/`formatTime`/`formatDuration`/`getInitials`
+locaux comme « duplication » à converger vers `src/utils/formatters.js`.
+
+**Vérification fine : une grande partie n'est PAS une vraie duplication.** Les
+formatters locaux ont des **formats et des replis intentionnellement différents** :
+
+| Site | Constat parité vs canonique |
+|---|---|
+| `AttendanceDetailModal.formatDate` (`toLocaleDateString('fr-FR')`, repli `-`) | **Identique** → convergé via `formatDate(_, { fallback: '-' })` |
+| `AttendanceDetailModal.formatTime` (HH:mm, repli `-`) | **Identique** → convergé via `formatTime(_, { fallback: '-' })` |
+| `AttendanceDetailModal.formatDuration` | **Différent** : `Math.round` (≠ `Math.floor`) + « 45 min » (espace, ≠ « 45min ») → **gardé local** |
+| `SeanceCard.formatTime` (HH:mm, repli `N/A`) | **Identique** → convergé via `formatTime(_, { fallback: 'N/A' })` |
+| `SeanceCard.formatDate` (`weekday:'short', day:'numeric', month:'short'`) | **Aucun canonique strictement identique** → gardé local |
+| `MatiereSeancesTab` / `MatiereEvaluationsTab` `formatDate`/`formatTime` | **Double repli** (`'Non défini'` pour null vs `'Date invalide'` pour date invalide) irreproductible avec un seul `fallback` → **gardé local** |
+| `EvaluationCard.formatDate` (`toLocaleDateString` AVEC heure → virgule ICU) | Rendu « 19/06/2026, 14:30 » ≠ `formatDateTime` « 19/06/2026 14:30 » → **gardé local** |
+
+## Règle de convergence (sûreté avant DRY)
+
+- **Converger UNIQUEMENT** quand le format (options Intl + locale) ET le repli
+  sont strictement reproductibles via le canonique + l'option `{ fallback }`.
+- **Ne jamais homogénéiser** un format/repli différent (changerait l'affichage,
+  aucune couverture de test visuel).
+- Le repli local distinct est porté par `{ fallback }` ; le format reste défini
+  une seule fois dans `utils/formatters.js` (gain DRY réel : la définition du
+  format est centralisée).
+
+## Portée livrée (PR1)
+
+Convergence **strictement à parité** : `AttendanceDetailModal` (date + heure),
+`SeanceCard` (heure). Le reste des sites est, après vérification, soit déjà
+canonique, soit légitimement spécifique → **la dette #23-FE-1 est plus petite
+qu'estimée** (beaucoup de faux positifs).
+
+## Suite (à la demande)
+
+Audit site par site des autres `formatDate/Time` : converger les rares cas à
+parité exacte ; documenter les formats spécifiques restants comme intentionnels.

--- a/src/components/attendance/AttendanceDetailModal.vue
+++ b/src/components/attendance/AttendanceDetailModal.vue
@@ -140,6 +140,8 @@
  * Émet les intentions ; la logique (chargement, export) reste dans le parent.
  */
 import { getAttendanceStatusBadgeClass } from '@/utils/attendance'
+// #23 : format date/heure centralisé (parité exacte via fallback '-')
+import { formatDate as fmtDate, formatTime as fmtTime } from '@/utils/formatters'
 
 defineProps({
   selectedSeance: { type: Object, default: null },
@@ -151,20 +153,17 @@ defineProps({
 
 defineEmits(['close', 'export-pdf', 'export-excel', 'retry'])
 
-// Formatters locaux (copie exacte de l'ex-vue ; dédup vers utils/formatters = dette #23).
+// #23 : date/heure délèguent au formatter centralisé (repli '-' identique à l'origine).
 function formatDate(dateString) {
-  if (!dateString) return '-'
-  return new Date(dateString).toLocaleDateString('fr-FR')
+  return fmtDate(dateString, { fallback: '-' })
 }
 
 function formatTime(dateString) {
-  if (!dateString) return '-'
-  return new Date(dateString).toLocaleTimeString('fr-FR', {
-    hour: '2-digit',
-    minute: '2-digit'
-  })
+  return fmtTime(dateString, { fallback: '-' })
 }
 
+// formatDuration NON convergé : sortie distincte du canonique
+// (Math.round vs Math.floor + « 45 min » avec espace) — gardé local (#23).
 function formatDuration(minutes) {
   if (!minutes || minutes === 0) return '-'
   const totalMinutes = Math.round(minutes)

--- a/src/components/seances/SeanceCard.vue
+++ b/src/components/seances/SeanceCard.vue
@@ -195,7 +195,11 @@ defineProps({
 
 defineEmits(['activate', 'start', 'deactivate', 'join', 'end'])
 
-// Formatters locaux (copie exacte de l'ex-vue ; dédup vers utils/formatters = dette #23).
+// #23 : l'heure délègue au formatter centralisé (repli 'N/A' identique).
+import { formatTime as fmtTime } from '@/utils/formatters'
+
+// formatDate gardé local : format « ven. 19 juin 2026 » (weekday court + jour
+// numérique) sans équivalent canonique strict (#23 — pas de convergence forcée).
 function formatDate(dateStr) {
   if (!dateStr) return 'N/A'
   return new Date(dateStr).toLocaleDateString('fr-FR', {
@@ -207,11 +211,7 @@ function formatDate(dateStr) {
 }
 
 function formatTime(dateTimeStr) {
-  if (!dateTimeStr) return 'N/A'
-  return new Date(dateTimeStr).toLocaleTimeString('fr-FR', {
-    hour: '2-digit',
-    minute: '2-digit'
-  })
+  return fmtTime(dateTimeStr, { fallback: 'N/A' })
 }
 </script>
 

--- a/tests/unit/formatters.test.js
+++ b/tests/unit/formatters.test.js
@@ -1,0 +1,39 @@
+/**
+ * Tests des formatters centralisés (#23) — vérifient la PARITÉ des cas convergés
+ * (AttendanceDetailModal date/heure, SeanceCard heure) : format fr-FR + repli.
+ */
+import { describe, it, expect } from 'vitest'
+import { formatDate, formatTime, formatDuration } from '@/utils/formatters'
+
+describe('utils/formatters — formatDate (parité AttendanceDetailModal)', () => {
+  it('date valide → JJ/MM/AAAA (toLocaleDateString fr-FR)', () => {
+    // Référence : new Date(x).toLocaleDateString('fr-FR')
+    const ref = new Date('2026-06-19T10:00:00').toLocaleDateString('fr-FR')
+    expect(formatDate('2026-06-19T10:00:00')).toBe(ref)
+  })
+  it('repli personnalisé pour null/vide (parité repli local "-")', () => {
+    expect(formatDate(null, { fallback: '-' })).toBe('-')
+    expect(formatDate('', { fallback: '-' })).toBe('-')
+  })
+})
+
+describe('utils/formatters — formatTime (parité Attendance + SeanceCard)', () => {
+  it('heure valide → HH:mm (toLocaleTimeString fr-FR)', () => {
+    const ref = new Date('2026-06-19T14:05:00').toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+    expect(formatTime('2026-06-19T14:05:00')).toBe(ref)
+  })
+  it('replis personnalisés "-" et "N/A" préservés', () => {
+    expect(formatTime(null, { fallback: '-' })).toBe('-')
+    expect(formatTime(null, { fallback: 'N/A' })).toBe('N/A')
+  })
+})
+
+describe('utils/formatters — formatDuration (NON convergé : doc de la divergence)', () => {
+  it('utilise Math.floor et « Ymin » sans espace (≠ formatters locaux conservés)', () => {
+    // Le canonique : "1h 30min" / "45min". Les locaux gardés diffèrent
+    // volontairement (Math.round + « 45 min »), d'où leur non-convergence.
+    expect(formatDuration(90)).toBe('1h 30min')
+    expect(formatDuration(45)).toBe('45min')
+    expect(formatDuration(0, { fallback: '-' })).toBe('-')
+  })
+})


### PR DESCRIPTION
## #23-FE-1 — Convergence des formatters (PR1)

### Constat (important)
La vérification fine montre qu'une **grande partie des « duplications » de formatters n'en sont pas** : formats Intl et replis **intentionnellement différents** selon les vues. Convergence sûre = sous-ensemble réduit (cf. `.claude/specs/formatters-convergence/`).

### Convergé (parité STRICTE vérifiée)
- **`AttendanceDetailModal`** : `formatDate` / `formatTime` délèguent à `utils/formatters` (format `fr-FR` identique, repli `'-'` via `{ fallback }`).
- **`SeanceCard`** : `formatTime` délègue (repli `'N/A'`).

### NON convergé (divergences réelles, gardé local + documenté)
- `AttendanceDetailModal.formatDuration` : `Math.round` (≠ `Math.floor`) + « 45 min » (espace, ≠ « 45min »).
- `SeanceCard.formatDate` : `weekday:'short'` — aucun canonique strictement identique.
- `MatiereSeancesTab`/`MatiereEvaluationsTab` : double repli (`'Non défini'` vs `'Date invalide'`) irreproductible.
- `EvaluationCard.formatDate` : virgule ICU (`toLocaleDateString` avec heure) ≠ `formatDateTime`.

### Gain
DRY réel : la **définition du format** vit une seule fois dans `formatters.js` ; le repli spécifique est porté par `{ fallback }` → **aucun changement d'affichage**.

### Vérifications
- ✅ **`tests/unit/formatters.test.js`** (nouveau) — 5 cas verrouillant la parité (format + replis `-`/`N/A`) + divergence `formatDuration` documentée.
- ✅ `npm run test` (unit) → 179/179 · ✅ `npm run test:contract` → 28/28 · ✅ `npm run build` → OK

> Conclusion : la dette #23-FE-1 est **plus petite qu'estimée**. Suite possible : audit site par site des autres `formatDate/Time` (rares cas à parité à converger, reste = spécifique intentionnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)