### PR TITLE
refactor(grades): décomposer StudentGrades.vue sous 300 lignes (G4)

### DIFF
--- a/src/composables/useStudentGrades.js
+++ b/src/composables/useStudentGrades.js
@@ -1,0 +1,54 @@
+import { ref } from 'vue'
+import api from '@/services/api'
+
+/**
+ * État + chargement des notes de l'élève (G4 — décomposition de StudentGrades.vue
+ * pour ramener son <script> sous 300 lignes).
+ *
+ * Encapsule l'état réactif (matières/moyenne/totaux + loading/error) et l'appel
+ * API `GET /my-grades`. L'identité de l'élève est dérivée du token côté backend
+ * (pas de paramètre client). Comportement et payload STRICTEMENT identiques à
+ * l'origine. La logique pure de présentation vit dans `@/utils/studentGrades`.
+ */
+export function useStudentGrades() {
+  const loading = ref(false)
+  const error = ref(null)
+  const matieres = ref([])
+  const moyenneGenerale = ref(0)
+  const totalMatieres = ref(0)
+  const totalEvaluations = ref(0)
+
+  async function fetchGrades() {
+    loading.value = true
+    error.value = null
+
+    try {
+      const response = await api.get('/my-grades')
+
+      if (response.success) {
+        const data = response.data
+        matieres.value = data.matieres || []
+        moyenneGenerale.value = data.moyenne_generale || 0
+        totalMatieres.value = data.total_matieres || 0
+        totalEvaluations.value = data.total_evaluations || 0
+      } else {
+        error.value = response.message || 'Erreur lors du chargement des notes'
+      }
+    } catch (err) {
+      console.error('Erreur récupération notes:', err)
+      error.value = err.response?.data?.message || 'Erreur de connexion au serveur'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    loading,
+    error,
+    matieres,
+    moyenneGenerale,
+    totalMatieres,
+    totalEvaluations,
+    fetchGrades
+  }
+}

--- a/src/utils/studentGrades.js
+++ b/src/utils/studentGrades.js
@@ -1,0 +1,195 @@
+/**
+ * Logique métier PURE des notes élève (G4 — décomposition de StudentGrades.vue
+ * pour ramener son <script> sous 300 lignes, PRODUCTION_STANDARDS §1.1).
+ *
+ * Fonctions extraites telles quelles depuis StudentGrades.vue : aucune
+ * dépendance Vue, aucun appel réseau → testables en isolation. Le comportement
+ * et les formats d'affichage sont STRICTEMENT identiques à l'origine (parité).
+ */
+import { formatDate as formatDateBase } from '@/utils/formatters'
+
+/** Libellés d'affichage des types d'évaluation. */
+export const EVALUATION_TYPE_LABELS = {
+  devoir: 'Devoir',
+  composition: 'Composition',
+  interrogation: 'Interrogation',
+  examen: 'Examen',
+  tp: 'TP',
+  td: 'TD',
+  qcm: 'QCM'
+}
+
+/** Type d'évaluation → libellé (valeur brute si inconnu). */
+export function formatType(type) {
+  return EVALUATION_TYPE_LABELS[type] || type
+}
+
+/**
+ * Date JJ/MM/AAAA (fr-FR). Réutilise le formatter centralisé (#23) mais
+ * conserve le repli historique « - » (et non « — ») pour la parité d'affichage.
+ */
+export function formatDate(dateString) {
+  if (!dateString) return '-'
+  return formatDateBase(dateString, { fallback: '-' })
+}
+
+/** Durée en minutes → « X min » (<60), « Xh » (heure pleine) ou « XhYY ». 0/null → « - ». */
+export function formatTemps(minutes) {
+  if (!minutes || minutes === 0) return '-'
+  if (minutes < 60) return `${minutes} min`
+  const heures = Math.floor(minutes / 60)
+  const mins = minutes % 60
+  return mins > 0 ? `${heures}h${mins}` : `${heures}h`
+}
+
+/** Classe CSS d'une moyenne, par paliers (≥16/14/12/10 sinon échec). */
+export function getMoyenneClass(moyenne) {
+  if (moyenne >= 16) return 'note-excellent'
+  if (moyenne >= 14) return 'note-good'
+  if (moyenne >= 12) return 'note-average'
+  if (moyenne >= 10) return 'note-below-average'
+  return 'note-fail'
+}
+
+/** Classe CSS d'une note (mêmes paliers que la moyenne). */
+export function getNoteClass(note) {
+  if (note >= 16) return 'note-excellent'
+  if (note >= 14) return 'note-good'
+  if (note >= 12) return 'note-average'
+  if (note >= 10) return 'note-below-average'
+  return 'note-fail'
+}
+
+/** Note maximale d'une matière (0 si aucune évaluation). */
+export function getMaxNote(matiere) {
+  if (!matiere.evaluations || matiere.evaluations.length === 0) return 0
+  return Math.max(...matiere.evaluations.map(e => parseFloat(e.note)))
+}
+
+/** Note minimale d'une matière (0 si aucune évaluation). */
+export function getMinNote(matiere) {
+  if (!matiere.evaluations || matiere.evaluations.length === 0) return 0
+  return Math.min(...matiere.evaluations.map(e => parseFloat(e.note)))
+}
+
+/**
+ * Pente d'une matière d'après la 1re et la dernière note (ordre chronologique).
+ * @returns {'na'|'up'|'down'|'flat'} 'na' si moins de 2 évaluations.
+ */
+function computeTrend(matiere) {
+  if (!matiere.evaluations || matiere.evaluations.length < 2) return 'na'
+  const sorted = [...matiere.evaluations].sort((a, b) =>
+    new Date(a.date_evaluation) - new Date(b.date_evaluation)
+  )
+  const firstNote = parseFloat(sorted[0].note)
+  const lastNote = parseFloat(sorted[sorted.length - 1].note)
+  if (lastNote > firstNote) return 'up'
+  if (lastNote < firstNote) return 'down'
+  return 'flat'
+}
+
+/** Icône de tendance (mdi) d'une matière. */
+export function getTrendIcon(matiere) {
+  switch (computeTrend(matiere)) {
+    case 'up': return 'mdi-trending-up'
+    case 'down': return 'mdi-trending-down'
+    default: return 'mdi-arrow-right'
+  }
+}
+
+/** Texte de tendance d'une matière. */
+export function getTrendText(matiere) {
+  switch (computeTrend(matiere)) {
+    case 'up': return 'En hausse'
+    case 'down': return 'En baisse'
+    default: return 'Stable'
+  }
+}
+
+/** Une évaluation soumise il y a moins de 48 h est « nouvelle ». */
+export function isNew(evaluation) {
+  if (!evaluation.date_soumission) return false
+  const soumissionDate = new Date(evaluation.date_soumission)
+  const now = new Date()
+  const diffHours = (now - soumissionDate) / (1000 * 60 * 60)
+  return diffHours < 48
+}
+
+/** Aplatit les évaluations de chaque matière en injectant matiere_nom / matiere_id. */
+export function flattenEvaluations(matieres) {
+  const evaluations = []
+  matieres.forEach(matiere => {
+    matiere.evaluations.forEach(evaluation => {
+      evaluations.push({
+        ...evaluation,
+        matiere_nom: matiere.matiere_nom,
+        matiere_id: matiere.matiere_id
+      })
+    })
+  })
+  return evaluations
+}
+
+/**
+ * Filtre (recherche/type/matière) puis trie les évaluations aplaties.
+ * Ne mute pas le tableau source (copie défensive).
+ */
+export function filterAndSortEvaluations(allEvaluations, { searchQuery, filterType, filterMatiere, sortBy }) {
+  let result = [...allEvaluations]
+
+  if (searchQuery) {
+    const query = searchQuery.toLowerCase()
+    result = result.filter(e =>
+      e.matiere_nom.toLowerCase().includes(query) ||
+      e.titre.toLowerCase().includes(query)
+    )
+  }
+
+  if (filterType) {
+    result = result.filter(e => e.type === filterType)
+  }
+
+  if (filterMatiere) {
+    result = result.filter(e => e.matiere_id === filterMatiere)
+  }
+
+  switch (sortBy) {
+    case 'date-desc':
+      result.sort((a, b) => new Date(b.date_evaluation) - new Date(a.date_evaluation))
+      break
+    case 'date-asc':
+      result.sort((a, b) => new Date(a.date_evaluation) - new Date(b.date_evaluation))
+      break
+    case 'note-desc':
+      result.sort((a, b) => parseFloat(b.note) - parseFloat(a.note))
+      break
+    case 'note-asc':
+      result.sort((a, b) => parseFloat(a.note) - parseFloat(b.note))
+      break
+    case 'matiere':
+      result.sort((a, b) => a.matiere_nom.localeCompare(b.matiere_nom))
+      break
+  }
+
+  return result
+}
+
+/** Statistiques de réussite (note ≥ 10) sur un ensemble d'évaluations. */
+export function computeStatsReussite(allEvaluations) {
+  const total = allEvaluations.length
+  const reussies = allEvaluations.filter(e => parseFloat(e.note) >= 10).length
+  const taux = total > 0 ? Math.round((reussies / total) * 100) : 0
+  return { total, reussies, taux }
+}
+
+/** Meilleure note d'un ensemble d'évaluations (0 si vide). */
+export function computeMeilleureNote(allEvaluations) {
+  if (allEvaluations.length === 0) return 0
+  return Math.max(...allEvaluations.map(e => parseFloat(e.note)))
+}
+
+/** Nom de la matière portant la meilleure note ('' si introuvable). */
+export function findMeilleureMatiere(allEvaluations, meilleureNote) {
+  const meilleureEval = allEvaluations.find(e => parseFloat(e.note) === meilleureNote)
+  return meilleureEval?.matiere_nom || ''
+}

--- a/src/views/student/StudentGrades.vue
+++ b/src/views/student/StudentGrades.vue
@@ -278,9 +278,27 @@
 <script>
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import api from '@/services/api'
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
+import { useStudentGrades } from '@/composables/useStudentGrades'
+// G4 : logique pure (format/tri/stats/tendance) extraite et testée.
+import {
+  formatType,
+  formatDate,
+  formatTemps,
+  getMoyenneClass,
+  getNoteClass,
+  getMaxNote,
+  getMinNote,
+  getTrendIcon,
+  getTrendText,
+  isNew,
+  flattenEvaluations,
+  filterAndSortEvaluations,
+  computeStatsReussite,
+  computeMeilleureNote,
+  findMeilleureMatiere
+} from '@/utils/studentGrades'
 
 export default {
   name: 'StudentGrades',
@@ -290,12 +308,17 @@ export default {
   },
   setup() {
     const router = useRouter()
-    const loading = ref(false)
-    const error = ref(null)
-    const matieres = ref([])
-    const moyenneGenerale = ref(0)
-    const totalMatieres = ref(0)
-    const totalEvaluations = ref(0)
+
+    // État + chargement délégués au composable (G4 : script < 300)
+    const {
+      loading,
+      error,
+      matieres,
+      moyenneGenerale,
+      totalMatieres,
+      totalEvaluations,
+      fetchGrades
+    } = useStudentGrades()
 
     // Filtres et tri
     const searchQuery = ref('')
@@ -304,221 +327,23 @@ export default {
     const sortBy = ref('date-desc')
     const showSummary = ref(true)
 
-    // Aplatir toutes les évaluations dans un seul tableau
-    const allEvaluations = computed(() => {
-      const evaluations = []
-      matieres.value.forEach(matiere => {
-        matiere.evaluations.forEach(evaluation => {
-          evaluations.push({
-            ...evaluation,
-            matiere_nom: matiere.matiere_nom,
-            matiere_id: matiere.matiere_id
-          })
-        })
-      })
-      return evaluations
-    })
+    // Évaluations aplaties, filtrées/triées et stats dérivées (utils purs)
+    const allEvaluations = computed(() => flattenEvaluations(matieres.value))
 
-    // Évaluations filtrées et triées
-    const filteredEvaluations = computed(() => {
-      let result = [...allEvaluations.value]
+    const filteredEvaluations = computed(() => filterAndSortEvaluations(allEvaluations.value, {
+      searchQuery: searchQuery.value,
+      filterType: filterType.value,
+      filterMatiere: filterMatiere.value,
+      sortBy: sortBy.value
+    }))
 
-      // Filtrer par recherche
-      if (searchQuery.value) {
-        const query = searchQuery.value.toLowerCase()
-        result = result.filter(e =>
-          e.matiere_nom.toLowerCase().includes(query) ||
-          e.titre.toLowerCase().includes(query)
-        )
-      }
-
-      // Filtrer par type
-      if (filterType.value) {
-        result = result.filter(e => e.type === filterType.value)
-      }
-
-      // Filtrer par matière
-      if (filterMatiere.value) {
-        result = result.filter(e => e.matiere_id === filterMatiere.value)
-      }
-
-      // Trier
-      switch (sortBy.value) {
-        case 'date-desc':
-          result.sort((a, b) => new Date(b.date_evaluation) - new Date(a.date_evaluation))
-          break
-        case 'date-asc':
-          result.sort((a, b) => new Date(a.date_evaluation) - new Date(b.date_evaluation))
-          break
-        case 'note-desc':
-          result.sort((a, b) => parseFloat(b.note) - parseFloat(a.note))
-          break
-        case 'note-asc':
-          result.sort((a, b) => parseFloat(a.note) - parseFloat(b.note))
-          break
-        case 'matiere':
-          result.sort((a, b) => a.matiere_nom.localeCompare(b.matiere_nom))
-          break
-      }
-
-      return result
-    })
-
-    // Statistiques de réussite
-    const statsReussite = computed(() => {
-      const total = allEvaluations.value.length
-      const reussies = allEvaluations.value.filter(e => parseFloat(e.note) >= 10).length
-      const taux = total > 0 ? Math.round((reussies / total) * 100) : 0
-      return { total, reussies, taux }
-    })
-
-    // Meilleure note
-    const statsMeilleureNote = computed(() => {
-      if (allEvaluations.value.length === 0) return 0
-      return Math.max(...allEvaluations.value.map(e => parseFloat(e.note)))
-    })
-
-    // Matière avec la meilleure note
-    const meilleureMatiere = computed(() => {
-      const meilleureEval = allEvaluations.value.find(
-        e => parseFloat(e.note) === statsMeilleureNote.value
-      )
-      return meilleureEval?.matiere_nom || ''
-    })
-
-    // Récupérer les notes
-    const fetchGrades = async () => {
-      loading.value = true
-      error.value = null
-
-      try {
-        const response = await api.get('/my-grades')
-
-        if (response.success) {
-          const data = response.data
-          matieres.value = data.matieres || []
-          moyenneGenerale.value = data.moyenne_generale || 0
-          totalMatieres.value = data.total_matieres || 0
-          totalEvaluations.value = data.total_evaluations || 0
-        } else {
-          error.value = response.message || 'Erreur lors du chargement des notes'
-        }
-      } catch (err) {
-        console.error('Erreur récupération notes:', err)
-        error.value = err.response?.data?.message || 'Erreur de connexion au serveur'
-      } finally {
-        loading.value = false
-      }
-    }
+    const statsReussite = computed(() => computeStatsReussite(allEvaluations.value))
+    const statsMeilleureNote = computed(() => computeMeilleureNote(allEvaluations.value))
+    const meilleureMatiere = computed(() => findMeilleureMatiere(allEvaluations.value, statsMeilleureNote.value))
 
     // Voir les résultats d'une évaluation
     const viewResults = (evaluationId) => {
       router.push(`/student/evaluations/${evaluationId}/results`)
-    }
-
-    // Formater le type d'évaluation
-    const formatType = (type) => {
-      const types = {
-        'devoir': 'Devoir',
-        'composition': 'Composition',
-        'interrogation': 'Interrogation',
-        'examen': 'Examen',
-        'tp': 'TP',
-        'td': 'TD',
-        'qcm': 'QCM'
-      }
-      return types[type] || type
-    }
-
-    // Formater la date
-    const formatDate = (dateString) => {
-      if (!dateString) return '-'
-      const date = new Date(dateString)
-      return date.toLocaleDateString('fr-FR', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric'
-      })
-    }
-
-    // Formater le temps passé
-    const formatTemps = (minutes) => {
-      if (!minutes || minutes === 0) return '-'
-      if (minutes < 60) return `${minutes} min`
-      const heures = Math.floor(minutes / 60)
-      const mins = minutes % 60
-      return mins > 0 ? `${heures}h${mins}` : `${heures}h`
-    }
-
-    // Classe CSS pour la moyenne
-    const getMoyenneClass = (moyenne) => {
-      if (moyenne >= 16) return 'note-excellent'
-      if (moyenne >= 14) return 'note-good'
-      if (moyenne >= 12) return 'note-average'
-      if (moyenne >= 10) return 'note-below-average'
-      return 'note-fail'
-    }
-
-    // Classe CSS pour une note
-    const getNoteClass = (note) => {
-      if (note >= 16) return 'note-excellent'
-      if (note >= 14) return 'note-good'
-      if (note >= 12) return 'note-average'
-      if (note >= 10) return 'note-below-average'
-      return 'note-fail'
-    }
-
-    // Note maximale d'une matière
-    const getMaxNote = (matiere) => {
-      if (!matiere.evaluations || matiere.evaluations.length === 0) return 0
-      return Math.max(...matiere.evaluations.map(e => parseFloat(e.note)))
-    }
-
-    // Note minimale d'une matière
-    const getMinNote = (matiere) => {
-      if (!matiere.evaluations || matiere.evaluations.length === 0) return 0
-      return Math.min(...matiere.evaluations.map(e => parseFloat(e.note)))
-    }
-
-    // Icône de tendance (progression ou régression)
-    const getTrendIcon = (matiere) => {
-      if (!matiere.evaluations || matiere.evaluations.length < 2) return 'mdi-arrow-right'
-
-      const sorted = [...matiere.evaluations].sort((a, b) =>
-        new Date(a.date_evaluation) - new Date(b.date_evaluation)
-      )
-
-      const firstNote = parseFloat(sorted[0].note)
-      const lastNote = parseFloat(sorted[sorted.length - 1].note)
-
-      if (lastNote > firstNote) return 'mdi-trending-up'
-      if (lastNote < firstNote) return 'mdi-trending-down'
-      return 'mdi-arrow-right'
-    }
-
-    // Texte de la tendance
-    const getTrendText = (matiere) => {
-      if (!matiere.evaluations || matiere.evaluations.length < 2) return 'Stable'
-
-      const sorted = [...matiere.evaluations].sort((a, b) =>
-        new Date(a.date_evaluation) - new Date(b.date_evaluation)
-      )
-
-      const firstNote = parseFloat(sorted[0].note)
-      const lastNote = parseFloat(sorted[sorted.length - 1].note)
-
-      if (lastNote > firstNote) return 'En hausse'
-      if (lastNote < firstNote) return 'En baisse'
-      return 'Stable'
-    }
-
-    // Vérifier si une note est nouvelle (< 48h)
-    const isNew = (evaluation) => {
-      if (!evaluation.date_soumission) return false
-      const soumissionDate = new Date(evaluation.date_soumission)
-      const now = new Date()
-      const diffHours = (now - soumissionDate) / (1000 * 60 * 60)
-      return diffHours < 48
     }
 
     // Réinitialiser les filtres

--- a/tests/unit/studentGrades.test.js
+++ b/tests/unit/studentGrades.test.js
@@ -1,0 +1,212 @@
+/**
+ * Tests de la logique métier pure des notes élève (G4 — décomposition de
+ * StudentGrades.vue pour ramener son <script> sous 300 lignes).
+ *
+ * Les assertions encodent le comportement EXACT d'origine (parité stricte).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  formatType,
+  formatDate,
+  formatTemps,
+  getMoyenneClass,
+  getNoteClass,
+  getMaxNote,
+  getMinNote,
+  getTrendIcon,
+  getTrendText,
+  isNew,
+  flattenEvaluations,
+  filterAndSortEvaluations,
+  computeStatsReussite,
+  computeMeilleureNote,
+  findMeilleureMatiere
+} from '@/utils/studentGrades'
+
+describe('studentGrades — formatType', () => {
+  it('mappe les types connus vers leur libellé', () => {
+    expect(formatType('devoir')).toBe('Devoir')
+    expect(formatType('composition')).toBe('Composition')
+    expect(formatType('interrogation')).toBe('Interrogation')
+    expect(formatType('examen')).toBe('Examen')
+    expect(formatType('tp')).toBe('TP')
+    expect(formatType('td')).toBe('TD')
+    expect(formatType('qcm')).toBe('QCM')
+  })
+  it('retourne la valeur brute pour un type inconnu', () => {
+    expect(formatType('autre')).toBe('autre')
+  })
+})
+
+describe('studentGrades — formatDate', () => {
+  it('formate JJ/MM/AAAA (fr-FR)', () => {
+    expect(formatDate(new Date(2026, 5, 15))).toBe('15/06/2026')
+    expect(formatDate(new Date(2026, 0, 5))).toBe('05/01/2026')
+  })
+  it('repli « - » pour une valeur absente', () => {
+    expect(formatDate('')).toBe('-')
+    expect(formatDate(null)).toBe('-')
+    expect(formatDate(undefined)).toBe('-')
+  })
+})
+
+describe('studentGrades — formatTemps', () => {
+  it('repli « - » pour 0 / null', () => {
+    expect(formatTemps(0)).toBe('-')
+    expect(formatTemps(null)).toBe('-')
+  })
+  it('minutes seules sous 60', () => {
+    expect(formatTemps(45)).toBe('45 min')
+  })
+  it('heures pleines', () => {
+    expect(formatTemps(60)).toBe('1h')
+    expect(formatTemps(120)).toBe('2h')
+  })
+  it('heures + minutes (format « XhYY » sans espace ni « min »)', () => {
+    expect(formatTemps(90)).toBe('1h30')
+    expect(formatTemps(125)).toBe('2h5')
+  })
+})
+
+describe('studentGrades — classes CSS de note', () => {
+  it('getMoyenneClass par paliers', () => {
+    expect(getMoyenneClass(16)).toBe('note-excellent')
+    expect(getMoyenneClass(14)).toBe('note-good')
+    expect(getMoyenneClass(12)).toBe('note-average')
+    expect(getMoyenneClass(10)).toBe('note-below-average')
+    expect(getMoyenneClass(9.99)).toBe('note-fail')
+  })
+  it('getNoteClass partage les mêmes paliers', () => {
+    expect(getNoteClass(16)).toBe('note-excellent')
+    expect(getNoteClass(13.5)).toBe('note-average')
+    expect(getNoteClass(5)).toBe('note-fail')
+  })
+})
+
+describe('studentGrades — min/max d\'une matière', () => {
+  const matiere = { evaluations: [{ note: '12' }, { note: '8' }, { note: '17' }] }
+  it('getMaxNote', () => {
+    expect(getMaxNote(matiere)).toBe(17)
+  })
+  it('getMinNote', () => {
+    expect(getMinNote(matiere)).toBe(8)
+  })
+  it('0 si aucune évaluation', () => {
+    expect(getMaxNote({ evaluations: [] })).toBe(0)
+    expect(getMinNote({})).toBe(0)
+  })
+})
+
+describe('studentGrades — tendance', () => {
+  const hausse = { evaluations: [
+    { note: '8', date_evaluation: '2026-01-01' },
+    { note: '14', date_evaluation: '2026-02-01' }
+  ] }
+  const baisse = { evaluations: [
+    { note: '15', date_evaluation: '2026-01-01' },
+    { note: '9', date_evaluation: '2026-02-01' }
+  ] }
+  const stable = { evaluations: [
+    { note: '12', date_evaluation: '2026-01-01' },
+    { note: '12', date_evaluation: '2026-02-01' }
+  ] }
+  it('icône selon la pente', () => {
+    expect(getTrendIcon(hausse)).toBe('mdi-trending-up')
+    expect(getTrendIcon(baisse)).toBe('mdi-trending-down')
+    expect(getTrendIcon(stable)).toBe('mdi-arrow-right')
+    expect(getTrendIcon({ evaluations: [{ note: '10' }] })).toBe('mdi-arrow-right')
+  })
+  it('texte selon la pente', () => {
+    expect(getTrendText(hausse)).toBe('En hausse')
+    expect(getTrendText(baisse)).toBe('En baisse')
+    expect(getTrendText(stable)).toBe('Stable')
+    expect(getTrendText({ evaluations: [] })).toBe('Stable')
+  })
+})
+
+describe('studentGrades — isNew (< 48 h depuis la soumission)', () => {
+  afterEach(() => vi.useRealTimers())
+  it('false sans date de soumission', () => {
+    expect(isNew({})).toBe(false)
+  })
+  it('true si soumis il y a moins de 48 h', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T12:00:00'))
+    expect(isNew({ date_soumission: '2026-06-20T12:00:00' })).toBe(true)
+  })
+  it('false si soumis il y a plus de 48 h', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T12:00:00'))
+    expect(isNew({ date_soumission: '2026-06-18T00:00:00' })).toBe(false)
+  })
+})
+
+describe('studentGrades — flattenEvaluations', () => {
+  it('aplatit les évaluations en injectant matiere_nom / matiere_id', () => {
+    const matieres = [
+      { matiere_id: 1, matiere_nom: 'Maths', evaluations: [{ id: 10, note: '12', titre: 'Devoir 1' }] },
+      { matiere_id: 2, matiere_nom: 'Physique', evaluations: [{ id: 20, note: '15', titre: 'TP' }] }
+    ]
+    const flat = flattenEvaluations(matieres)
+    expect(flat).toHaveLength(2)
+    expect(flat[0]).toMatchObject({ id: 10, note: '12', matiere_nom: 'Maths', matiere_id: 1 })
+    expect(flat[1]).toMatchObject({ id: 20, matiere_nom: 'Physique', matiere_id: 2 })
+  })
+})
+
+describe('studentGrades — filterAndSortEvaluations', () => {
+  const data = [
+    { titre: 'Algèbre', matiere_nom: 'Maths', matiere_id: 1, type: 'devoir', note: '8', date_evaluation: '2026-03-01' },
+    { titre: 'Optique', matiere_nom: 'Physique', matiere_id: 2, type: 'examen', note: '16', date_evaluation: '2026-01-01' },
+    { titre: 'Géométrie', matiere_nom: 'Maths', matiere_id: 1, type: 'examen', note: '12', date_evaluation: '2026-02-01' }
+  ]
+  const base = { searchQuery: '', filterType: '', filterMatiere: '', sortBy: 'date-desc' }
+
+  it('tri date décroissante par défaut', () => {
+    const r = filterAndSortEvaluations(data, base)
+    expect(r.map(e => e.date_evaluation)).toEqual(['2026-03-01', '2026-02-01', '2026-01-01'])
+  })
+  it('tri note croissante', () => {
+    const r = filterAndSortEvaluations(data, { ...base, sortBy: 'note-asc' })
+    expect(r.map(e => e.note)).toEqual(['8', '12', '16'])
+  })
+  it('tri par matière (localeCompare)', () => {
+    const r = filterAndSortEvaluations(data, { ...base, sortBy: 'matiere' })
+    expect(r.map(e => e.matiere_nom)).toEqual(['Maths', 'Maths', 'Physique'])
+  })
+  it('filtre recherche (titre ou matière, insensible à la casse)', () => {
+    expect(filterAndSortEvaluations(data, { ...base, searchQuery: 'optique' })).toHaveLength(1)
+    expect(filterAndSortEvaluations(data, { ...base, searchQuery: 'maths' })).toHaveLength(2)
+  })
+  it('filtre type et filtre matière', () => {
+    expect(filterAndSortEvaluations(data, { ...base, filterType: 'examen' })).toHaveLength(2)
+    expect(filterAndSortEvaluations(data, { ...base, filterMatiere: 1 })).toHaveLength(2)
+  })
+  it('ne mute pas le tableau source', () => {
+    const copy = [...data]
+    filterAndSortEvaluations(data, { ...base, sortBy: 'note-asc' })
+    expect(data).toEqual(copy)
+  })
+})
+
+describe('studentGrades — stats', () => {
+  const evals = [{ note: '8' }, { note: '12' }, { note: '16' }, { note: '10' }]
+  it('computeStatsReussite (>= 10 réussi)', () => {
+    expect(computeStatsReussite(evals)).toEqual({ total: 4, reussies: 3, taux: 75 })
+  })
+  it('computeStatsReussite tableau vide', () => {
+    expect(computeStatsReussite([])).toEqual({ total: 0, reussies: 0, taux: 0 })
+  })
+  it('computeMeilleureNote', () => {
+    expect(computeMeilleureNote(evals)).toBe(16)
+    expect(computeMeilleureNote([])).toBe(0)
+  })
+  it('findMeilleureMatiere', () => {
+    const flat = [
+      { note: '16', matiere_nom: 'Physique' },
+      { note: '12', matiere_nom: 'Maths' }
+    ]
+    expect(findMeilleureMatiere(flat, 16)).toBe('Physique')
+    expect(findMeilleureMatiere(flat, 20)).toBe('')
+  })
+})

--- a/tests/unit/studentGradesView.test.js
+++ b/tests/unit/studentGradesView.test.js
@@ -1,0 +1,92 @@
+/**
+ * Test de MONTAGE de la vue StudentGrades (G4 — décomposition < 300 lignes).
+ *
+ * Vérifie qu'après extraction du composable `useStudentGrades` et des utils purs
+ * `studentGrades`, la vue monte sans erreur, déclenche le chargement
+ * (GET /my-grades) au montage, et reflète les données (parité de câblage).
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock du service HTTP partagé : aucune requête réelle, payload contrôlé.
+const getMock = vi.fn()
+vi.mock('@/services/api', () => ({
+  default: { get: (...args) => getMock(...args) }
+}))
+
+// Routeur minimal (la vue n'utilise que router.push dans viewResults).
+const pushMock = vi.fn()
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock })
+}))
+
+import StudentGrades from '@/views/student/StudentGrades.vue'
+
+const SAMPLE = {
+  success: true,
+  data: {
+    matieres: [
+      {
+        matiere_id: 1,
+        matiere_nom: 'Mathématiques',
+        evaluations: [
+          { id: 10, titre: 'Devoir 1', type: 'devoir', note: '14', date_evaluation: '2026-02-01' },
+          { id: 11, titre: 'Examen', type: 'examen', note: '8', date_evaluation: '2026-03-01' }
+        ]
+      }
+    ],
+    moyenne_generale: 11,
+    total_matieres: 1,
+    total_evaluations: 2
+  }
+}
+
+function mountView() {
+  return mount(StudentGrades, {
+    global: {
+      stubs: {
+        // Rend le contenu par défaut pour pouvoir l'inspecter.
+        DashboardLayout: { template: '<div><slot /></div>' },
+        ContentLoader: { template: '<div><slot /></div>' }
+      }
+    }
+  })
+}
+
+describe('StudentGrades (G4) — montage', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    pushMock.mockReset()
+    getMock.mockResolvedValue(SAMPLE)
+  })
+
+  it('monte sans erreur et charge les notes au montage', async () => {
+    const w = mountView()
+    await flushPromises()
+
+    expect(w.find('.grades-container').exists()).toBe(true)
+    expect(w.find('.page-title').text()).toContain('Mes Notes')
+    expect(getMock).toHaveBeenCalledWith('/my-grades')
+  })
+
+  it('reflète les statistiques dérivées (moyenne, totaux, réussite)', async () => {
+    const w = mountView()
+    await flushPromises()
+
+    const text = w.text()
+    expect(text).toContain('11/20')          // moyenne générale
+    expect(text).toContain('2 évaluations')  // total évaluations
+    expect(text).toContain('50%')            // 1 réussie (14) / 2 → taux
+    expect(text).toContain('14/20')          // meilleure note
+    expect(text).toContain('Mathématiques')  // option de filtre matière
+  })
+
+  it('reste stable quand le backend répond en échec (aucune donnée)', async () => {
+    getMock.mockResolvedValue({ success: false, message: 'Erreur' })
+    const w = mountView()
+    await flushPromises()
+
+    expect(w.find('.grades-container').exists()).toBe(true)
+    expect(w.text()).toContain('0/20') // moyenne par défaut
+  })
+})


### PR DESCRIPTION
## Contexte
Groupe **G4** de la décomposition « code métier < 300 lignes » (`.claude/specs/decomposition-300`).

Le découpage listait les lignes du **fichier entier** ; le critère réel étant le **`<script>` < 300**, la remesure montre qu'**un seul** des 7 fichiers G4 dépassait : `StudentGrades.vue` (script **302**). Les 6 autres ont des templates/CSS riches mais des scripts déjà conformes (96–279) et ne sont pas touchés.

## Changements
`StudentGrades.vue` : `<script>` **302 → 127**.
- **`src/utils/studentGrades.js`** (logique pure, neuf) : format/tri/filtre/stats/tendance.
- **`src/composables/useStudentGrades.js`** (état + `GET /my-grades`, neuf).
- La vue devient une fine couche de câblage exposant **les mêmes noms** au template.

## Parité (vérifiée dans le code réel)
- `formatTemps` recopié à l'identique (sortie distincte de `formatDuration` : `1h30` ≠ `1h 30min`).
- `formatDate` réutilise le formatter centralisé (#23) avec `{ fallback: '-' }` (sortie valide identique en fr-FR, repli `'-'` conservé). Service `formatters.js` **consommé, non édité**.
- Dette mineure tracée : pour une chaîne **non vide invalide**, l'ancien `formatDate` rendait `"Invalid Date"`, le nouveau rend `'-'` — cas inatteignable avec les dates ISO backend.

## Vérification
- `npx vite build` : **vert**.
- `npx vitest run` (ciblé) : **32/32** — 26 cas purs (parité encodée) + 3 cas de montage (API/router mockés).
- Aucun service/util partagé édité, aucun backend, aucun autre fichier G4 touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)