### PR TITLE
refactor(G5): script < 300 — Leçons & Chapitres

### DIFF
--- a/src/components/lessons/ChapterManager.vue
+++ b/src/components/lessons/ChapterManager.vue
@@ -106,6 +106,7 @@ import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
 import knowledgeCheckService from '@/services/knowledgeCheck'
 import ChapterViewMode from '@/components/lessons/ChapterViewMode.vue'
 import ChapterEditForm from '@/components/lessons/ChapterEditForm.vue'
+import { createEmptyChapter, buildChapterPayload } from '@/utils/chapterManager'
 
 export default {
   name: 'ChapterManager',
@@ -188,19 +189,7 @@ export default {
     },
 
     addChapter() {
-      const newChapter = {
-        tempId: this.nextTempId++,
-        title: '',
-        content_type: 'text',
-        content: '',
-        video_url: '',
-        external_link: '',
-        autoplay_video: false,
-        order: this.chapters.length,
-        isEditing: true,
-        isNew: true
-      }
-      this.chapters.push(newChapter)
+      this.chapters.push(createEmptyChapter(this.chapters.length, this.nextTempId++))
     },
 
     editChapter(chapter) {
@@ -229,15 +218,7 @@ export default {
 
       this.saving = true
       try {
-        const chapterData = {
-          title: chapter.title,
-          content_type: chapter.content_type,
-          content: chapter.content,
-          video_url: chapter.video_url,
-          external_link: chapter.external_link,
-          autoplay_video: chapter.autoplay_video,
-          order: chapter.order
-        }
+        const chapterData = buildChapterPayload(chapter)
 
         let response
         if (chapter.id) {

--- a/src/utils/chapterManager.js
+++ b/src/utils/chapterManager.js
@@ -1,0 +1,46 @@
+/**
+ * Logique pure de gestion des chapitres (G5).
+ *
+ * Extraite de `components/lessons/ChapterManager.vue` pour ramener son `<script>`
+ * sous 300 lignes : fabrique de chapitre vide et sélection des champs persistés.
+ * Fonctions pures → testables et garantes de la parité du payload envoyé à l'API.
+ */
+
+/**
+ * Construit un nouveau chapitre vide (état d'édition local, pas encore persisté).
+ * `order` et `tempId` sont injectés par l'appelant pour rester sans effet de bord.
+ * @param {number} order  position dans la liste (= longueur actuelle)
+ * @param {number} tempId identifiant temporaire unique côté client
+ */
+export function createEmptyChapter(order, tempId) {
+  return {
+    tempId,
+    title: '',
+    content_type: 'text',
+    content: '',
+    video_url: '',
+    external_link: '',
+    autoplay_video: false,
+    order,
+    isEditing: true,
+    isNew: true
+  }
+}
+
+/**
+ * Réduit un chapitre à son payload persistable (exclut tout état UI local :
+ * isEditing, isNew, selectedFile, _originalState…). Les champs et leur ordre
+ * sont identiques à l'objet inline d'origine pour préserver la parité backend.
+ * @param {object} chapter
+ */
+export function buildChapterPayload(chapter) {
+  return {
+    title: chapter.title,
+    content_type: chapter.content_type,
+    content: chapter.content,
+    video_url: chapter.video_url,
+    external_link: chapter.external_link,
+    autoplay_video: chapter.autoplay_video,
+    order: chapter.order
+  }
+}

--- a/tests/unit/ChapterEditForm.test.js
+++ b/tests/unit/ChapterEditForm.test.js
@@ -1,0 +1,53 @@
+/**
+ * Test de montage du sous-composant ChapterEditForm (G5).
+ * Vérifie le rendu lié au chapitre et la liaison two-way (édition d'item en place).
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import ChapterEditForm from '@/components/lessons/ChapterEditForm.vue'
+
+function mountForm(chapter = {}) {
+  return mount(ChapterEditForm, {
+    props: {
+      chapter: { title: 'Intro', content_type: 'text', content: '', ...chapter },
+      quiz: null,
+      saving: false
+    },
+    global: { stubs: { TipTapEditor: true } }
+  })
+}
+
+describe('ChapterEditForm (G5) — montage', () => {
+  it('monte sans erreur et pré-remplit le titre du chapitre', () => {
+    const w = mountForm()
+    expect(w.find('.title-input').element.value).toBe('Intro')
+    expect(w.find('.content-type-select').exists()).toBe(true)
+  })
+
+  it('met à jour le chapitre par référence (édition en place)', async () => {
+    const chapter = { title: 'Intro', content_type: 'text', content: '' }
+    const w = mount(ChapterEditForm, {
+      props: { chapter, quiz: null, saving: false },
+      global: { stubs: { TipTapEditor: true } }
+    })
+    await w.find('.title-input').setValue('Chapitre 1')
+    expect(chapter.title).toBe('Chapitre 1')
+  })
+
+  it('émet « save » et « cancel » avec le chapitre via les boutons d\'action', async () => {
+    const chapter = { title: 'Intro', content_type: 'text', content: '' }
+    const w = mount(ChapterEditForm, {
+      props: { chapter, quiz: null, saving: false },
+      global: { stubs: { TipTapEditor: true } }
+    })
+    await w.find('.btn-save').trigger('click')
+    expect(w.emitted('save')[0]).toEqual([chapter])
+    await w.find('.btn-cancel').trigger('click')
+    expect(w.emitted('cancel')[0]).toEqual([chapter])
+  })
+
+  it('désactive « Enregistrer » tant que le titre est vide', () => {
+    const w = mountForm({ title: '' })
+    expect(w.find('.btn-save').attributes('disabled')).toBeDefined()
+  })
+})

--- a/tests/unit/LessonCard.test.js
+++ b/tests/unit/LessonCard.test.js
@@ -1,0 +1,51 @@
+/**
+ * Test de montage du composant LessonCard (G5).
+ * Vérifie le rendu (titre, badge de type) et l'émission de l'action principale.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/lesson', () => ({
+  default: {
+    getTypeBadge: () => ({ text: 'Cours' }),
+    getStatusBadge: () => ({ text: 'Publié' }),
+    formatDuration: (m) => `${m} min`
+  }
+}))
+
+import LessonCard from '@/components/lessons/LessonCard.vue'
+
+const lesson = {
+  id: 7,
+  title: 'Algèbre linéaire',
+  type: 'cours',
+  status: 'published',
+  duration_minutes: 30,
+  content_type: 'text'
+}
+
+function mountCard(props = {}) {
+  return mount(LessonCard, {
+    props: { lesson, ...props },
+    global: { stubs: { LessonProgress: true } }
+  })
+}
+
+describe('LessonCard (G5) — rendu', () => {
+  it('monte sans erreur et affiche le titre + le badge de type', () => {
+    const w = mountCard()
+    expect(w.find('.lesson-title').text()).toContain('Algèbre linéaire')
+    expect(w.find('.lesson-badge').text()).toContain('Cours')
+  })
+
+  it("émet « view » avec l'id de la leçon au clic sur Consulter", async () => {
+    const w = mountCard()
+    await w.find('.btn-primary').trigger('click')
+    expect(w.emitted('view')[0]).toEqual([7])
+  })
+
+  it('expose les actions enseignant uniquement si isTeacher', () => {
+    expect(mountCard().find('.btn-edit').exists()).toBe(false)
+    expect(mountCard({ isTeacher: true }).find('.btn-edit').exists()).toBe(true)
+  })
+})

--- a/tests/unit/LessonChapters.test.js
+++ b/tests/unit/LessonChapters.test.js
@@ -1,0 +1,43 @@
+/**
+ * Test de montage de la vue LessonChapters (G5).
+ * Vérifie le montage et le chargement de la leçon (parité route `getLesson`).
+ */
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getLesson = vi.fn()
+vi.mock('@/services/lesson', () => ({
+  default: { getLesson: (...a) => getLesson(...a), publishLesson: vi.fn() }
+}))
+vi.mock('@/services/toast', () => ({ toast: { error: vi.fn() } }))
+vi.mock('@/services/errorHandler', () => ({ normalizeError: (e) => ({ userMessage: String(e) }) }))
+
+import LessonChapters from '@/views/lessons/LessonChapters.vue'
+
+function mountView() {
+  return shallowMount(LessonChapters, {
+    global: {
+      mocks: {
+        $route: { params: { id: '12' }, query: {} },
+        $router: { push: vi.fn(), back: vi.fn(), resolve: () => ({ href: '/x' }) }
+      }
+    }
+  })
+}
+
+describe('LessonChapters (G5) — montage', () => {
+  beforeEach(() => getLesson.mockReset())
+
+  it('monte sans erreur et charge la leçon par son id de route', async () => {
+    getLesson.mockResolvedValue({ success: true, data: { id: 12, title: 'L', matiere_id: 3 } })
+    const w = mountView()
+    await flushPromises()
+    expect(getLesson).toHaveBeenCalledWith(12)
+    expect(w.vm.lesson).toEqual({ id: 12, title: 'L', matiere_id: 3 })
+  })
+
+  it('mode lecture seule uniquement si ?readonly=true', () => {
+    const w = mountView()
+    expect(w.vm.isReadOnly).toBe(false)
+  })
+})

--- a/tests/unit/LessonEditor.test.js
+++ b/tests/unit/LessonEditor.test.js
@@ -1,0 +1,38 @@
+/**
+ * Test de montage de la vue LessonEditor (G5).
+ * Vérifie le montage en mode création (sans id de route) et le chargement des
+ * référentiels (matières/classes) au montage.
+ */
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: {} }),
+  useRouter: () => ({ push: vi.fn(), go: vi.fn() })
+}))
+
+const getMatieres = vi.fn().mockResolvedValue([])
+const getClasses = vi.fn().mockResolvedValue([])
+vi.mock('@/services/klassci', () => ({
+  klassciService: { getMatieres: (...a) => getMatieres(...a), getClasses: (...a) => getClasses(...a) }
+}))
+vi.mock('@/services/lesson', () => ({
+  default: { getLesson: vi.fn(), createLesson: vi.fn(), updateLesson: vi.fn(), deleteLesson: vi.fn() }
+}))
+vi.mock('@/services/chapter', () => ({
+  default: { getChapters: vi.fn().mockResolvedValue({ success: true, data: [] }) }
+}))
+vi.mock('@/services/toast', () => ({ toast: { error: vi.fn() } }))
+vi.mock('@/services/errorHandler', () => ({ normalizeError: (e) => ({ userMessage: String(e) }) }))
+
+import LessonEditor from '@/views/lessons/LessonEditor.vue'
+
+describe('LessonEditor (G5) — montage', () => {
+  it('monte en mode création et charge matières + classes au montage', async () => {
+    const w = shallowMount(LessonEditor)
+    await flushPromises()
+    expect(w.exists()).toBe(true)
+    expect(getMatieres).toHaveBeenCalled()
+    expect(getClasses).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/StudentLessonView.test.js
+++ b/tests/unit/StudentLessonView.test.js
@@ -1,0 +1,42 @@
+/**
+ * Test de montage de la vue StudentLessonView (G5).
+ * Vérifie le montage et le chargement (leçon + chapitres) avec parité des routes.
+ */
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getLesson = vi.fn()
+const apiGet = vi.fn()
+vi.mock('@/services/lesson', () => ({ default: { getLesson: (...a) => getLesson(...a) } }))
+vi.mock('@/services/api', () => ({ default: { get: (...a) => apiGet(...a) } }))
+vi.mock('@/services/chapterProgress', () => ({ default: { markComplete: vi.fn() } }))
+
+import StudentLessonView from '@/views/student/StudentLessonView.vue'
+
+function mountView() {
+  return shallowMount(StudentLessonView, {
+    global: { mocks: { $route: { params: { id: '5' } } } }
+  })
+}
+
+describe('StudentLessonView (G5) — montage', () => {
+  beforeEach(() => {
+    getLesson.mockReset()
+    apiGet.mockReset()
+  })
+
+  it('monte sans erreur et charge leçon + chapitres par id de route', async () => {
+    getLesson.mockResolvedValue({ success: true, data: { id: 5, title: 'L' } })
+    apiGet.mockResolvedValue({ success: true, data: [{ id: 1, content_type: 'text' }] })
+    const w = mountView()
+    await flushPromises()
+    expect(getLesson).toHaveBeenCalledWith(5)
+    expect(apiGet).toHaveBeenCalledWith('/lessons/5/chapters')
+    expect(w.vm.chapters).toHaveLength(1)
+  })
+
+  it('overallProgress vaut 0 quand aucun chapitre', () => {
+    const w = mountView()
+    expect(w.vm.overallProgress).toBe(0)
+  })
+})

--- a/tests/unit/TeacherLessons.test.js
+++ b/tests/unit/TeacherLessons.test.js
@@ -1,0 +1,26 @@
+/**
+ * Test de montage de la vue TeacherLessons (G5).
+ * Vérifie le montage et le chargement des leçons (cache vide → appel API).
+ */
+import { shallowMount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+const getLessons = vi.fn().mockResolvedValue({ success: true, data: { data: [] } })
+const getMatieres = vi.fn().mockResolvedValue([])
+vi.mock('@/services/lesson', () => ({ default: { getLessons: (...a) => getLessons(...a) } }))
+vi.mock('@/services/klassci', () => ({ klassciService: { getMatieres: (...a) => getMatieres(...a) } }))
+vi.mock('@/services/cache', () => ({ readCache: () => null, writeCache: vi.fn() }))
+
+import TeacherLessons from '@/views/lessons/TeacherLessons.vue'
+
+describe('TeacherLessons (G5) — montage', () => {
+  it('monte sans erreur et charge leçons + matières (cache vide → API)', async () => {
+    const w = shallowMount(TeacherLessons)
+    await flushPromises()
+    expect(w.exists()).toBe(true)
+    expect(getLessons).toHaveBeenCalled()
+    expect(getMatieres).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/chapterManager.test.js
+++ b/tests/unit/chapterManager.test.js
@@ -1,0 +1,78 @@
+/**
+ * Tests de la logique pure de gestion des chapitres (G5 — ChapterManager.vue).
+ *
+ * Couvre la fabrique de chapitre vide et le builder de payload extraits du
+ * god-component, garantissant la parité exacte des champs envoyés à l'API.
+ */
+import { describe, it, expect } from 'vitest'
+import { createEmptyChapter, buildChapterPayload } from '@/utils/chapterManager'
+
+describe('utils/chapterManager — createEmptyChapter', () => {
+  it('crée un chapitre vide avec les valeurs par défaut attendues', () => {
+    const chapter = createEmptyChapter(2, 7)
+    expect(chapter).toEqual({
+      tempId: 7,
+      title: '',
+      content_type: 'text',
+      content: '',
+      video_url: '',
+      external_link: '',
+      autoplay_video: false,
+      order: 2,
+      isEditing: true,
+      isNew: true
+    })
+  })
+
+  it('reporte order et tempId tels quels (aucune dérivation interne)', () => {
+    const chapter = createEmptyChapter(0, 1)
+    expect(chapter.order).toBe(0)
+    expect(chapter.tempId).toBe(1)
+    expect(chapter.isNew).toBe(true)
+    expect(chapter.isEditing).toBe(true)
+  })
+})
+
+describe('utils/chapterManager — buildChapterPayload', () => {
+  it("ne retient que les champs persistés (pas d'état UI)", () => {
+    const chapter = {
+      id: 12,
+      title: 'Intro',
+      content_type: 'video',
+      content: 'desc',
+      video_url: 'https://x',
+      external_link: '',
+      autoplay_video: true,
+      order: 3,
+      // champs UI qui ne doivent PAS partir au backend
+      isEditing: true,
+      isNew: false,
+      selectedFile: {},
+      _originalState: {}
+    }
+    expect(buildChapterPayload(chapter)).toEqual({
+      title: 'Intro',
+      content_type: 'video',
+      content: 'desc',
+      video_url: 'https://x',
+      external_link: '',
+      autoplay_video: true,
+      order: 3
+    })
+  })
+
+  it('préserve les valeurs falsy sans les remplacer', () => {
+    const payload = buildChapterPayload({
+      title: '',
+      content_type: 'text',
+      content: '',
+      video_url: '',
+      external_link: '',
+      autoplay_video: false,
+      order: 0
+    })
+    expect(payload.autoplay_video).toBe(false)
+    expect(payload.order).toBe(0)
+    expect(payload.content).toBe('')
+  })
+})

--- a/tests/unit/chapterManagerMount.test.js
+++ b/tests/unit/chapterManagerMount.test.js
@@ -1,0 +1,69 @@
+/**
+ * Test de montage du god-component ChapterManager (G5).
+ *
+ * Vérifie que le composant monte sans erreur, déclenche le chargement des
+ * chapitres au montage (parité de la route `/lessons/:id/chapters`) et crée
+ * automatiquement un premier chapitre vide quand la liste revient vide
+ * (chemin qui exerce la logique pure extraite vers utils/chapterManager).
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const apiGet = vi.fn()
+vi.mock('@/services/api', () => ({
+  default: {
+    get: (...a) => apiGet(...a),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+vi.mock('@/services/toast', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('@/services/errorHandler', () => ({ normalizeError: (e) => ({ userMessage: String(e) }) }))
+vi.mock('@/services/knowledgeCheck', () => ({
+  default: { getByChapter: vi.fn().mockResolvedValue({ success: true, data: [] }), delete: vi.fn() }
+}))
+
+import ChapterManager from '@/components/lessons/ChapterManager.vue'
+
+const stubs = {
+  ContentLoader: true,
+  KnowledgeCheckEditor: true,
+  KnowledgeCheckPlayer: true,
+  ChapterViewMode: true,
+  ChapterEditForm: true
+}
+
+function mountManager(props = {}) {
+  return mount(ChapterManager, {
+    props: { lessonId: 42, ...props },
+    global: { stubs }
+  })
+}
+
+describe('ChapterManager (G5) — montage', () => {
+  beforeEach(() => {
+    apiGet.mockReset()
+  })
+
+  it('monte sans erreur et charge les chapitres de la leçon au montage', async () => {
+    apiGet.mockResolvedValue({ success: true, data: [{ id: 1, title: 'Ch1' }] })
+    const w = mountManager()
+    await flushPromises()
+    expect(apiGet).toHaveBeenCalledWith('/lessons/42/chapters')
+    expect(w.vm.chapters).toHaveLength(1)
+    expect(w.vm.chapters[0].isEditing).toBe(false)
+  })
+
+  it('crée automatiquement un chapitre vide si la leçon n’en a aucun', async () => {
+    apiGet.mockResolvedValue({ success: true, data: [] })
+    const w = mountManager()
+    await flushPromises()
+    expect(w.vm.chapters).toHaveLength(1)
+    const created = w.vm.chapters[0]
+    expect(created.isNew).toBe(true)
+    expect(created.isEditing).toBe(true)
+    expect(created.content_type).toBe('text')
+    expect(created.order).toBe(0)
+  })
+})


### PR DESCRIPTION
## Groupe G5 — Leçons & Chapitres (décomposition « code métier < 300 lignes »)

### Constat
Sur les 7 fichiers de G5, **6 ont déjà un `<script>` < 300** sur `dev` (la table du découpage mesurait le fichier entier ; ces composants sont lourds en *template/CSS*, cas prévu par la spec). Seul **ChapterManager.vue** dépassait (script à 301).

### Changements
**1. Refacto — `ChapterManager.vue` : script 301 → 282** (commit 1)
Extraction de la logique pure vers un fichier neuf `src/utils/chapterManager.js` :
- `createEmptyChapter(order, tempId)` — fabrique du chapitre vide.
- `buildChapterPayload(chapter)` — sélection des champs persistés (exclut l'état UI).

Comportement, routes et payloads **strictement identiques** (diff mécanique).

**2. Tests de montage des 6 fichiers déjà conformes** (commit 2)
LessonCard, ChapterEditForm, LessonChapters, StudentLessonView, LessonEditor, TeacherLessons : montage sans erreur, parité des appels services/routes, interactions clés.

### Vérification
- `vitest run` sur les 8 fichiers G5 : **19/19 verts**.
- `vite build` : **vert**.
- Parité confirmée (mêmes champs/ordre, mêmes routes).

### Critères d'acceptation (par fichier)
Les 7 fichiers satisfont : `script < 300` · build vert · test de montage · parité.

### Périmètre
1 composant refactoré + 1 util neuf + 8 tests. Aucun service/util partagé édité, aucun WIP non lié embarqué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)