### PR TITLE
refactor(seances): décomposition G7 — script < 300 (SeanceManagement) + tests de montage

### DIFF
--- a/src/composables/useCoordinatorSeances.js
+++ b/src/composables/useCoordinatorSeances.js
@@ -1,0 +1,138 @@
+import { ref, reactive } from 'vue'
+import lmsService from '@/services/lms'
+import { klassciService } from '@/services/klassci'
+import { readCache, writeCache } from '@/services/cache'
+
+/**
+ * Composable de données des séances côté coordinateur (G7).
+ *
+ * Encapsule l'état réactif (séances, classes, enseignants, filtres) et les
+ * appels API de chargement (LMS + KLASSCI, avec cache `seances_management` et
+ * rafraîchissement en arrière-plan). Extrait du god-component
+ * `SeanceManagement.vue` — comportement, logs et clés de cache identiques.
+ */
+export function useCoordinatorSeances() {
+  // État réactif
+  const loading = ref(false)
+  const error = ref(null)
+  const seances = ref([])
+  const classes = ref([])
+  const enseignants = ref([])
+  const filters = reactive({
+    days: 30,
+    teacher_id: null,
+    classe_id: null
+  })
+
+  const loadClasses = async () => {
+    try {
+      console.log('[CLASSES] Chargement...')
+      // #26 : source unique des classes brutes = klassciService (/proxy/classes),
+      // qui renvoie directement le tableau (déballe response.data).
+      classes.value = await klassciService.getClasses()
+      console.log(`[OK] ${classes.value.length} classes chargées`)
+    } catch (err) {
+      console.error('[ERREUR] Chargement classes:', err)
+    }
+  }
+
+  const loadEnseignants = async () => {
+    try {
+      console.log('[ENSEIGNANTS] Chargement...')
+      const response = await lmsService.getEnseignants()
+
+      if (response && response.success) {
+        enseignants.value = response.data || []
+        console.log(`[OK] ${enseignants.value.length} enseignants chargés`)
+      }
+    } catch (err) {
+      console.error('[ERREUR] Chargement enseignants:', err)
+    }
+  }
+
+  const loadSeances = async () => {
+    // Try cache first
+    if (!filters.teacher_id && !filters.classe_id) {
+      const cachedEntry = readCache('seances_management')
+      if (cachedEntry !== null && cachedEntry.filterState?.days === filters.days) {
+        console.log('[CACHE] Séances chargées depuis le cache')
+        seances.value = cachedEntry.data
+        loading.value = false
+        refreshInBackground()
+        return
+      }
+    }
+
+    loading.value = true
+    error.value = null
+
+    try {
+      console.log('[SEANCES] Chargement à venir...')
+
+      const params = {}
+      if (filters.days) params.days = filters.days
+      if (filters.teacher_id) params.teacher_id = filters.teacher_id
+      if (filters.classe_id) params.classe_id = filters.classe_id
+
+      const data = await lmsService.getUpcomingSeances(params)
+
+      console.log('[OK] Séances reçues:', data)
+
+      if (data.success) {
+        seances.value = Array.isArray(data.data) ? data.data : (data.data.seances || [])
+        console.log(`[OK] ${seances.value.length} séances chargées`)
+
+        // Save to cache only if no filters applied
+        if (!filters.teacher_id && !filters.classe_id) {
+          writeCache('seances_management', {
+            data: seances.value,
+            filterState: { days: filters.days }
+          })
+        }
+      } else {
+        error.value = 'Erreur lors du chargement des séances'
+      }
+    } catch (err) {
+      console.error('[ERREUR] Chargement séances:', err)
+      error.value = 'Impossible de charger les séances. Veuillez réessayer.'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  // Refresh in background
+  async function refreshInBackground() {
+    try {
+      console.log('[BACKGROUND] Rafraîchissement séances...')
+
+      const params = { days: filters.days }
+      const data = await lmsService.getUpcomingSeances(params)
+
+      if (data.success) {
+        seances.value = Array.isArray(data.data) ? data.data : (data.data.seances || [])
+
+        writeCache('seances_management', {
+          data: seances.value,
+          filterState: { days: filters.days }
+        })
+
+        console.log('[BACKGROUND] Rafraîchissement terminé')
+      }
+    } catch (error) {
+      console.warn('[BACKGROUND] Erreur rafraîchissement:', error)
+    }
+  }
+
+  return {
+    loading,
+    error,
+    seances,
+    classes,
+    enseignants,
+    filters,
+    loadClasses,
+    loadEnseignants,
+    loadSeances,
+    refreshInBackground
+  }
+}

--- a/src/views/coordinateur/SeanceManagement.vue
+++ b/src/views/coordinateur/SeanceManagement.vue
@@ -284,9 +284,9 @@ import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
 
 import lmsService from '@/services/lms'
-import { klassciService } from '@/services/klassci'
-import { readCache, writeCache, clearCache } from '@/services/cache'
+import { clearCache } from '@/services/cache'
 import { buildJitsiUrl } from '@/constants/visio'
+import { useCoordinatorSeances } from '@/composables/useCoordinatorSeances'
 
 const router = useRouter()
 
@@ -294,21 +294,24 @@ const router = useRouter()
 const instance = getCurrentInstance()
 const $toast = instance?.appContext.config.globalProperties.$toast
 
-// Reactive state
-const loading = ref(false)
-const error = ref(null)
-const seances = ref([])
-const classes = ref([])
-const enseignants = ref([])
+// Données + appels API (état séances/classes/enseignants/filtres + loaders)
+const {
+  loading,
+  error,
+  seances,
+  classes,
+  enseignants,
+  filters,
+  loadClasses,
+  loadEnseignants,
+  loadSeances
+} = useCoordinatorSeances()
+
+// État UI local
 const showParticipantsModal = ref(false)
 const selectedSeanceId = ref(null)
 const viewMode = ref('list')
 const calendarRef = ref(null)
-const filters = reactive({
-  days: 30,
-  teacher_id: null,
-  classe_id: null
-})
 
 // Get current user for Jitsi (#19 : via store, plus de localStorage('user'))
 const currentUser = useAuthStore().currentUser
@@ -335,105 +338,6 @@ const formatDate = (date) => {
     month: 'short',
     year: 'numeric'
   })
-}
-
-const loadClasses = async () => {
-  try {
-    console.log('[CLASSES] Chargement...')
-    // #26 : source unique des classes brutes = klassciService (/proxy/classes),
-    // qui renvoie directement le tableau (déballe response.data).
-    classes.value = await klassciService.getClasses()
-    console.log(`[OK] ${classes.value.length} classes chargées`)
-  } catch (err) {
-    console.error('[ERREUR] Chargement classes:', err)
-  }
-}
-
-const loadEnseignants = async () => {
-  try {
-    console.log('[ENSEIGNANTS] Chargement...')
-    const response = await lmsService.getEnseignants()
-
-    if (response && response.success) {
-      enseignants.value = response.data || []
-      console.log(`[OK] ${enseignants.value.length} enseignants chargés`)
-    }
-  } catch (err) {
-    console.error('[ERREUR] Chargement enseignants:', err)
-  }
-}
-
-const loadSeances = async () => {
-  // Try cache first
-  if (!filters.teacher_id && !filters.classe_id) {
-    const cachedEntry = readCache('seances_management')
-    if (cachedEntry !== null && cachedEntry.filterState?.days === filters.days) {
-      console.log('[CACHE] Séances chargées depuis le cache')
-      seances.value = cachedEntry.data
-      loading.value = false
-      refreshInBackground()
-      return
-    }
-  }
-
-  loading.value = true
-  error.value = null
-
-  try {
-    console.log('[SEANCES] Chargement à venir...')
-
-    const params = {}
-    if (filters.days) params.days = filters.days
-    if (filters.teacher_id) params.teacher_id = filters.teacher_id
-    if (filters.classe_id) params.classe_id = filters.classe_id
-
-    const data = await lmsService.getUpcomingSeances(params)
-
-    console.log('[OK] Séances reçues:', data)
-
-    if (data.success) {
-      seances.value = Array.isArray(data.data) ? data.data : (data.data.seances || [])
-      console.log(`[OK] ${seances.value.length} séances chargées`)
-
-      // Save to cache only if no filters applied
-      if (!filters.teacher_id && !filters.classe_id) {
-        writeCache('seances_management', {
-          data: seances.value,
-          filterState: { days: filters.days }
-        })
-      }
-    } else {
-      error.value = 'Erreur lors du chargement des séances'
-    }
-  } catch (err) {
-    console.error('[ERREUR] Chargement séances:', err)
-    error.value = 'Impossible de charger les séances. Veuillez réessayer.'
-  } finally {
-    loading.value = false
-  }
-}
-
-// Refresh in background
-async function refreshInBackground() {
-  try {
-    console.log('[BACKGROUND] Rafraîchissement séances...')
-
-    const params = { days: filters.days }
-    const data = await lmsService.getUpcomingSeances(params)
-
-    if (data.success) {
-      seances.value = Array.isArray(data.data) ? data.data : (data.data.seances || [])
-
-      writeCache('seances_management', {
-        data: seances.value,
-        filterState: { days: filters.days }
-      })
-
-      console.log('[BACKGROUND] Rafraîchissement terminé')
-    }
-  } catch (error) {
-    console.warn('[BACKGROUND] Erreur rafraîchissement:', error)
-  }
 }
 
 const toggleSeanceVisio = async (seance) => {

--- a/tests/unit/AttendanceDetailModal.test.js
+++ b/tests/unit/AttendanceDetailModal.test.js
@@ -1,0 +1,38 @@
+/**
+ * Test de montage de la modale AttendanceDetailModal (G7).
+ * Vérifie l'état fermé (rien d'affiché par défaut), l'état ouvert (overlay +
+ * état vide quand aucune participation) et l'émission de "close".
+ * Composant feuille : aucun service/store/router, utils réels.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import AttendanceDetailModal from '@/components/attendance/AttendanceDetailModal.vue'
+
+describe('AttendanceDetailModal (G7) — montage', () => {
+  it('monte fermé sans erreur (pas d\'overlay quand selectedSeance est null)', () => {
+    const w = mount(AttendanceDetailModal)
+    expect(w.find('.modal-overlay').exists()).toBe(false)
+  })
+
+  it('ouvert sans participation : affiche l\'overlay et l\'état vide', () => {
+    const w = mount(AttendanceDetailModal, {
+      props: {
+        selectedSeance: { klassci_seance_id: 7, matiere_nom: 'Maths', date: '2026-06-20' },
+        attendances: { attendances: [] }
+      }
+    })
+    expect(w.find('.modal-overlay').exists()).toBe(true)
+    expect(w.find('.modal-empty').exists()).toBe(true)
+  })
+
+  it('émet "close" au clic sur le bouton de fermeture', async () => {
+    const w = mount(AttendanceDetailModal, {
+      props: {
+        selectedSeance: { klassci_seance_id: 7, matiere_nom: 'Maths', date: '2026-06-20' },
+        attendances: { attendances: [] }
+      }
+    })
+    await w.find('.modal-close-btn').trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+  })
+})

--- a/tests/unit/AttendanceHistory.test.js
+++ b/tests/unit/AttendanceHistory.test.js
@@ -1,0 +1,30 @@
+/**
+ * Test de montage de la vue AttendanceHistory (G7, Options API).
+ * Vérifie le montage sans erreur (route + services mockés) et le rendu du
+ * conteneur racine. Enfants stubbés via shallow ; chargement neutralisé.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/lms', () => {
+  const p = new Proxy({}, {
+    get: () => vi.fn().mockResolvedValue({ success: false, data: { seances: [], pagination: {} } })
+  })
+  return { default: p, lmsService: p }
+})
+vi.mock('@/services/api', () => ({ auth: { getUser: () => ({ role: 'coordinateur', name: 'X' }) } }))
+
+import AttendanceHistory from '@/views/attendance/AttendanceHistory.vue'
+
+describe('AttendanceHistory (G7) — montage', () => {
+  it('monte sans erreur et rend le conteneur racine', () => {
+    const w = mount(AttendanceHistory, {
+      shallow: true,
+      global: {
+        stubs: { DashboardLayout: { template: '<div><slot /></div>' } },
+        mocks: { $route: { params: {}, query: {} }, $router: { push: vi.fn() } }
+      }
+    })
+    expect(w.find('.attendance-history-container').exists()).toBe(true)
+  })
+})

--- a/tests/unit/SeanceAttendanceHistory.test.js
+++ b/tests/unit/SeanceAttendanceHistory.test.js
@@ -1,0 +1,32 @@
+/**
+ * Test de montage de la vue SeanceAttendanceHistory (G7, Options API).
+ * Vérifie le montage sans erreur (services mockés) et le rendu du conteneur.
+ * Enfants stubbés via shallow ; chargement neutralisé par les mocks.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/lms', () => {
+  const p = new Proxy({}, {
+    get: () => vi.fn().mockResolvedValue({ success: false, data: { seances: [], pagination: {} } })
+  })
+  return { default: p, lmsService: p }
+})
+vi.mock('@/services/attendanceExport', () => ({
+  default: { exportToPdf: vi.fn(), exportToExcel: vi.fn() }
+}))
+
+import SeanceAttendanceHistory from '@/views/attendance/SeanceAttendanceHistory.vue'
+
+describe('SeanceAttendanceHistory (G7) — montage', () => {
+  it('monte sans erreur et rend le conteneur racine', () => {
+    const w = mount(SeanceAttendanceHistory, {
+      shallow: true,
+      global: {
+        stubs: { DashboardLayout: { template: '<div><slot /></div>' } },
+        mocks: { $route: { params: {}, query: {} }, $router: { push: vi.fn() } }
+      }
+    })
+    expect(w.find('.attendance-container').exists()).toBe(true)
+  })
+})

--- a/tests/unit/SeanceCard.test.js
+++ b/tests/unit/SeanceCard.test.js
@@ -1,0 +1,41 @@
+/**
+ * Test de montage du sous-composant de présentation SeanceCard (G7).
+ * Vérifie qu'il monte sans erreur, affiche la matière, le bon état d'action
+ * selon l'absence de visio, et émet les intentions d'action attendues.
+ * Composant feuille : aucun service/store/router, formatters réels.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import SeanceCard from '@/components/seances/SeanceCard.vue'
+
+const baseSeance = {
+  id: 42,
+  matiere: { nom: 'Mathématiques', code: 'MATH101' },
+  classe: { nom: '6e A' },
+  salle: 'B12',
+  programmation: { date: '2026-06-20', heure_debut: '2026-06-20T08:00:00', heure_fin: '2026-06-20T10:00:00' }
+}
+
+describe('SeanceCard (G7) — montage', () => {
+  it('monte sans erreur et affiche la matière', () => {
+    const w = mount(SeanceCard, { props: { seance: baseSeance } })
+    expect(w.find('.seance-card').exists()).toBe(true)
+    expect(w.text()).toContain('Mathématiques')
+    expect(w.text()).toContain('6e A')
+  })
+
+  it('sans visio : propose l\'activation et émet "activate" au clic', async () => {
+    const w = mount(SeanceCard, { props: { seance: baseSeance } })
+    expect(w.find('.action-none').exists()).toBe(true)
+    await w.find('.action-none button').trigger('click')
+    expect(w.emitted('activate')[0]).toEqual([baseSeance])
+  })
+
+  it('visio active : affiche EN DIRECT et émet "join"', async () => {
+    const seance = { ...baseSeance, visio: { enabled: true, status: 'active', room_id: 'r1', participants_count: 3 } }
+    const w = mount(SeanceCard, { props: { seance } })
+    expect(w.text()).toContain('EN DIRECT')
+    await w.find('.btn-success').trigger('click')
+    expect(w.emitted('join')[0]).toEqual([seance])
+  })
+})

--- a/tests/unit/SeanceDetails.test.js
+++ b/tests/unit/SeanceDetails.test.js
@@ -1,0 +1,39 @@
+/**
+ * Test de montage de la vue SeanceDetails (G7, Options API).
+ * Vérifie que la vue monte sans erreur (route + services mockés) et rend son
+ * conteneur racine. Les enfants (DashboardLayout, ContentLoader) sont stubbés
+ * via shallow ; les services sont mockés pour neutraliser le chargement.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/lms', () => {
+  const p = new Proxy({}, {
+    get: () => vi.fn().mockResolvedValue({
+      success: false,
+      data: { seance: null, visio: null, participants: null }
+    })
+  })
+  return { default: p, lmsService: p }
+})
+vi.mock('@/services/api', () => ({ auth: { getUser: () => ({ role: 'coordinateur', name: 'X' }) } }))
+vi.mock('@/services/toast', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('@/services/errorHandler', () => ({ normalizeError: () => ({ userMessage: 'err' }) }))
+vi.mock('@/composables/useVisioParticipation', () => ({
+  useVisioParticipation: () => ({ joinVisio: vi.fn(), leaveVisio: vi.fn() })
+}))
+
+import SeanceDetails from '@/views/seances/SeanceDetails.vue'
+
+describe('SeanceDetails (G7) — montage', () => {
+  it('monte sans erreur et rend le conteneur racine', () => {
+    const w = mount(SeanceDetails, {
+      shallow: true,
+      global: {
+        stubs: { DashboardLayout: { template: '<div><slot /></div>' } },
+        mocks: { $route: { params: { id: '1' }, query: {} }, $router: { push: vi.fn() } }
+      }
+    })
+    expect(w.find('.seance-details').exists()).toBe(true)
+  })
+})

--- a/tests/unit/TeacherSeances.test.js
+++ b/tests/unit/TeacherSeances.test.js
@@ -1,0 +1,41 @@
+/**
+ * Test de montage de la vue TeacherSeances (G7, script setup).
+ * Vérifie le montage sans erreur (store/services/cache mockés) et le rendu du
+ * conteneur racine. Enfants (SeanceCard, DashboardLayout) stubbés via shallow.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/services/lms', () => {
+  const p = new Proxy({}, {
+    get: () => vi.fn().mockResolvedValue({ success: true, data: [] })
+  })
+  return { default: p, lmsService: p }
+})
+vi.mock('@/services/klassci', () => ({
+  klassciService: new Proxy({}, { get: () => vi.fn().mockResolvedValue([]) })
+}))
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({ currentUser: { id: 1, role: 'enseignant', name: 'X' } })
+}))
+vi.mock('@/services/toast', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('@/services/errorHandler', () => ({ normalizeError: () => ({ userMessage: 'err' }) }))
+vi.mock('@/services/cache', () => ({ readCache: () => null, writeCache: vi.fn(), clearCache: vi.fn() }))
+vi.mock('@/composables/useVisioParticipation', () => ({
+  useVisioParticipation: () => ({ joinVisio: vi.fn(), leaveVisio: vi.fn() })
+}))
+
+import TeacherSeances from '@/views/TeacherSeances.vue'
+
+describe('TeacherSeances (G7) — montage', () => {
+  it('monte sans erreur et rend le conteneur racine', () => {
+    const w = mount(TeacherSeances, {
+      shallow: true,
+      global: {
+        stubs: { DashboardLayout: { template: '<div><slot /></div>' } },
+        mocks: { $route: { params: {}, query: {} }, $router: { push: vi.fn() } }
+      }
+    })
+    expect(w.find('.seances-container').exists()).toBe(true)
+  })
+})

--- a/tests/unit/useCoordinatorSeances.test.js
+++ b/tests/unit/useCoordinatorSeances.test.js
@@ -1,0 +1,126 @@
+/**
+ * Tests du composable de données séances coordinateur (G7) — useCoordinatorSeances.
+ * Couvre le chargement classes/enseignants, la stratégie cache-first des séances,
+ * la construction des params selon les filtres, l'écriture conditionnelle du cache
+ * et les états d'erreur. Logique extraite du god-component SeanceManagement.vue.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const { mockGetClasses, mockGetEnseignants, mockGetUpcoming, mockReadCache, mockWriteCache } =
+  vi.hoisted(() => ({
+    mockGetClasses: vi.fn(),
+    mockGetEnseignants: vi.fn(),
+    mockGetUpcoming: vi.fn(),
+    mockReadCache: vi.fn(),
+    mockWriteCache: vi.fn()
+  }))
+
+vi.mock('@/services/lms', () => ({
+  default: { getEnseignants: mockGetEnseignants, getUpcomingSeances: mockGetUpcoming }
+}))
+vi.mock('@/services/klassci', () => ({
+  klassciService: { getClasses: mockGetClasses }
+}))
+vi.mock('@/services/cache', () => ({
+  readCache: mockReadCache,
+  writeCache: mockWriteCache
+}))
+
+import { useCoordinatorSeances } from '@/composables/useCoordinatorSeances'
+
+describe('useCoordinatorSeances (G7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockReadCache.mockReturnValue(null)
+    mockGetClasses.mockResolvedValue([])
+    mockGetEnseignants.mockResolvedValue({ success: true, data: [] })
+    mockGetUpcoming.mockResolvedValue({ success: true, data: [] })
+  })
+
+  it('expose un état initial cohérent', () => {
+    const c = useCoordinatorSeances()
+    expect(c.loading.value).toBe(false)
+    expect(c.error.value).toBe(null)
+    expect(c.seances.value).toEqual([])
+    expect(c.filters.days).toBe(30)
+    expect(c.filters.teacher_id).toBe(null)
+  })
+
+  it('loadClasses remplit classes depuis klassciService', async () => {
+    mockGetClasses.mockResolvedValue([{ id: 1 }, { id: 2 }])
+    const c = useCoordinatorSeances()
+    await c.loadClasses()
+    expect(c.classes.value).toHaveLength(2)
+  })
+
+  it('loadEnseignants remplit enseignants quand success', async () => {
+    mockGetEnseignants.mockResolvedValue({ success: true, data: [{ id: 7 }] })
+    const c = useCoordinatorSeances()
+    await c.loadEnseignants()
+    expect(c.enseignants.value).toEqual([{ id: 7 }])
+  })
+
+  it('loadEnseignants ignore une réponse non-success', async () => {
+    mockGetEnseignants.mockResolvedValue({ success: false })
+    const c = useCoordinatorSeances()
+    await c.loadEnseignants()
+    expect(c.enseignants.value).toEqual([])
+  })
+
+  it('loadSeances sans cache : appelle l\'API, remplit et écrit le cache', async () => {
+    mockGetUpcoming.mockResolvedValue({ success: true, data: [{ id: 'a' }] })
+    const c = useCoordinatorSeances()
+    await c.loadSeances()
+    expect(mockGetUpcoming).toHaveBeenCalledWith({ days: 30 })
+    expect(c.seances.value).toEqual([{ id: 'a' }])
+    expect(mockWriteCache).toHaveBeenCalledWith('seances_management', {
+      data: [{ id: 'a' }],
+      filterState: { days: 30 }
+    })
+    expect(c.loading.value).toBe(false)
+  })
+
+  it('loadSeances déballe data.seances quand data.data n\'est pas un tableau', async () => {
+    mockGetUpcoming.mockResolvedValue({ success: true, data: { seances: [{ id: 'x' }] } })
+    const c = useCoordinatorSeances()
+    await c.loadSeances()
+    expect(c.seances.value).toEqual([{ id: 'x' }])
+  })
+
+  it('loadSeances avec filtres : inclut les params et n\'écrit PAS le cache', async () => {
+    const c = useCoordinatorSeances()
+    c.filters.teacher_id = 12
+    c.filters.classe_id = 5
+    await c.loadSeances()
+    expect(mockGetUpcoming).toHaveBeenCalledWith({ days: 30, teacher_id: 12, classe_id: 5 })
+    expect(mockWriteCache).not.toHaveBeenCalled()
+    expect(mockReadCache).not.toHaveBeenCalled()
+  })
+
+  it('loadSeances cache-first : sert le cache immédiatement puis rafraîchit en arrière-plan', async () => {
+    mockReadCache.mockReturnValue({ data: [{ id: 'cached' }], filterState: { days: 30 } })
+    // Refresh d'arrière-plan suspendu : on isole le service du cache (pas d'écrasement)
+    mockGetUpcoming.mockReturnValue(new Promise(() => {}))
+    const c = useCoordinatorSeances()
+    await c.loadSeances()
+    expect(c.seances.value).toEqual([{ id: 'cached' }])
+    expect(c.loading.value).toBe(false)
+    // Le rafraîchissement d'arrière-plan a bien été déclenché
+    expect(mockGetUpcoming).toHaveBeenCalledWith({ days: 30 })
+  })
+
+  it('loadSeances met error si la réponse échoue', async () => {
+    mockGetUpcoming.mockResolvedValue({ success: false })
+    const c = useCoordinatorSeances()
+    await c.loadSeances()
+    expect(c.error.value).toBe('Erreur lors du chargement des séances')
+  })
+
+  it('loadSeances met un message d\'erreur si l\'appel jette', async () => {
+    mockGetUpcoming.mockRejectedValue(new Error('boom'))
+    const c = useCoordinatorSeances()
+    await c.loadSeances()
+    expect(c.error.value).toBe('Impossible de charger les séances. Veuillez réessayer.')
+    expect(c.loading.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## G7 — Séances & Présences (décomposition < 300 lignes)

### Refacto
- `SeanceManagement.vue` : script **322 → 226** lignes. Extraction de l'état (séances/classes/enseignants/filtres) + loaders vers le composable neuf `useCoordinatorSeances.js`. Appels API, clés de cache, logs et template strictement identiques (parité confirmée).

### Tests (20 verts)
- `useCoordinatorSeances` : 10 tests unitaires (cache-first, params filtres, écriture conditionnelle du cache, états d'erreur).
- 6 tests de montage `@vue/test-utils` : SeanceCard, AttendanceDetailModal, SeanceDetails, SeanceAttendanceHistory, AttendanceHistory, TeacherSeances.

### Vérifs
- `vite build` ✅ — `vitest run` (sous-groupe G7) ✅ 20/20.
- Périmètre limité aux fichiers G7 ; aucun service/util partagé modifié.

Les 6 autres fichiers du groupe avaient déjà leur `<script>` < 300 (les gros totaux du découpage étaient du template+CSS) : aucune refacto, seulement des tests de montage ajoutés pour satisfaire la définition « fini ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)