### PR TITLE
test(evaluations): tests de montage des 7 vues/composants (G3)

### DIFF
--- a/tests/unit/CoordinatorEvaluations.test.js
+++ b/tests/unit/CoordinatorEvaluations.test.js
@@ -1,0 +1,42 @@
+/**
+ * Test de montage de la vue CoordinatorEvaluations (G3).
+ * api.get mocké (renvoie des listes vides) ; useRouter mocké ; DashboardLayout
+ * stubé en passe-plat. Vérifie le rendu et l'état dérivé après chargement.
+ * Parité : aucune source modifiée, mêmes endpoints consommés.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+const get = vi.fn().mockResolvedValue({ data: [] })
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+vi.mock('@/services/api', () => ({
+  default: { get }
+}))
+
+const stubs = {
+  DashboardLayout: { template: '<div><slot /></div>' },
+  ContentLoader: { template: '<div class="content-loader" />' }
+}
+
+describe('CoordinatorEvaluations (G3) — montage', () => {
+  it('monte sans erreur et affiche le titre global', async () => {
+    const w = mount((await import('@/views/coordinateur/CoordinatorEvaluations.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(w.find('.page-title').text()).toBe('Toutes les Évaluations')
+  })
+
+  it('charge les évaluations via /evaluations et termine en loading=false', async () => {
+    const w = mount((await import('@/views/coordinateur/CoordinatorEvaluations.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(get).toHaveBeenCalledWith('/evaluations')
+    expect(w.vm.loading).toBe(false)
+  })
+})

--- a/tests/unit/CreateEvaluation.test.js
+++ b/tests/unit/CreateEvaluation.test.js
@@ -1,0 +1,52 @@
+/**
+ * Test de montage de la vue CreateEvaluation (G3, Options API).
+ * klassciService et evaluationService mockés ; $route/$router via global.mocks.
+ * Sans paramètres d'URL → chargement des matières/classes KLASSCI seul.
+ * Vérifie le rendu de l'en-tête et l'ajout d'une question. Source intacte.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+const getMatieres = vi.fn().mockResolvedValue({ success: true, data: [] })
+const getClasses = vi.fn().mockResolvedValue({ success: true, data: [] })
+
+vi.mock('@/services/klassci', () => ({
+  default: { getMatieres, getClasses, getEvaluations: vi.fn() }
+}))
+
+vi.mock('@/services/evaluation', () => ({
+  default: { createEvaluation: vi.fn(), publishEvaluation: vi.fn() }
+}))
+
+function mountCreate(query = {}) {
+  return import('@/views/evaluations/CreateEvaluation.vue').then(({ default: cmp }) =>
+    mount(cmp, {
+      global: {
+        mocks: { $route: { query }, $router: { push: vi.fn() } }
+      }
+    })
+  )
+}
+
+describe('CreateEvaluation (G3) — montage', () => {
+  it('monte sans erreur et affiche le titre « Créer version en ligne »', async () => {
+    const w = await mountCreate()
+    await flushPromises()
+    expect(w.find('h1').text()).toBe('Créer version en ligne')
+  })
+
+  it('charge les données KLASSCI (matières + classes) au montage', async () => {
+    await mountCreate()
+    await flushPromises()
+    expect(getMatieres).toHaveBeenCalled()
+    expect(getClasses).toHaveBeenCalled()
+  })
+
+  it('addQuestion ajoute une question vide', async () => {
+    const w = await mountCreate()
+    await flushPromises()
+    expect(w.vm.questions.length).toBe(0)
+    w.vm.addQuestion()
+    expect(w.vm.questions.length).toBe(1)
+  })
+})

--- a/tests/unit/CreateQuestions.test.js
+++ b/tests/unit/CreateQuestions.test.js
@@ -1,0 +1,52 @@
+/**
+ * Test de montage de la vue CreateQuestions (G3).
+ * vue-router (useRoute/useRouter), evaluationService et klassciService mockés.
+ * Mode création (pas de :id) avec klassci_id en query → chargement KLASSCI.
+ * Vérifie le rendu de l'en-tête et l'ajout d'une question. Source intacte.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  useRoute: () => ({ params: {}, query: { klassci_id: '42' } })
+}))
+
+vi.mock('@/services/klassci', () => ({
+  default: {
+    getEvaluations: vi.fn().mockResolvedValue({
+      success: true,
+      data: [{ id: 42, titre: 'Éval KLASSCI', matiere: { id: 1 }, classe: { id: 2 } }]
+    }),
+    getTeacherDashboard: vi.fn()
+  }
+}))
+
+vi.mock('@/services/evaluation', () => ({
+  default: { getEvaluation: vi.fn(), createEvaluation: vi.fn(), updateEvaluation: vi.fn(), publishEvaluation: vi.fn() }
+}))
+
+const stubs = {
+  DashboardLayout: { template: '<div><slot /></div>' }
+}
+
+describe('CreateQuestions (G3) — montage', () => {
+  it('monte en mode création et affiche le titre « Créer les questions QCM »', async () => {
+    const w = mount((await import('@/views/evaluations/CreateQuestions.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(w.find('h1').text()).toContain('Créer les questions QCM')
+  })
+
+  it('addQuestion ajoute une question vide au state', async () => {
+    const w = mount((await import('@/views/evaluations/CreateQuestions.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(w.vm.questions.length).toBe(0)
+    w.vm.addQuestion()
+    expect(w.vm.questions.length).toBe(1)
+    expect(w.vm.questions[0]).toMatchObject({ type: 'qcm', points: 1 })
+  })
+})

--- a/tests/unit/EvaluationCard.test.js
+++ b/tests/unit/EvaluationCard.test.js
@@ -1,0 +1,44 @@
+/**
+ * Test de montage du sous-composant EvaluationCard (G3 — #28, tranche 3).
+ * Composant présentationnel pur (props + emit) extrait de TeacherEvaluations.
+ * Vérifie le rendu (titre, statut) et les intentions d'action émises selon
+ * la présence d'une version en ligne. Parité : aucune source modifiée.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import EvaluationCard from '@/components/evaluations/EvaluationCard.vue'
+
+function mountCard(evaluation = {}, props = {}) {
+  return mount(EvaluationCard, {
+    props: {
+      evaluation: { titre: 'Contrôle 1', status: 'planifiee', has_online: false, ...evaluation },
+      ...props
+    }
+  })
+}
+
+describe('EvaluationCard (G3) — montage', () => {
+  it('monte sans erreur et affiche le titre + le libellé de statut', () => {
+    const w = mountCard()
+    expect(w.find('.evaluation-card').exists()).toBe(true)
+    expect(w.find('.eval-title').text()).toBe('Contrôle 1')
+    expect(w.find('.status-badge').text()).toContain('Planifiée')
+  })
+
+  it('sans version en ligne → bouton « Créer version en ligne » qui émet create', async () => {
+    const w = mountCard({ has_online: false })
+    const btn = w.find('.btn-create')
+    expect(btn.exists()).toBe(true)
+    await btn.trigger('click')
+    expect(w.emitted('create')).toBeTruthy()
+    expect(w.emitted('create')[0][0]).toMatchObject({ titre: 'Contrôle 1' })
+  })
+
+  it('avec version en ligne → bouton « Modifier les questions » qui émet edit', async () => {
+    const w = mountCard({ has_online: true, online_version: { id: 9, is_published: true } })
+    const btn = w.find('.btn-edit')
+    expect(btn.exists()).toBe(true)
+    await btn.trigger('click')
+    expect(w.emitted('edit')).toBeTruthy()
+  })
+})

--- a/tests/unit/PreviewEvaluation.test.js
+++ b/tests/unit/PreviewEvaluation.test.js
@@ -1,0 +1,45 @@
+/**
+ * Test de montage de la vue PreviewEvaluation (G3).
+ * vue-router (useRoute/useRouter) et evaluationService.previewEvaluation mockés.
+ * Vérifie le rendu du bandeau de prévisualisation et l'appel de chargement.
+ * Parité : aucune source modifiée, même endpoint consommé.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+const previewEvaluation = vi.fn().mockResolvedValue({
+  success: true,
+  data: { id: 7, titre: 'Prévisualisation', questions_count: 0, questions: [] }
+})
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ params: { id: '7' } })
+}))
+
+vi.mock('@/services/evaluation', () => ({
+  default: { previewEvaluation, publishEvaluation: vi.fn() }
+}))
+
+const stubs = {
+  DashboardLayout: { template: '<div><slot /></div>' },
+  ContentLoader: { template: '<div class="content-loader" />' }
+}
+
+describe('PreviewEvaluation (G3) — montage', () => {
+  it('monte sans erreur et affiche le bandeau de prévisualisation', async () => {
+    const w = mount((await import('@/views/evaluations/PreviewEvaluation.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(w.find('.preview-banner-title').text()).toBe('MODE PRÉVISUALISATION')
+  })
+
+  it('charge la prévisualisation via previewEvaluation(id) au montage', async () => {
+    mount((await import('@/views/evaluations/PreviewEvaluation.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(previewEvaluation).toHaveBeenCalledWith('7')
+  })
+})

--- a/tests/unit/TakeEvaluation.test.js
+++ b/tests/unit/TakeEvaluation.test.js
@@ -1,0 +1,55 @@
+/**
+ * Test de montage de la vue TakeEvaluation (G3, Options API).
+ * Services (evaluation + auth) mockés ; $route/$router injectés via global.mocks.
+ * On exerce le chemin déterministe sans timer : utilisateur présent mais
+ * submission_id absent → erreur « ID de soumission manquant ». Source intacte.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/evaluation', () => ({
+  default: {
+    getEvaluation: vi.fn().mockResolvedValue({ success: false }),
+    submitEvaluation: vi.fn(),
+    getTimeStatus: vi.fn()
+  }
+}))
+
+vi.mock('@/services/api', () => ({
+  default: { get: vi.fn() },
+  auth: { getUser: vi.fn(() => ({ id: 1, name: 'Élève Test' })) }
+}))
+
+const stubs = {
+  DashboardLayout: { template: '<div><slot /></div>' },
+  ContentLoader: { template: '<div class="content-loader" />' }
+}
+
+function mountTake(routeOverrides = {}) {
+  return import('@/views/evaluations/TakeEvaluation.vue').then(({ default: cmp }) =>
+    mount(cmp, {
+      global: {
+        stubs,
+        mocks: {
+          $route: { params: { id: '1' }, query: {}, ...routeOverrides },
+          $router: { push: vi.fn() }
+        }
+      }
+    })
+  )
+}
+
+describe('TakeEvaluation (G3) — montage', () => {
+  it('monte sans erreur (conteneur présent)', async () => {
+    const w = await mountTake()
+    await flushPromises()
+    expect(w.find('.take-evaluation-container').exists()).toBe(true)
+  })
+
+  it('submission_id manquant → erreur explicite et loading=false', async () => {
+    const w = await mountTake({ query: {} })
+    await flushPromises()
+    expect(w.vm.error).toBe('ID de soumission manquant')
+    expect(w.vm.loading).toBe(false)
+  })
+})

--- a/tests/unit/TeacherEvaluations.test.js
+++ b/tests/unit/TeacherEvaluations.test.js
@@ -1,0 +1,58 @@
+/**
+ * Test de montage de la vue TeacherEvaluations (G3).
+ * Le composable de données est mocké (sa logique pure est déjà couverte par
+ * evaluations.test.js) ; on isole le rendu de la vue. DashboardLayout est
+ * stubé en passe-plat pour exposer le contenu interne. Parité : source intacte.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() })
+}))
+
+vi.mock('@/composables/useTeacherEvaluations', async () => {
+  const { ref, reactive } = await import('vue')
+  return {
+    useTeacherEvaluations: () => ({
+      evaluationsLMS: ref([]),
+      classes: ref([]),
+      matieres: ref([]),
+      loading: ref(false),
+      error: ref(null),
+      hideExpired: ref(true),
+      filters: reactive({ classe_id: '', matiere_id: '', statut: '' }),
+      expiredWithoutOnlineCount: ref(0),
+      filteredEvaluations: ref([]),
+      stats: ref({ total: 0, enCours: 0, terminees: 0, avecVersionEnLigne: 0 }),
+      loadData: vi.fn(),
+      loadEvaluationsLMS: vi.fn(),
+      applyFilters: vi.fn(),
+      resetFilters: vi.fn()
+    })
+  }
+})
+
+const stubs = {
+  DashboardLayout: { template: '<div><slot /></div>' },
+  ContentLoader: { template: '<div class="content-loader" />' }
+}
+
+describe('TeacherEvaluations (G3) — montage', () => {
+  it('monte sans erreur et affiche le titre de page', async () => {
+    const w = mount((await import('@/views/evaluations/TeacherEvaluations.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(w.find('.page-title').text()).toBe('Évaluations')
+  })
+
+  it('loading=false → état vide (aucune carte d’évaluation) et stats à 0', async () => {
+    const w = mount((await import('@/views/evaluations/TeacherEvaluations.vue')).default, {
+      global: { stubs }
+    })
+    await flushPromises()
+    expect(w.findAllComponents({ name: 'EvaluationCard' }).length).toBe(0)
+    expect(w.find('.stat-value').text()).toBe('0')
+  })
+})


### PR DESCRIPTION
## Groupe G3 — Évaluations · Création & passage

### Constat
La branche partait de `dev` à jour. **Les 7 fichiers G3 ont déjà leur `<script>` sous 300 lignes** (découpage livré en #28 : composable `useTeacherEvaluations`, sous-composant `EvaluationCard`, utils `@/utils/evaluations`). Mesure vérifiée sur le code réel :

| Fichier | Script | < 300 |
|---|---|---|
| TeacherEvaluations.vue | 246 | ✅ |
| TakeEvaluation.vue | 215 | ✅ |
| CoordinatorEvaluations.vue | 183 | ✅ |
| PreviewEvaluation.vue | 105 | ✅ |
| EvaluationCard.vue | 56 | ✅ |
| CreateQuestions.vue | 263 | ✅ |
| CreateEvaluation.vue | 210 | ✅ |

**Aucune refacto source** : modifier des fichiers déjà conformes n'apporterait aucun gain et introduirait un risque de régression.

### Ce que livre cette PR
La seule condition manquante de la définition de « fini » : **les tests de montage**. 7 tests `@vue/test-utils` neufs (services/router mockés, `DashboardLayout` stubé en passe-plat) :
- `EvaluationCard` — titre, statut, émissions `create`/`edit`
- `TeacherEvaluations` — composable mocké, titre de page, état vide
- `TakeEvaluation` — chemin déterministe sans timer (submission_id manquant)
- `CoordinatorEvaluations` — `api.get('/evaluations')`, loading final
- `PreviewEvaluation` — `previewEvaluation(id)`, bandeau
- `CreateQuestions` — mode création, `addQuestion`
- `CreateEvaluation` — chargement matières/classes KLASSCI, `addQuestion`

### Vérifications
- `npx vite build` → **vert** (exit 0)
- `npx vitest run` (7 fichiers ciblés) → **16/16 verts**
- **Parité garantie par construction** : `git status -- src/` vide, **0 fichier source modifié**
- Aucun service/util partagé touché, pas de WIP embarqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)