### PR TITLE
test(g6): tests de montage des composants éditeurs/contenu (G6)

### DIFF
--- a/tests/unit/EditorToolbar.test.js
+++ b/tests/unit/EditorToolbar.test.js
@@ -1,0 +1,44 @@
+/**
+ * Test de montage du sous-composant EditorToolbar (G6).
+ * La toolbar partagée de l'éditeur riche : le bouton « mode étendu » n'apparaît
+ * qu'avec showFullscreenToggle, et son clic émet `toggle-fullscreen`.
+ * Aucun appel service/route : composant 100 % présentation + handlers locaux.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import EditorToolbar from '@/components/common/EditorToolbar.vue'
+
+// Éditeur TipTap factice : chaîne fluide `chain().focus().X().run()` + isActive.
+function makeEditor() {
+  const chain = {}
+  const methods = [
+    'focus', 'run', 'toggleBold', 'toggleItalic', 'toggleStrike', 'toggleCode',
+    'toggleHeading', 'setParagraph', 'toggleBulletList', 'toggleOrderedList',
+    'toggleBlockquote', 'toggleCodeBlock', 'setLink', 'unsetLink', 'setImage',
+    'insertTable', 'setYoutubeVideo', 'undo', 'redo', 'setTextAlign'
+  ]
+  methods.forEach((m) => { chain[m] = () => chain })
+  return { isActive: () => false, can: () => ({ undo: () => true, redo: () => true }), chain: () => chain }
+}
+
+function mountToolbar(props = {}) {
+  return mount(EditorToolbar, { props: { editor: makeEditor(), ...props } })
+}
+
+describe('EditorToolbar (G6) — montage', () => {
+  it('monte sans erreur avec un editor fourni', () => {
+    const w = mountToolbar()
+    expect(w.findAll('button').length).toBeGreaterThan(0)
+  })
+
+  it('bouton « mode étendu » masqué par défaut, affiché avec showFullscreenToggle', () => {
+    expect(mountToolbar().find('.toolbar-btn-fullscreen').exists()).toBe(false)
+    expect(mountToolbar({ showFullscreenToggle: true }).find('.toolbar-btn-fullscreen').exists()).toBe(true)
+  })
+
+  it('clic sur « mode étendu » émet toggle-fullscreen', async () => {
+    const w = mountToolbar({ showFullscreenToggle: true })
+    await w.find('.toolbar-btn-fullscreen').trigger('click')
+    expect(w.emitted('toggle-fullscreen')).toBeTruthy()
+  })
+})

--- a/tests/unit/ForumTopic.test.js
+++ b/tests/unit/ForumTopic.test.js
@@ -1,0 +1,52 @@
+/**
+ * Test de montage de ForumTopic (G6, Options API).
+ * Service forum, store d'auth et $route/$router sont mockés ; DashboardLayout est
+ * stubé. On vérifie le chargement du topic au montage et le rendu de son titre.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+const { getTopic } = vi.hoisted(() => ({
+  getTopic: vi.fn(() => Promise.resolve({
+    data: { id: 1, title: 'Sujet de discussion', user_id: 1, posts: [] }
+  }))
+}))
+
+vi.mock('@/services/api', () => ({
+  forum: {
+    getTopic,
+    replyToTopic: vi.fn(() => Promise.resolve({})),
+    markAsSolution: vi.fn(() => Promise.resolve({}))
+  }
+}))
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ currentUser: { id: 1, role: 'enseignant' } })
+}))
+
+import ForumTopic from '@/views/ForumTopic.vue'
+
+function mountTopic() {
+  return mount(ForumTopic, {
+    global: {
+      mocks: {
+        $route: { params: { id: '1' } },
+        $router: { push: vi.fn() }
+      },
+      stubs: { DashboardLayout: { template: '<div><slot /></div>' } }
+    }
+  })
+}
+
+describe('ForumTopic (G6) — montage', () => {
+  it('charge le topic au montage avec l\'id de la route', async () => {
+    mountTopic()
+    await flushPromises()
+    expect(getTopic).toHaveBeenCalledWith('1')
+  })
+
+  it('affiche le titre du topic une fois chargé', async () => {
+    const w = mountTopic()
+    await flushPromises()
+    expect(w.find('.forum-title').text()).toBe('Sujet de discussion')
+  })
+})

--- a/tests/unit/GlobalSearchModal.test.js
+++ b/tests/unit/GlobalSearchModal.test.js
@@ -1,0 +1,36 @@
+/**
+ * Test de montage de GlobalSearchModal (G6).
+ * Le contenu est rendu via <Teleport to="body"> et conditionné par modelValue.
+ * Router et service de recherche sont mockés. On vérifie le montage fermé puis
+ * l'apparition du modal dans le body quand modelValue passe à true.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/services/search', () => ({
+  searchService: {
+    globalSearch: vi.fn(() => Promise.resolve({ results: {} })),
+    getSearchHistory: vi.fn(() => Promise.resolve([])),
+    saveToHistory: vi.fn()
+  }
+}))
+
+import GlobalSearchModal from '@/components/modals/GlobalSearchModal.vue'
+
+afterEach(() => { document.body.innerHTML = '' })
+
+describe('GlobalSearchModal (G6) — montage', () => {
+  it('monte fermé sans erreur (rien dans le body)', () => {
+    const w = mount(GlobalSearchModal, { props: { modelValue: false } })
+    expect(w.exists()).toBe(true)
+    expect(document.body.querySelector('.search-modal')).toBeNull()
+  })
+
+  it('ouvert (modelValue=true) : le modal et son champ de recherche sont téléportés dans le body', async () => {
+    mount(GlobalSearchModal, { props: { modelValue: true }, attachTo: document.body })
+    await flushPromises()
+    expect(document.body.querySelector('.search-modal')).not.toBeNull()
+    expect(document.body.querySelector('.search-input')).not.toBeNull()
+  })
+})

--- a/tests/unit/KnowledgeCheckEditor.test.js
+++ b/tests/unit/KnowledgeCheckEditor.test.js
@@ -1,0 +1,46 @@
+/**
+ * Test de montage de KnowledgeCheckEditor (G6).
+ * Vérifie le rendu création vs édition (titre d'en-tête) et l'ajout de question
+ * via le service (createEmptyQuestion). `draggable` (vuedraggable) est stubé : on
+ * teste l'éditeur, pas la lib de glisser-déposer.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/knowledgeCheck', () => ({
+  default: {
+    createEmptyQuestion: vi.fn(() => ({
+      question: '', type: 'single', options: ['', ''], correct_answer: null
+    })),
+    create: vi.fn(),
+    update: vi.fn()
+  }
+}))
+
+import KnowledgeCheckEditor from '@/components/lessons/KnowledgeCheckEditor.vue'
+
+function mountEditor(props = {}) {
+  return mount(KnowledgeCheckEditor, {
+    props: { chapterId: 42, ...props },
+    global: { stubs: { draggable: true } }
+  })
+}
+
+describe('KnowledgeCheckEditor (G6) — montage', () => {
+  it('monte en mode création : titre « Nouveau quiz »', () => {
+    const w = mountEditor()
+    expect(w.find('.knowledge-check-editor').exists()).toBe(true)
+    expect(w.find('.editor-title').text()).toContain('Nouveau quiz')
+  })
+
+  it('mode édition quand existingQuiz est fourni : titre « Modifier le quiz »', () => {
+    const w = mountEditor({ existingQuiz: { id: 7, title: 'X', questions: [] } })
+    expect(w.find('.editor-title').text()).toContain('Modifier le quiz')
+  })
+
+  it('le bouton fermer émet close', async () => {
+    const w = mountEditor()
+    await w.find('.close-btn').trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+  })
+})

--- a/tests/unit/KnowledgeCheckPlayer.test.js
+++ b/tests/unit/KnowledgeCheckPlayer.test.js
@@ -1,0 +1,38 @@
+/**
+ * Test de montage de KnowledgeCheckPlayer (G6).
+ * État initial « intro » : aucun appel service au montage (startAttempt n'est
+ * déclenché que par le clic « Commencer »). On vérifie le rendu de l'intro.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/knowledgeCheck', () => ({
+  default: {
+    startAttempt: vi.fn(),
+    submitAttempt: vi.fn(),
+    createEmptyQuestion: vi.fn(() => ({}))
+  }
+}))
+
+import KnowledgeCheckPlayer from '@/components/lessons/KnowledgeCheckPlayer.vue'
+
+const quiz = {
+  id: 1,
+  title: 'Quiz Chapitre 1',
+  description: 'Testez vos connaissances',
+  passing_score: 70,
+  questions: [{ question: 'Q1', options: ['a', 'b'], type: 'single', correct_answer: 0 }]
+}
+
+describe('KnowledgeCheckPlayer (G6) — montage', () => {
+  it('monte en état intro et affiche le titre du quiz', () => {
+    const w = mount(KnowledgeCheckPlayer, { props: { quiz } })
+    expect(w.find('.knowledge-check-player').exists()).toBe(true)
+    expect(w.find('.intro-title').text()).toBe('Quiz Chapitre 1')
+  })
+
+  it('affiche le score minimum requis', () => {
+    const w = mount(KnowledgeCheckPlayer, { props: { quiz } })
+    expect(w.html()).toContain('70%')
+  })
+})

--- a/tests/unit/NotificationsWidget.test.js
+++ b/tests/unit/NotificationsWidget.test.js
@@ -1,0 +1,41 @@
+/**
+ * Test de montage de NotificationsWidget (G6).
+ * Le service de notifications et le router sont mockés (le widget charge ses
+ * données au montage). On vérifie le rendu de l'en-tête et le badge non-lus.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+const { getRecentNotifications, getUnreadCount } = vi.hoisted(() => ({
+  getRecentNotifications: vi.fn(() => Promise.resolve([])),
+  getUnreadCount: vi.fn(() => Promise.resolve(0))
+}))
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/services/notifications', () => ({
+  notificationsService: {
+    getRecentNotifications,
+    getUnreadCount,
+    markAsRead: vi.fn(),
+    markAllAsRead: vi.fn(),
+    deleteNotification: vi.fn()
+  }
+}))
+
+import NotificationsWidget from '@/components/widgets/NotificationsWidget.vue'
+
+describe('NotificationsWidget (G6) — montage', () => {
+  it('monte et affiche le titre du widget', async () => {
+    const w = mount(NotificationsWidget)
+    await flushPromises()
+    expect(w.find('.notifications-widget').exists()).toBe(true)
+    expect(w.find('.widget-title').text()).toBe('Notifications')
+  })
+
+  it('charge les notifications au montage avec la limite par défaut (5)', async () => {
+    mount(NotificationsWidget)
+    await flushPromises()
+    expect(getRecentNotifications).toHaveBeenCalledWith(5)
+    expect(getUnreadCount).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/TipTapEditor.test.js
+++ b/tests/unit/TipTapEditor.test.js
@@ -1,0 +1,48 @@
+/**
+ * Test de montage de TipTapEditor (G6).
+ * L'éditeur TipTap (useEditor) et ses extensions sont mockés : on teste le shell
+ * Vue (mode normal vs plein écran, intégration de la toolbar), pas ProseMirror.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/config/tiptapExtensions', () => ({ buildEditorExtensions: () => [] }))
+vi.mock('@tiptap/vue-3', async () => {
+  const { ref } = await import('vue')
+  const chain = {}
+  ;['focus', 'run', 'setContent', 'setLink'].forEach((m) => { chain[m] = () => chain })
+  const editor = ref({
+    getHTML: () => '',
+    getText: () => '',
+    isActive: () => false,
+    commands: { setContent: () => {} },
+    chain: () => chain
+  })
+  return {
+    useEditor: () => editor,
+    EditorContent: { name: 'EditorContent', template: '<div class="editor-content-stub" />' }
+  }
+})
+
+import TipTapEditor from '@/components/common/TipTapEditor.vue'
+
+function mountEditor(props = {}) {
+  return mount(TipTapEditor, {
+    props,
+    // bubble-menu n'est pas importé (custom element) ; EditorToolbar décorrélé.
+    global: { stubs: { EditorToolbar: true, 'bubble-menu': true } }
+  })
+}
+
+describe('TipTapEditor (G6) — montage', () => {
+  it('monte en mode normal avec un editor présent', () => {
+    const w = mountEditor({ modelValue: '<p>Bonjour</p>' })
+    expect(w.find('.tiptap-editor-wrapper').exists()).toBe(true)
+    expect(w.find('.editor-normal').exists()).toBe(true)
+  })
+
+  it('rend la zone de contenu de l\'éditeur', () => {
+    const w = mountEditor()
+    expect(w.find('.editor-content-stub').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Groupe G6 — Éditeurs riches & Contenu interactif

### Constat
Les **7 fichiers de G6 ont déjà leur `<script>` sous 300 lignes** (extractions faites en #23/#25/#28). Le critère d'acceptation (« script < 300 ») était donc déjà satisfait : **aucun refacto nécessaire, aucun fichier source modifié** → parité totale par construction.

| Fichier | `<script>` | < 300 |
|---|---|---|
| KnowledgeCheckPlayer.vue | 177 | ✅ |
| KnowledgeCheckEditor.vue | 143 | ✅ |
| TipTapEditor.vue | 89 | ✅ |
| GlobalSearchModal.vue | 236 | ✅ |
| NotificationsWidget.vue | 153 | ✅ |
| EditorToolbar.vue | 39 | ✅ |
| ForumTopic.vue | 102 | ✅ |

### Apport de cette PR
Ajout des **tests de montage `@vue/test-utils` manquants** pour valider le 4ᵉ critère « fini » de chaque fichier. Dépendances tierces lourdes mockées sur leurs vraies signatures (`@tiptap/vue-3`, services `knowledgeCheck`/`notifications`/`search`/`api`, `vue-router`, `vuedraggable`, store d'auth).

### Vérifications
- `npx vite build` : ✅ vert
- `npx vitest run` (7 fichiers G6, ciblé) : ✅ **7 fichiers / 16 tests**
- Parité : aucun fichier source touché ; routes/appels/payloads/rendu inchangés
- Aucun fichier partagé (`services/*`, `formatters.js`, `main.js`…) modifié

🤖 Generated with [Claude Code](https://claude.com/claude-code)