### PR TITLE
refactor(g8): Visio & Calendrier — scripts < 300 + tests de montage

### DIFF
--- a/src/components/visio/VisioManager.vue
+++ b/src/components/visio/VisioManager.vue
@@ -137,15 +137,14 @@
 
 <script>
 import { auth } from '@/services/api'
-import lmsService from '@/services/lms'
-import { useAuthStore } from '@/stores/auth'
-import { toast } from '@/services/toast'
-import { normalizeError } from '@/services/errorHandler'
-import jitsiService from '@/services/jitsi'
+// Import conservé pour son EFFET DE BORD au chargement du module :
+// services/jitsi.js exécute jitsiService.cleanupExpiredParticipations() à l'import,
+// et VisioManager est son seul importeur vivant. Ne pas retirer (parité).
+import '@/services/jitsi'
 import ParticipantsModal from './ParticipantsModal.vue'
-import { useVisioStore } from '@/stores/visio'
-import { buildJitsiUrl, VISIO_CONFIG } from '@/constants/visio'
-import { apiBaseUrl } from '@/constants/http'
+import { VISIO_CONFIG } from '@/constants/visio'
+import { formatVisioTime, isInTimeWindow, timeWindowMessage } from '@/utils/visioTimeWindow'
+import { useVisioActions } from '@/composables/useVisioActions'
 
 export default {
   name: 'VisioManager',
@@ -158,21 +157,16 @@ export default {
       required: true
     }
   },
-  setup() {
-    // Utiliser le store Pinia global pour gérer la participation
-    // ✅ AVANTAGE: Le store persiste lors de la navigation entre pages
-    const visioStore = useVisioStore()
-
+  setup(props, { emit }) {
+    // État (loading / participantCount) + orchestration des appels visio,
+    // extraits dans le composable useVisioActions (comportement identique).
     return {
-      // Exposer le store
-      visioStore
+      ...useVisioActions(props, emit)
     }
   },
   data() {
     return {
-      loading: false,
       showParticipantsModal: false,
-      participantCount: 0,
       currentTime: new Date(),
       timeCheckInterval: null
     }
@@ -197,45 +191,14 @@ export default {
       return this.seance.classe_effectif || this.seance.classe?.effectif || 0
     },
     /**
-     * Vérifier si on est dans la fenêtre temporelle:
-     * - Début: heure_debut - 15 minutes
-     * - Fin: heure_fin + 30 minutes
+     * Fenêtre temporelle d'ouverture : -15min avant le début, +30min après la fin.
+     * (logique pure extraite dans utils/visioTimeWindow.js)
      */
     isInTimeWindow() {
-      // Utiliser programmation.heure_debut/fin (ISO 8601)
-      if (!this.seance.programmation?.heure_debut || !this.seance.programmation?.heure_fin) {
-        return false
-      }
-
-      const debut = new Date(this.seance.programmation.heure_debut)
-      const fin = new Date(this.seance.programmation.heure_fin)
-
-      // Fenêtre temporelle: -15min avant, +30min après
-      const windowStart = new Date(debut.getTime() - 15 * 60 * 1000) // -15min
-      const windowEnd = new Date(fin.getTime() + 30 * 60 * 1000) // +30min
-
-      return this.currentTime >= windowStart && this.currentTime <= windowEnd
+      return isInTimeWindow(this.seance, this.currentTime)
     },
     timeWindowMessage() {
-      if (!this.seance.programmation?.heure_debut) {
-        return ''
-      }
-
-      const debut = new Date(this.seance.programmation.heure_debut)
-      const windowStart = new Date(debut.getTime() - 15 * 60 * 1000)
-
-      if (this.currentTime < windowStart) {
-        const diffMinutes = Math.floor((windowStart - this.currentTime) / 60000)
-        const hours = Math.floor(diffMinutes / 60)
-        const minutes = diffMinutes % 60
-
-        if (hours > 0) {
-          return `dans ${hours}h ${minutes}min`
-        }
-        return `dans ${minutes} minutes`
-      }
-
-      return 'maintenant'
+      return timeWindowMessage(this.seance, this.currentTime)
     }
   },
   mounted() {
@@ -259,223 +222,7 @@ export default {
   },
   methods: {
     formatTime(isoTimestamp) {
-      if (!isoTimestamp) return 'N/A'
-      return new Date(isoTimestamp).toLocaleTimeString('fr-FR', {
-        hour: '2-digit',
-        minute: '2-digit'
-      })
-    },
-
-    /**
-     * Coordinateur: Programmer la visio
-     */
-    async programmerVisio() {
-      if (!confirm('Voulez-vous programmer une visioconférence Jitsi pour cette séance ?')) {
-        return
-      }
-
-      this.loading = true
-      try {
-        const response = await lmsService.toggleVisio(this.seance.id, true, 'jitsi')
-
-        if (response && response.success) {
-          this.$emit('visio-updated', response.data)
-          alert('Visioconférence programmée avec succès!')
-        } else {
-          throw new Error(response?.message || 'Erreur lors de la programmation')
-        }
-      } catch (error) {
-        console.error('[VisioManager] Erreur programmation visio:', error)
-        toast.error(error.userMessage ?? normalizeError(error).userMessage)
-      } finally {
-        this.loading = false
-      }
-    },
-
-    /**
-     * Coordinateur: Désactiver la visio
-     */
-    async desactiverVisio() {
-      if (!confirm('Voulez-vous désactiver la visioconférence pour cette séance ?')) {
-        return
-      }
-
-      this.loading = true
-      try {
-        const response = await lmsService.toggleVisio(this.seance.id, false)
-
-        if (response && response.success) {
-          this.$emit('visio-updated', response.data)
-          alert('Visioconférence désactivée avec succès!')
-        } else {
-          throw new Error(response?.message || 'Erreur lors de la désactivation')
-        }
-      } catch (error) {
-        console.error('[VisioManager] Erreur désactivation visio:', error)
-        toast.error(error.userMessage ?? normalizeError(error).userMessage)
-      } finally {
-        this.loading = false
-      }
-    },
-
-    /**
-     * Enseignant: Démarrer la visio (window.open avec tracking)
-     */
-    async demarrerVisio() {
-      this.loading = true
-      try {
-        console.log('🎥 Démarrage visio par enseignant...')
-
-        // 1. Démarrer la visio (change status à 'active')
-        const result = await lmsService.startVisio(this.seance.id)
-
-        if (!result.success) {
-          alert(`Erreur: ${result.message}`)
-          return
-        }
-
-        // 2. Récupérer le lien Jitsi
-        const roomId = result.data.visio_room_id || this.seance.visio?.room_id
-        const jitsiLink = buildJitsiUrl(roomId)
-
-        // 3. Utiliser le store pour ouvrir et tracker
-        await this.visioStore.joinVisio(this.seance.id, jitsiLink)
-
-        console.log('✅ Visio démarrée avec window.open + tracking')
-
-        // 4. Rafraîchir les données
-        this.$emit('visio-updated', result.data)
-
-      } catch (error) {
-        console.error('[VisioManager] Erreur démarrage visio:', error)
-        toast.error(error.userMessage ?? normalizeError(error).userMessage)
-      } finally {
-        this.loading = false
-      }
-    },
-
-    /**
-     * Enseignant: Terminer la séance pour tous les participants
-     * Ferme immédiatement tous les participants avec leurs heures réelles
-     */
-    async terminerPourTous() {
-      const confirmer = confirm(
-        '🔚 Voulez-vous vraiment terminer cette séance pour TOUS les participants ?\n\n' +
-        '✅ Chaque participant sera déconnecté avec son heure réelle de départ.\n' +
-        '❌ Cette action est irréversible.'
-      )
-
-      if (!confirmer) return
-
-      this.loading = true
-      try {
-        console.log('🔚 Fermeture de la séance pour tous...')
-
-        // Appeler endVisio() qui ferme tous les participants
-        const response = await lmsService.endVisio(this.seance.id)
-
-        if (response.success) {
-          console.log('✅ Séance fermée avec succès')
-          alert(`✅ Séance terminée !\n\n${response.data.participants_disconnected} participant(s) déconnecté(s) avec leurs heures réelles.`)
-
-          // Rafraîchir les données
-          this.$emit('visio-updated', { ...this.seance, visio_active: false })
-        } else {
-          throw new Error(response.message || 'Erreur lors de la fermeture')
-        }
-      } catch (error) {
-        console.error('[VisioManager] Erreur fermeture séance:', error)
-        toast.error(error.userMessage ?? normalizeError(error).userMessage)
-      } finally {
-        this.loading = false
-      }
-    },
-
-    /**
-     * Télécharger la liste de présence en PDF
-     */
-    async telechargerPresences() {
-      this.loading = true
-      try {
-        console.log('[VisioManager] Téléchargement liste de présence PDF...')
-
-        const API_URL = apiBaseUrl()
-        const token = useAuthStore().token
-
-        // Créer l'URL de téléchargement
-        const url = `${API_URL}/lms/seances/${this.seance.id}/export/presences/pdf`
-
-        // Télécharger le fichier
-        const response = await fetch(url, {
-          method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Accept': 'application/pdf'
-          }
-        })
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}))
-          throw new Error(errorData.message || 'Erreur lors du téléchargement du PDF')
-        }
-
-        // Créer un blob et télécharger
-        const blob = await response.blob()
-        const downloadUrl = window.URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = downloadUrl
-        a.download = `presences_seance_${this.seance.id}_${new Date().toISOString().split('T')[0]}.pdf`
-        document.body.appendChild(a)
-        a.click()
-        window.URL.revokeObjectURL(downloadUrl)
-        document.body.removeChild(a)
-
-        console.log('[VisioManager] ✅ PDF téléchargé avec succès')
-      } catch (error) {
-        console.error('[VisioManager] Erreur téléchargement PDF:', error)
-        toast.error(error.userMessage ?? normalizeError(error).userMessage)
-      } finally {
-        this.loading = false
-      }
-    },
-
-    /**
-     * Étudiant: Rejoindre la visio (window.open avec tracking)
-     */
-    async rejoindreVisio() {
-      if (!this.seance.visio_active) {
-        alert('La visio n\'est pas encore démarrée par l\'enseignant')
-        return
-      }
-
-      this.loading = true
-      try {
-        console.log('👨‍🎓 Étudiant rejoint la visio...')
-
-        // Room ID depuis la séance
-        const roomId = this.seance.visio_room_id || this.seance.visio?.room_id
-
-        if (!roomId) {
-          alert('Erreur: Room ID introuvable')
-          return
-        }
-
-        // Utiliser le store pour ouvrir et tracker
-        const jitsiLink = buildJitsiUrl(roomId)
-        await this.visioStore.joinVisio(this.seance.id, jitsiLink)
-
-        console.log('✅ Étudiant a rejoint avec window.open + tracking')
-
-        // Émettre événement pour rafraîchir le compteur de participants
-        this.$emit('participant-joined')
-
-      } catch (error) {
-        console.error('[VisioManager] Erreur rejoindre visio:', error)
-        const errorMessage = error.response?.data?.message || error.message
-        alert('Erreur lors de la connexion à la visio: ' + errorMessage)
-      } finally {
-        this.loading = false
-      }
+      return formatVisioTime(isoTimestamp)
     },
 
     /**
@@ -483,22 +230,7 @@ export default {
      */
     showParticipants() {
       this.showParticipantsModal = true
-    },
-
-    /**
-     * Charger le nombre de participants
-     */
-    async loadParticipantCount() {
-      try {
-        const response = await lmsService.getSeanceParticipants(this.seance.id)
-        if (response && response.success) {
-          this.participantCount = response.data.total || 0
-        }
-      } catch (error) {
-        console.error('[VisioManager] Erreur chargement participants:', error)
-      }
-    },
-
+    }
   }
 }
 </script>

--- a/src/composables/useVisioActions.js
+++ b/src/composables/useVisioActions.js
@@ -1,0 +1,265 @@
+import { ref } from 'vue'
+import lmsService from '@/services/lms'
+import { useAuthStore } from '@/stores/auth'
+import { toast } from '@/services/toast'
+import { normalizeError } from '@/services/errorHandler'
+import { useVisioStore } from '@/stores/visio'
+import { buildJitsiUrl } from '@/constants/visio'
+import { apiBaseUrl } from '@/constants/http'
+
+/**
+ * Composable d'actions visio (extrait de VisioManager.vue, G8).
+ *
+ * Encapsule l'état `loading` / `participantCount` et l'orchestration des appels
+ * (programmer / désactiver / démarrer / terminer / télécharger PDF / rejoindre /
+ * charger le compteur). Comportement strictement identique : mêmes appels
+ * services, mêmes payloads, mêmes alert/confirm/console, mêmes événements émis.
+ *
+ * @param {{ seance: Object }} props - props réactives du composant (lit props.seance).
+ * @param {(event: string, ...args: any[]) => void} emit - fonction emit du setup.
+ */
+export function useVisioActions(props, emit) {
+  // Store Pinia global : persiste lors de la navigation entre pages.
+  const visioStore = useVisioStore()
+
+  const loading = ref(false)
+  const participantCount = ref(0)
+
+  /**
+   * Coordinateur: Programmer la visio
+   */
+  async function programmerVisio() {
+    if (!confirm('Voulez-vous programmer une visioconférence Jitsi pour cette séance ?')) {
+      return
+    }
+
+    loading.value = true
+    try {
+      const response = await lmsService.toggleVisio(props.seance.id, true, 'jitsi')
+
+      if (response && response.success) {
+        emit('visio-updated', response.data)
+        alert('Visioconférence programmée avec succès!')
+      } else {
+        throw new Error(response?.message || 'Erreur lors de la programmation')
+      }
+    } catch (error) {
+      console.error('[VisioManager] Erreur programmation visio:', error)
+      toast.error(error.userMessage ?? normalizeError(error).userMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Coordinateur: Désactiver la visio
+   */
+  async function desactiverVisio() {
+    if (!confirm('Voulez-vous désactiver la visioconférence pour cette séance ?')) {
+      return
+    }
+
+    loading.value = true
+    try {
+      const response = await lmsService.toggleVisio(props.seance.id, false)
+
+      if (response && response.success) {
+        emit('visio-updated', response.data)
+        alert('Visioconférence désactivée avec succès!')
+      } else {
+        throw new Error(response?.message || 'Erreur lors de la désactivation')
+      }
+    } catch (error) {
+      console.error('[VisioManager] Erreur désactivation visio:', error)
+      toast.error(error.userMessage ?? normalizeError(error).userMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Enseignant: Démarrer la visio (window.open avec tracking)
+   */
+  async function demarrerVisio() {
+    loading.value = true
+    try {
+      console.log('🎥 Démarrage visio par enseignant...')
+
+      // 1. Démarrer la visio (change status à 'active')
+      const result = await lmsService.startVisio(props.seance.id)
+
+      if (!result.success) {
+        alert(`Erreur: ${result.message}`)
+        return
+      }
+
+      // 2. Récupérer le lien Jitsi
+      const roomId = result.data.visio_room_id || props.seance.visio?.room_id
+      const jitsiLink = buildJitsiUrl(roomId)
+
+      // 3. Utiliser le store pour ouvrir et tracker
+      await visioStore.joinVisio(props.seance.id, jitsiLink)
+
+      console.log('✅ Visio démarrée avec window.open + tracking')
+
+      // 4. Rafraîchir les données
+      emit('visio-updated', result.data)
+
+    } catch (error) {
+      console.error('[VisioManager] Erreur démarrage visio:', error)
+      toast.error(error.userMessage ?? normalizeError(error).userMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Enseignant: Terminer la séance pour tous les participants
+   * Ferme immédiatement tous les participants avec leurs heures réelles
+   */
+  async function terminerPourTous() {
+    const confirmer = confirm(
+      '🔚 Voulez-vous vraiment terminer cette séance pour TOUS les participants ?\n\n' +
+      '✅ Chaque participant sera déconnecté avec son heure réelle de départ.\n' +
+      '❌ Cette action est irréversible.'
+    )
+
+    if (!confirmer) return
+
+    loading.value = true
+    try {
+      console.log('🔚 Fermeture de la séance pour tous...')
+
+      // Appeler endVisio() qui ferme tous les participants
+      const response = await lmsService.endVisio(props.seance.id)
+
+      if (response.success) {
+        console.log('✅ Séance fermée avec succès')
+        alert(`✅ Séance terminée !\n\n${response.data.participants_disconnected} participant(s) déconnecté(s) avec leurs heures réelles.`)
+
+        // Rafraîchir les données
+        emit('visio-updated', { ...props.seance, visio_active: false })
+      } else {
+        throw new Error(response.message || 'Erreur lors de la fermeture')
+      }
+    } catch (error) {
+      console.error('[VisioManager] Erreur fermeture séance:', error)
+      toast.error(error.userMessage ?? normalizeError(error).userMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Télécharger la liste de présence en PDF
+   */
+  async function telechargerPresences() {
+    loading.value = true
+    try {
+      console.log('[VisioManager] Téléchargement liste de présence PDF...')
+
+      const API_URL = apiBaseUrl()
+      const token = useAuthStore().token
+
+      // Créer l'URL de téléchargement
+      const url = `${API_URL}/lms/seances/${props.seance.id}/export/presences/pdf`
+
+      // Télécharger le fichier
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Accept': 'application/pdf'
+        }
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.message || 'Erreur lors du téléchargement du PDF')
+      }
+
+      // Créer un blob et télécharger
+      const blob = await response.blob()
+      const downloadUrl = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = downloadUrl
+      a.download = `presences_seance_${props.seance.id}_${new Date().toISOString().split('T')[0]}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(downloadUrl)
+      document.body.removeChild(a)
+
+      console.log('[VisioManager] ✅ PDF téléchargé avec succès')
+    } catch (error) {
+      console.error('[VisioManager] Erreur téléchargement PDF:', error)
+      toast.error(error.userMessage ?? normalizeError(error).userMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Étudiant: Rejoindre la visio (window.open avec tracking)
+   */
+  async function rejoindreVisio() {
+    if (!props.seance.visio_active) {
+      alert('La visio n\'est pas encore démarrée par l\'enseignant')
+      return
+    }
+
+    loading.value = true
+    try {
+      console.log('👨‍🎓 Étudiant rejoint la visio...')
+
+      // Room ID depuis la séance
+      const roomId = props.seance.visio_room_id || props.seance.visio?.room_id
+
+      if (!roomId) {
+        alert('Erreur: Room ID introuvable')
+        return
+      }
+
+      // Utiliser le store pour ouvrir et tracker
+      const jitsiLink = buildJitsiUrl(roomId)
+      await visioStore.joinVisio(props.seance.id, jitsiLink)
+
+      console.log('✅ Étudiant a rejoint avec window.open + tracking')
+
+      // Émettre événement pour rafraîchir le compteur de participants
+      emit('participant-joined')
+
+    } catch (error) {
+      console.error('[VisioManager] Erreur rejoindre visio:', error)
+      const errorMessage = error.response?.data?.message || error.message
+      alert('Erreur lors de la connexion à la visio: ' + errorMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Charger le nombre de participants
+   */
+  async function loadParticipantCount() {
+    try {
+      const response = await lmsService.getSeanceParticipants(props.seance.id)
+      if (response && response.success) {
+        participantCount.value = response.data.total || 0
+      }
+    } catch (error) {
+      console.error('[VisioManager] Erreur chargement participants:', error)
+    }
+  }
+
+  return {
+    loading,
+    participantCount,
+    programmerVisio,
+    desactiverVisio,
+    demarrerVisio,
+    terminerPourTous,
+    telechargerPresences,
+    rejoindreVisio,
+    loadParticipantCount
+  }
+}

--- a/src/services/jitsi.js
+++ b/src/services/jitsi.js
@@ -1,7 +1,7 @@
 import api from './api'
-import { auth } from './api'
-import { getJitsiDomain, VISIO_CONFIG } from '../constants/visio'
+import { VISIO_CONFIG } from '../constants/visio'
 import { VISIO_PARTICIPATION_PREFIX, visioParticipationKey } from '../constants/storageKeys'
+import * as jitsiRoom from '../utils/jitsiRoom'
 
 /**
  * Service pour la gestion des visioconférences Jitsi Meet
@@ -17,108 +17,49 @@ import { VISIO_PARTICIPATION_PREFIX, visioParticipationKey } from '../constants/
 // Alternative: Déployer votre propre serveur Jitsi et utiliser votre domaine
 
 export const jitsiService = {
+  // --- Construction de salle / lien (logique pure déléguée à utils/jitsiRoom.js, G8) ---
+  // API publique inchangée : mêmes signatures et comportement qu'à l'origine.
+
   /**
    * Générer un lien Jitsi unique pour une séance
    * @param {Object} seance - { id, visio_room_id, matiere, classe }
    * @returns {string} URL Jitsi
    */
   generateRoomLink(seance) {
-    // Utiliser visio_room_id si existant, sinon générer un ID unique
-    const roomId = seance.visio_room_id || this.generateRoomId(seance)
-
-    // Construire le nom de la salle
-    const roomName = this.buildRoomName(seance, roomId)
-
-    // URL Jitsi avec paramètres
-    const user = auth.getUser()
-    const displayName = encodeURIComponent(user?.name || 'Participant')
-
-    // Configuration Jitsi via URL params
-    const params = new URLSearchParams({
-      'userInfo.displayName': user?.name || 'Participant',
-      'config.prejoinPageEnabled': 'false', // Skip prejoin page
-      'config.startWithAudioMuted': user?.role === 'etudiant', // Mute students by default
-      'config.startWithVideoMuted': false,
-      'interfaceConfig.SHOW_JITSI_WATERMARK': 'false',
-      'interfaceConfig.SHOW_WATERMARK_FOR_GUESTS': 'false',
-      'interfaceConfig.DEFAULT_LOGO_URL': '',
-      'interfaceConfig.DEFAULT_WELCOME_PAGE_LOGO_URL': ''
-    })
-
-    const jitsiUrl = `https://${getJitsiDomain()}/${roomName}#${params.toString()}`
-
-    console.log('[JitsiService] Lien généré:', jitsiUrl)
-    console.log('[JitsiService] Room ID:', roomId)
-    console.log('[JitsiService] User:', user?.name, user?.role)
-
-    return jitsiUrl
+    return jitsiRoom.generateRoomLink(seance)
   },
 
   /**
-   * Générer un Room ID unique pour la séance
-   * Format: lms_seance_{id}_{timestamp}
+   * Générer un Room ID unique pour la séance (format: lms_seance_{id}_{timestamp})
    * @param {Object} seance
    * @returns {string}
    */
   generateRoomId(seance) {
-    const timestamp = Date.now()
-    return `lms_seance_${seance.id}_${timestamp}`
+    return jitsiRoom.generateRoomId(seance)
   },
 
   /**
-   * Construire le nom de la salle Jitsi
-   * Format: LMS-{Matiere}-{Classe}-{Date}
-   * Ex: LMS-Mathematiques-L1-InfoA-2025-10-20
+   * Construire le nom de la salle Jitsi (format: LMS-{Matiere}-{Classe}-{Date})
    * @param {Object} seance
    * @param {string} roomId
    * @returns {string}
    */
   buildRoomName(seance, roomId) {
-    const parts = ['LMS']
-
-    // Ajouter matière (sanitized)
-    if (seance.matiere?.nom) {
-      parts.push(this.sanitizeForUrl(seance.matiere.nom))
-    }
-
-    // Ajouter classe (sanitized)
-    if (seance.classe?.nom) {
-      parts.push(this.sanitizeForUrl(seance.classe.nom))
-    }
-
-    // Ajouter date
-    if (seance.programmation?.date) {
-      const date = new Date(seance.programmation.date)
-      const dateStr = date.toISOString().split('T')[0] // YYYY-MM-DD
-      parts.push(dateStr)
-    }
-
-    // Ajouter Room ID court (derniers 8 caractères)
-    parts.push(roomId.slice(-8))
-
-    return parts.join('-')
+    return jitsiRoom.buildRoomName(seance, roomId)
   },
 
   /**
-   * Sanitize string pour URL
-   * Supprime espaces, accents, caractères spéciaux
+   * Sanitize string pour URL (supprime espaces, accents, caractères spéciaux)
    * @param {string} str
    * @returns {string}
    */
   sanitizeForUrl(str) {
-    return str
-      .normalize('NFD') // Décompose les caractères accentués
-      .replace(/[\u0300-\u036f]/g, '') // Supprime les accents
-      .replace(/[^a-zA-Z0-9]/g, '') // Garde seulement alphanumérique
-      .substring(0, 20) // Limite à 20 caractères
+    return jitsiRoom.sanitizeForUrl(str)
   },
 
   /**
-   * Enregistrer qu'un participant a rejoint la visio
-   * Enregistre l'heure de début dans localStorage (tracking côté client)
-   * @param {number} seanceId
-   * @param {number} userId
-   * @returns {Promise<Object>}
+   * Enregistrer qu'un participant a rejoint la visio (heure de début en localStorage).
+   * @param {number} seanceId @param {number} userId @returns {Promise<Object>}
    */
   async trackParticipantJoin(seanceId, userId) {
     const joinTime = new Date().toISOString()
@@ -156,11 +97,8 @@ export const jitsiService = {
   },
 
   /**
-   * Enregistrer qu'un participant a quitté la visio
-   * Calcule la durée et synchronise avec KLASSCI
-   * @param {number} seanceId
-   * @param {number} userId
-   * @returns {Promise<Object>}
+   * Enregistrer qu'un participant a quitté la visio : calcule la durée et synchronise (KLASSCI).
+   * @param {number} seanceId @param {number} userId @returns {Promise<Object>}
    */
   async trackParticipantLeave(seanceId, userId) {
     const leaveTime = new Date().toISOString()
@@ -211,11 +149,8 @@ export const jitsiService = {
   },
 
   /**
-   * Synchroniser une participation vers KLASSCI
-   * Envoie les données de présence via l'endpoint LMS
-   * @param {number} seanceId
-   * @param {Object} participation
-   * @returns {Promise<Object>}
+   * Synchroniser une participation vers KLASSCI (présences via l'endpoint LMS).
+   * @param {number} seanceId @param {Object} participation @returns {Promise<Object>}
    */
   async syncParticipation(seanceId, participation) {
     try {
@@ -256,8 +191,7 @@ export const jitsiService = {
   },
 
   /**
-   * Synchroniser toutes les participations en attente
-   * Utile pour retry des syncs échouées
+   * Synchroniser toutes les participations en attente (retry des syncs échouées).
    * @returns {Promise<Array>}
    */
   async syncPendingParticipations() {
@@ -344,10 +278,8 @@ export const jitsiService = {
   },
 
   /**
-   * Vérifier si une séance a une visio active
-   * (Utile pour l'UI: afficher badge "En cours")
-   * @param {number} seanceId
-   * @returns {Promise<boolean>}
+   * Vérifier si une séance a une visio active (UI: badge "En cours").
+   * @param {number} seanceId @returns {Promise<boolean>}
    */
   async isVisioActive(seanceId) {
     try {

--- a/src/utils/jitsiRoom.js
+++ b/src/utils/jitsiRoom.js
@@ -1,0 +1,105 @@
+import { auth } from '@/services/api'
+import { getJitsiDomain } from '@/constants/visio'
+
+/**
+ * Helpers purs de construction de salle / lien Jitsi (extraits de services/jitsi.js, G8).
+ *
+ * Logique sans état : génération d'ID de salle, nom de salle lisible, sanitation
+ * d'URL et assemblage du lien Jitsi. `jitsiService` (services/jitsi.js) délègue à
+ * ces fonctions ; son API publique reste strictement identique.
+ */
+
+/**
+ * Sanitize string pour URL
+ * Supprime espaces, accents, caractères spéciaux
+ * @param {string} str
+ * @returns {string}
+ */
+export function sanitizeForUrl(str) {
+  return str
+    .normalize('NFD') // Décompose les caractères accentués
+    .replace(/[̀-ͯ]/g, '') // Supprime les accents
+    .replace(/[^a-zA-Z0-9]/g, '') // Garde seulement alphanumérique
+    .substring(0, 20) // Limite à 20 caractères
+}
+
+/**
+ * Générer un Room ID unique pour la séance
+ * Format: lms_seance_{id}_{timestamp}
+ * @param {Object} seance
+ * @returns {string}
+ */
+export function generateRoomId(seance) {
+  const timestamp = Date.now()
+  return `lms_seance_${seance.id}_${timestamp}`
+}
+
+/**
+ * Construire le nom de la salle Jitsi
+ * Format: LMS-{Matiere}-{Classe}-{Date}
+ * Ex: LMS-Mathematiques-L1-InfoA-2025-10-20
+ * @param {Object} seance
+ * @param {string} roomId
+ * @returns {string}
+ */
+export function buildRoomName(seance, roomId) {
+  const parts = ['LMS']
+
+  // Ajouter matière (sanitized)
+  if (seance.matiere?.nom) {
+    parts.push(sanitizeForUrl(seance.matiere.nom))
+  }
+
+  // Ajouter classe (sanitized)
+  if (seance.classe?.nom) {
+    parts.push(sanitizeForUrl(seance.classe.nom))
+  }
+
+  // Ajouter date
+  if (seance.programmation?.date) {
+    const date = new Date(seance.programmation.date)
+    const dateStr = date.toISOString().split('T')[0] // YYYY-MM-DD
+    parts.push(dateStr)
+  }
+
+  // Ajouter Room ID court (derniers 8 caractères)
+  parts.push(roomId.slice(-8))
+
+  return parts.join('-')
+}
+
+/**
+ * Générer un lien Jitsi unique pour une séance
+ * @param {Object} seance - { id, visio_room_id, matiere, classe }
+ * @returns {string} URL Jitsi
+ */
+export function generateRoomLink(seance) {
+  // Utiliser visio_room_id si existant, sinon générer un ID unique
+  const roomId = seance.visio_room_id || generateRoomId(seance)
+
+  // Construire le nom de la salle
+  const roomName = buildRoomName(seance, roomId)
+
+  // URL Jitsi avec paramètres
+  const user = auth.getUser()
+
+  // Configuration Jitsi via URL params
+  const params = new URLSearchParams({
+    'userInfo.displayName': user?.name || 'Participant',
+    'config.prejoinPageEnabled': 'false', // Skip prejoin page
+    'config.startWithAudioMuted': user?.role === 'etudiant', // Mute students by default
+    'config.startWithVideoMuted': false,
+    'interfaceConfig.SHOW_JITSI_WATERMARK': 'false',
+    'interfaceConfig.SHOW_WATERMARK_FOR_GUESTS': 'false',
+    'interfaceConfig.DEFAULT_LOGO_URL': '',
+    'interfaceConfig.DEFAULT_WELCOME_PAGE_LOGO_URL': ''
+  })
+
+  const jitsiUrl = `https://${getJitsiDomain()}/${roomName}#${params.toString()}`
+
+  console.log('[JitsiService] Lien généré:', jitsiUrl)
+  console.log('[JitsiService] Room ID:', roomId)
+  console.log('[JitsiService] User:', user?.name, user?.role)
+
+  return jitsiUrl
+}

--- a/src/utils/visioTimeWindow.js
+++ b/src/utils/visioTimeWindow.js
@@ -1,0 +1,75 @@
+/**
+ * Logique temporelle pure de la visio (extraite de VisioManager.vue, G8).
+ *
+ * Fenêtre d'ouverture d'une séance : de 15 min avant `heure_debut` à 30 min après
+ * `heure_fin`. Fonctions sans état (testables) consommées par les `computed` du
+ * composant — comportement et formats d'affichage strictement identiques.
+ */
+
+const WINDOW_BEFORE_MS = 15 * 60 * 1000 // -15 min avant le début
+const WINDOW_AFTER_MS = 30 * 60 * 1000 // +30 min après la fin
+
+/**
+ * Formate un timestamp ISO en heure locale FR (HH:MM), ou 'N/A' si absent.
+ * @param {string|null|undefined} isoTimestamp
+ * @returns {string}
+ */
+export function formatVisioTime(isoTimestamp) {
+  if (!isoTimestamp) return 'N/A'
+  return new Date(isoTimestamp).toLocaleTimeString('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+/**
+ * Indique si `now` est dans la fenêtre temporelle de la séance
+ * (heure_debut - 15min → heure_fin + 30min).
+ * @param {Object} seance
+ * @param {Date} now
+ * @returns {boolean}
+ */
+export function isInTimeWindow(seance, now) {
+  // Utiliser programmation.heure_debut/fin (ISO 8601)
+  if (!seance.programmation?.heure_debut || !seance.programmation?.heure_fin) {
+    return false
+  }
+
+  const debut = new Date(seance.programmation.heure_debut)
+  const fin = new Date(seance.programmation.heure_fin)
+
+  // Fenêtre temporelle: -15min avant, +30min après
+  const windowStart = new Date(debut.getTime() - WINDOW_BEFORE_MS)
+  const windowEnd = new Date(fin.getTime() + WINDOW_AFTER_MS)
+
+  return now >= windowStart && now <= windowEnd
+}
+
+/**
+ * Message de compte à rebours avant l'ouverture de la fenêtre
+ * ('dans Xh Ymin' / 'dans Y minutes' / 'maintenant' / '').
+ * @param {Object} seance
+ * @param {Date} now
+ * @returns {string}
+ */
+export function timeWindowMessage(seance, now) {
+  if (!seance.programmation?.heure_debut) {
+    return ''
+  }
+
+  const debut = new Date(seance.programmation.heure_debut)
+  const windowStart = new Date(debut.getTime() - WINDOW_BEFORE_MS)
+
+  if (now < windowStart) {
+    const diffMinutes = Math.floor((windowStart - now) / 60000)
+    const hours = Math.floor(diffMinutes / 60)
+    const minutes = diffMinutes % 60
+
+    if (hours > 0) {
+      return `dans ${hours}h ${minutes}min`
+    }
+    return `dans ${minutes} minutes`
+  }
+
+  return 'maintenant'
+}

--- a/tests/unit/CalendarWidget.test.js
+++ b/tests/unit/CalendarWidget.test.js
@@ -1,0 +1,43 @@
+/**
+ * Test de montage de CalendarWidget.vue (G8 — Agent B).
+ * <script setup> utilisant useRouter() et le composant FullCalendar (@fullcalendar/vue3).
+ * On mocke vue-router (push) et on stub FullCalendar pour éviter l'init réelle du calendrier.
+ * Assertions : montage sans erreur (.calendar-widget) + titre + bascule de vue (changeView).
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+import CalendarWidget from '@/components/widgets/CalendarWidget.vue'
+
+function mountWidget(props = {}) {
+  return mount(CalendarWidget, {
+    props: { events: [], height: '500px', ...props },
+    global: {
+      stubs: { FullCalendar: true }
+    }
+  })
+}
+
+describe('CalendarWidget.vue (G8) — montage', () => {
+  it('monte sans erreur (racine .calendar-widget présente)', () => {
+    const w = mountWidget()
+    expect(w.find('.calendar-widget').exists()).toBe(true)
+  })
+
+  it('affiche le titre du widget', () => {
+    const w = mountWidget()
+    expect(w.find('.widget-title').text()).toContain('Calendrier des événements')
+  })
+
+  it('change la vue active au clic sur le bouton Semaine', async () => {
+    const w = mountWidget()
+    const buttons = w.findAll('.view-btn')
+    // index 1 = "Semaine" (Mois, Semaine, Jour)
+    await buttons[1].trigger('click')
+    expect(buttons[1].classes()).toContain('active')
+  })
+})

--- a/tests/unit/EventDetailModal.test.js
+++ b/tests/unit/EventDetailModal.test.js
@@ -1,0 +1,54 @@
+/**
+ * Test de montage de EventDetailModal.vue (G8 — Agent B).
+ * Composant pur (computeds + format, pas d'appel API). On vérifie :
+ *  - montage sans erreur + racine .modal-overlay
+ *  - rendu du titre depuis event.title / extendedProps
+ *  - émission de l'événement `close` au clic sur le bouton fermer
+ *  - émission de `action` (type viewDetails) via le bouton "Voir détails complets"
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import EventDetailModal from '@/components/calendar/EventDetailModal.vue'
+
+function mountModal(props = {}) {
+  return mount(EventDetailModal, {
+    props: {
+      event: {
+        title: 'Cours de Maths',
+        start: '2025-10-20T09:00:00.000Z',
+        end: '2025-10-20T11:00:00.000Z',
+        extendedProps: {
+          eventType: 'seance',
+          data: { matiere_nom: 'Maths', classe_nom: '6e A' }
+        }
+      },
+      userRole: 'student',
+      ...props
+    }
+  })
+}
+
+describe('EventDetailModal.vue (G8) — montage', () => {
+  it('monte sans erreur et affiche la racine .modal-overlay', () => {
+    const w = mountModal()
+    expect(w.find('.modal-overlay').exists()).toBe(true)
+  })
+
+  it('affiche le titre de l’événement', () => {
+    const w = mountModal()
+    expect(w.find('.modal-title').text()).toBe('Cours de Maths')
+  })
+
+  it('émet `close` au clic sur le bouton de fermeture', async () => {
+    const w = mountModal()
+    await w.find('.close-btn').trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+  })
+
+  it('émet `action` (viewDetails) au clic sur "Voir détails complets"', async () => {
+    const w = mountModal()
+    await w.find('.action-btn.outline').trigger('click')
+    expect(w.emitted('action')).toBeTruthy()
+    expect(w.emitted('action')[0][0].type).toBe('viewDetails')
+  })
+})

--- a/tests/unit/JitsiMeet.test.js
+++ b/tests/unit/JitsiMeet.test.js
@@ -1,0 +1,67 @@
+/**
+ * Test de montage de JitsiMeet.vue (G8 — Agent B).
+ * Le composant charge dynamiquement le script Jitsi External API au montage (initJitsi)
+ * et instancie window.JitsiMeetExternalAPI. On neutralise :
+ *  - @/services/lms (joinVisio/leaveVisio/heartbeatVisio) → no-op
+ *  - @/constants/visio (jitsiExternalApiSrc / getJitsiDomain / VISIO_CONFIG)
+ *  - window.JitsiMeetExternalAPI → faux constructeur (addEventListener / dispose)
+ *  Comme JitsiMeetExternalAPI est déjà défini, loadJitsiScript résout immédiatement
+ *  (pas d'injection réelle de <script>).
+ * Assertions : montage sans erreur (racine .jitsi-container) + le faux constructeur Jitsi
+ * a été instancié au montage.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/services/lms', () => ({
+  default: { joinVisio: vi.fn(() => Promise.resolve({ success: true })), leaveVisio: vi.fn(() => Promise.resolve()), heartbeatVisio: vi.fn(() => Promise.resolve()) }
+}))
+vi.mock('@/constants/visio', () => ({
+  jitsiExternalApiSrc: () => 'https://meet.jit.si/external_api.js',
+  getJitsiDomain: () => 'meet.jit.si',
+  VISIO_CONFIG: { HEARTBEAT_INTERVAL_MS: 30000 }
+}))
+
+import JitsiMeet from '@/components/visio/JitsiMeet.vue'
+
+const JitsiCtor = vi.fn(function () {
+  this.addEventListener = vi.fn()
+  this.dispose = vi.fn()
+})
+
+function mountJitsi(props = {}) {
+  return mount(JitsiMeet, {
+    props: {
+      seanceId: 1,
+      jitsiLink: 'https://meet.jit.si/RoomTest',
+      userName: 'Alice',
+      userEmail: 'alice@test.dev',
+      ...props
+    },
+    global: { stubs: { ContentLoader: true } }
+  })
+}
+
+describe('JitsiMeet.vue (G8) — montage', () => {
+  beforeEach(() => {
+    JitsiCtor.mockClear()
+    // Définir l'API externe avant le montage → loadJitsiScript résout sans injecter de <script>
+    window.JitsiMeetExternalAPI = JitsiCtor
+  })
+  afterEach(() => {
+    delete window.JitsiMeetExternalAPI
+  })
+
+  it('monte sans erreur (racine .jitsi-container présente)', () => {
+    const w = mountJitsi()
+    expect(w.find('.jitsi-container').exists()).toBe(true)
+  })
+
+  it('instancie window.JitsiMeetExternalAPI au montage', async () => {
+    mountJitsi()
+    // initJitsi est async (await loadJitsiScript) → laisser la microtask se résoudre
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(JitsiCtor).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/ParticipantsModal.test.js
+++ b/tests/unit/ParticipantsModal.test.js
@@ -1,0 +1,65 @@
+/**
+ * Test de montage de ParticipantsModal.vue (G8 — Agent B).
+ * Le composant appelle lmsService.getVisioParticipants() au montage et lance un
+ * setInterval de refresh. On mocke :
+ *  - @/services/lms (default export lmsService.getVisioParticipants) → promesse résolue neutre
+ *  - @/services/toast et @/services/errorHandler (utilisés par les exports) → no-op
+ *  - @/constants/http (apiBaseUrl) → no-op
+ * Pinia est fourni (le store auth est utilisé dans les méthodes d'export, pas au montage).
+ * Assertions : montage sans erreur (overlay racine), appel du service au montage,
+ * émission de `close` au clic sur le bouton Fermer du footer.
+ */
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { getVisioParticipants } = vi.hoisted(() => ({
+  getVisioParticipants: vi.fn(() =>
+    Promise.resolve({ success: true, data: { students: [], statistics: {}, teacher: null, coordinator: null } })
+  )
+}))
+
+vi.mock('@/services/lms', () => ({
+  default: { getVisioParticipants },
+  lmsService: { getVisioParticipants }
+}))
+vi.mock('@/services/toast', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('@/services/errorHandler', () => ({ normalizeError: (e) => ({ userMessage: String(e) }) }))
+vi.mock('@/constants/http', () => ({ apiBaseUrl: () => 'http://test' }))
+
+import ParticipantsModal from '@/components/visio/ParticipantsModal.vue'
+
+function mountModal(props = {}) {
+  return mount(ParticipantsModal, {
+    props: { seanceId: 42, ...props },
+    global: { plugins: [createPinia()] }
+  })
+}
+
+describe('ParticipantsModal.vue (G8) — montage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    getVisioParticipants.mockClear()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('monte sans erreur (overlay racine présent)', () => {
+    const w = mountModal()
+    expect(w.find('.fixed').exists()).toBe(true)
+  })
+
+  it('appelle getVisioParticipants au montage avec le seanceId', () => {
+    mountModal({ seanceId: 7 })
+    expect(getVisioParticipants).toHaveBeenCalledWith(7)
+  })
+
+  it('émet `close` au clic sur le bouton Fermer du footer', async () => {
+    const w = mountModal()
+    // Le dernier bouton est le bouton "Fermer" du footer
+    const buttons = w.findAll('button')
+    await buttons[buttons.length - 1].trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+  })
+})

--- a/tests/unit/TeacherVisioList.test.js
+++ b/tests/unit/TeacherVisioList.test.js
@@ -1,0 +1,55 @@
+/**
+ * Test de montage de TeacherVisioList.vue (G8 — Agent B).
+ * Vue avec router + cache + services. On mocke :
+ *  - @/services/lms (named lmsService.getMyTeachingSeances) → liste vide neutre
+ *  - @/services/cache (readCache/writeCache/clearCache) → no-op (readCache=null pour forcer l'appel API)
+ *  - @/constants/visio (buildJitsiUrl) → no-op
+ * On stub DashboardLayout (layout lourd avec router/stores) et ContentLoader, et on fournit Pinia.
+ * Assertion minimale : montage sans erreur + un conteneur racine .visio-container existe.
+ */
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { describe, it, expect, vi } from 'vitest'
+
+const { getMyTeachingSeances } = vi.hoisted(() => ({
+  getMyTeachingSeances: vi.fn(() => Promise.resolve({ data: [] }))
+}))
+
+vi.mock('@/services/lms', () => ({
+  lmsService: { getMyTeachingSeances },
+  default: { getMyTeachingSeances }
+}))
+vi.mock('@/services/cache', () => ({
+  readCache: vi.fn(() => null),
+  writeCache: vi.fn(),
+  clearCache: vi.fn()
+}))
+vi.mock('@/constants/visio', () => ({ buildJitsiUrl: (id) => `https://meet.jit.si/${id}` }))
+
+import TeacherVisioList from '@/views/teacher/TeacherVisioList.vue'
+
+function mountView() {
+  return mount(TeacherVisioList, {
+    global: {
+      plugins: [createPinia()],
+      // DashboardLayout doit rendre son slot par défaut pour exposer le contenu
+      stubs: {
+        DashboardLayout: { template: '<div><slot /></div>' },
+        ContentLoader: true,
+        'router-link': true
+      }
+    }
+  })
+}
+
+describe('TeacherVisioList.vue (G8) — montage', () => {
+  it('monte sans erreur et expose le conteneur racine .visio-container', () => {
+    const w = mountView()
+    expect(w.find('.visio-container').exists()).toBe(true)
+  })
+
+  it('charge les séances au montage via le service', () => {
+    mountView()
+    expect(getMyTeachingSeances).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/UniversalCalendar.test.js
+++ b/tests/unit/UniversalCalendar.test.js
@@ -1,0 +1,61 @@
+/**
+ * Test de montage (smoke) de UniversalCalendar.vue (#28bis / G8 — Agent B).
+ * Le composant utilise useRouter(), le composable useCalendarEvents (appels réseau),
+ * FullCalendar et les sous-composants CalendarFilters / EventDetailModal.
+ * On mocke :
+ *  - vue-router (useRouter)
+ *  - @/composables/useCalendarEvents → refs neutres + loadEvents/refreshData no-op (zéro réseau)
+ * et on stub FullCalendar, CalendarFilters, EventDetailModal, ContentLoader.
+ * Assertion : montage sans erreur (racine .calendar-container présente).
+ */
+import { mount } from '@vue/test-utils'
+import { ref } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+const loadEvents = vi.fn()
+const refreshData = vi.fn(() => Promise.resolve())
+
+vi.mock('@/composables/useCalendarEvents', () => ({
+  useCalendarEvents: () => ({
+    events: ref([]),
+    matieres: ref([]),
+    classes: ref([]),
+    enseignants: ref([]),
+    loading: ref(false),
+    refreshing: ref(false),
+    loadEvents,
+    refreshData
+  })
+}))
+
+import UniversalCalendar from '@/components/calendar/UniversalCalendar.vue'
+
+function mountCalendar(props = {}) {
+  return mount(UniversalCalendar, {
+    props: { userRole: 'teacher', userId: 1, ...props },
+    global: {
+      stubs: {
+        FullCalendar: true,
+        CalendarFilters: true,
+        EventDetailModal: true,
+        ContentLoader: true
+      }
+    }
+  })
+}
+
+describe('UniversalCalendar.vue (#28bis) — montage smoke', () => {
+  it('monte sans erreur (racine .calendar-container présente)', () => {
+    const w = mountCalendar()
+    expect(w.find('.calendar-container').exists()).toBe(true)
+  })
+
+  it('déclenche loadEvents au montage', () => {
+    mountCalendar()
+    expect(loadEvents).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/VisioManager.test.js
+++ b/tests/unit/VisioManager.test.js
@@ -1,0 +1,58 @@
+/**
+ * Test de montage de VisioManager.vue après extraction (G8).
+ * Vérifie que le composant monte sans erreur et que le rendu conditionnel par rôle
+ * (via auth.getUser) reste identique : bouton "Programmer en visio" pour le
+ * coordinateur quand la visio n'est pas activée.
+ */
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import VisioManager from '@/components/visio/VisioManager.vue'
+import { auth } from '@/services/api'
+
+function mountManager(seance = {}) {
+  return mount(VisioManager, {
+    props: { seance: { id: 1, ...seance } },
+    global: {
+      plugins: [createPinia()],
+      stubs: { ParticipantsModal: true }
+    }
+  })
+}
+
+describe('VisioManager.vue (G8) — montage', () => {
+  let getUserSpy
+
+  beforeEach(() => {
+    getUserSpy = vi.spyOn(auth, 'getUser').mockReturnValue(null)
+  })
+  afterEach(() => {
+    getUserSpy.mockRestore()
+  })
+
+  it('monte sans erreur (racine .visio-manager présente)', () => {
+    const w = mountManager()
+    expect(w.find('.visio-manager').exists()).toBe(true)
+  })
+
+  it('coordinateur + visio désactivée → bouton "Programmer en visio"', () => {
+    getUserSpy.mockReturnValue({ role: 'coordinateur' })
+    const w = mountManager({ visio_enabled: false })
+    expect(w.text()).toContain('Programmer en visio')
+  })
+
+  it('étudiant + visio activée non démarrée → message d’attente', () => {
+    getUserSpy.mockReturnValue({ role: 'etudiant' })
+    const w = mountManager({ visio_enabled: true, visio_active: false })
+    expect(w.text()).toContain("lorsque l'enseignant la démarrera")
+  })
+
+  it('formatTime expose HH:MM via l’horaire de séance enseignant', () => {
+    getUserSpy.mockReturnValue({ role: 'enseignant' })
+    const w = mountManager({
+      visio_enabled: true,
+      programmation: { heure_debut: '2025-10-20T09:00:00.000Z', heure_fin: '2025-10-20T11:00:00.000Z' }
+    })
+    expect(w.text()).toMatch(/Séance programmée: \d{2}:\d{2} - \d{2}:\d{2}/)
+  })
+})

--- a/tests/unit/jitsiRoom.test.js
+++ b/tests/unit/jitsiRoom.test.js
@@ -1,0 +1,67 @@
+/**
+ * Tests des helpers purs de construction de salle/lien Jitsi (utils/jitsiRoom.js, G8).
+ * Parité avec l'ancien services/jitsi.js : sanitation, format d'ID et de nom de salle,
+ * et assemblage du lien avec les paramètres Jitsi.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/services/api', () => ({
+  auth: { getUser: vi.fn(() => ({ name: 'Alice', role: 'etudiant' })) }
+}))
+vi.mock('@/constants/visio', () => ({ getJitsiDomain: () => 'meet.test' }))
+
+import { sanitizeForUrl, generateRoomId, buildRoomName, generateRoomLink } from '@/utils/jitsiRoom'
+import { auth } from '@/services/api'
+
+describe('utils/jitsiRoom — sanitizeForUrl', () => {
+  it('supprime accents, espaces et caractères spéciaux', () => {
+    // tronqué à 20 caractères ('Mathematiquesgenerales' → 22 → 20)
+    expect(sanitizeForUrl('Mathématiques générales !')).toBe('Mathematiquesgeneral')
+  })
+  it('limite à 20 caractères', () => {
+    expect(sanitizeForUrl('abcdefghijklmnopqrstuvwxyz').length).toBe(20)
+  })
+})
+
+describe('utils/jitsiRoom — generateRoomId', () => {
+  it('format lms_seance_{id}_{timestamp}', () => {
+    expect(generateRoomId({ id: 7 })).toMatch(/^lms_seance_7_\d+$/)
+  })
+})
+
+describe('utils/jitsiRoom — buildRoomName', () => {
+  it('assemble LMS-Matiere-Classe-Date-roomId8', () => {
+    const seance = {
+      matiere: { nom: 'Maths' },
+      classe: { nom: 'L1 InfoA' },
+      programmation: { date: '2025-10-20T00:00:00.000Z' }
+    }
+    expect(buildRoomName(seance, 'abcdef1234567890')).toBe('LMS-Maths-L1InfoA-2025-10-20-34567890')
+  })
+  it('omet les parties absentes mais garde le suffixe roomId', () => {
+    expect(buildRoomName({}, '0000000087654321')).toBe('LMS-87654321')
+  })
+})
+
+describe('utils/jitsiRoom — generateRoomLink', () => {
+  beforeEach(() => {
+    auth.getUser.mockReturnValue({ name: 'Alice', role: 'etudiant' })
+  })
+
+  it('utilise visio_room_id existant et le domaine configuré', () => {
+    const url = generateRoomLink({ id: 1, visio_room_id: 'room-xyz12345', matiere: { nom: 'Maths' } })
+    expect(url.startsWith('https://meet.test/LMS-Maths-')).toBe(true)
+    expect(url).toContain('#')
+  })
+
+  it('mute les étudiants par défaut (startWithAudioMuted=true)', () => {
+    const url = generateRoomLink({ id: 1, visio_room_id: 'room-xyz12345' })
+    expect(decodeURIComponent(url)).toContain('config.startWithAudioMuted=true')
+  })
+
+  it('ne mute pas les enseignants (startWithAudioMuted=false)', () => {
+    auth.getUser.mockReturnValue({ name: 'Bob', role: 'enseignant' })
+    const url = generateRoomLink({ id: 1, visio_room_id: 'room-xyz12345' })
+    expect(decodeURIComponent(url)).toContain('config.startWithAudioMuted=false')
+  })
+})

--- a/tests/unit/visioTimeWindow.test.js
+++ b/tests/unit/visioTimeWindow.test.js
@@ -1,0 +1,65 @@
+/**
+ * Tests de la logique temporelle pure de la visio (utils/visioTimeWindow.js, G8).
+ * Fenêtre : -15 min avant heure_debut → +30 min après heure_fin.
+ * Calculs relatifs (Dates comparées par instant) → indépendants du fuseau horaire.
+ */
+import { describe, it, expect } from 'vitest'
+import { formatVisioTime, isInTimeWindow, timeWindowMessage } from '@/utils/visioTimeWindow'
+
+const MIN = 60 * 1000
+const at = (ms) => new Date(ms).toISOString()
+
+describe('utils/visioTimeWindow — formatVisioTime', () => {
+  it("retourne 'N/A' si absent", () => {
+    expect(formatVisioTime(null)).toBe('N/A')
+    expect(formatVisioTime(undefined)).toBe('N/A')
+  })
+  it('formate en HH:MM', () => {
+    expect(formatVisioTime('2025-10-20T09:05:00.000Z')).toMatch(/^\d{2}:\d{2}$/)
+  })
+})
+
+describe('utils/visioTimeWindow — isInTimeWindow', () => {
+  it('false si programmation incomplète', () => {
+    expect(isInTimeWindow({ programmation: {} }, new Date())).toBe(false)
+    expect(isInTimeWindow({}, new Date())).toBe(false)
+  })
+  it('true à l’intérieur de la fenêtre (-15min/+30min)', () => {
+    const now = 1_000_000_000_000
+    const seance = { programmation: { heure_debut: at(now + 5 * MIN), heure_fin: at(now + 60 * MIN) } }
+    expect(isInTimeWindow(seance, new Date(now))).toBe(true) // début-15min déjà passé
+  })
+  it('false avant l’ouverture (> 15min avant le début)', () => {
+    const now = 1_000_000_000_000
+    const seance = { programmation: { heure_debut: at(now + 30 * MIN), heure_fin: at(now + 90 * MIN) } }
+    expect(isInTimeWindow(seance, new Date(now))).toBe(false)
+  })
+  it('false après la fermeture (> 30min après la fin)', () => {
+    const now = 1_000_000_000_000
+    const seance = { programmation: { heure_debut: at(now - 120 * MIN), heure_fin: at(now - 31 * MIN) } }
+    expect(isInTimeWindow(seance, new Date(now))).toBe(false)
+  })
+})
+
+describe('utils/visioTimeWindow — timeWindowMessage', () => {
+  it("'' si pas d’heure de début", () => {
+    expect(timeWindowMessage({ programmation: {} }, new Date())).toBe('')
+  })
+  it("'maintenant' une fois la fenêtre ouverte", () => {
+    const now = 1_000_000_000_000
+    const seance = { programmation: { heure_debut: at(now + 5 * MIN) } }
+    expect(timeWindowMessage(seance, new Date(now))).toBe('maintenant')
+  })
+  it("'dans X minutes' quand < 1h avant l’ouverture", () => {
+    const now = 1_000_000_000_000
+    // ouverture = debut-15min ; on veut ~10min avant l'ouverture → debut = now+25min
+    const seance = { programmation: { heure_debut: at(now + 25 * MIN) } }
+    expect(timeWindowMessage(seance, new Date(now))).toBe('dans 10 minutes')
+  })
+  it("'dans Xh Ymin' quand > 1h avant l’ouverture", () => {
+    const now = 1_000_000_000_000
+    // ouverture = debut-15min ; on veut 1h10 avant → debut = now+85min
+    const seance = { programmation: { heure_debut: at(now + 85 * MIN) } }
+    expect(timeWindowMessage(seance, new Date(now))).toBe('dans 1h 10min')
+  })
+})


### PR DESCRIPTION
## Groupe G8 — Visio & Calendrier (décomposition « code métier < 300 »)

Objectif : ramener le `<script>` de chaque fichier sous 300 lignes **sans changer le comportement ni l'affichage**.

### Cadrage
La table de découpage donnait les lignes de **fichier entier** ; le critère réel est le **`<script>`**. Sur `dev` à jour, **6 des 8 fichiers avaient déjà leur script < 300** (aucune refacto). Seuls 2 dépassaient.

### Refactorisé
| Fichier | script avant → après | Extrait vers |
|---|---|---|
| `components/visio/VisioManager.vue` | **367 → 99** | `utils/visioTimeWindow.js` (logique temporelle pure) + `composables/useVisioActions.js` (état + 7 appels API) |
| `services/jitsi.js` | **366 → 298** | `utils/jitsiRoom.js` (génération salle/lien pures) ; `jitsiService` délègue — **API publique identique** |

Fichiers neufs : `utils/jitsiRoom.js`, `utils/visioTimeWindow.js`, `composables/useVisioActions.js`. Aucun service/util partagé existant modifié.

### Parité (vérifiée sur le code réel)
- Effet de bord `cleanupExpiredParticipations()` au chargement conservé (import side-effect de `services/jitsi` dans VisioManager — seul importeur vivant).
- Itérations `localStorage` de jitsi.js inchangées (parité stricte).
- Mêmes routes/payloads/`alert`/`confirm`/`console`/événements émis.
- Nettoyage neutre : variable morte `displayName` et imports inutiles retirés de jitsi.js.

### Vérification
- **`vite build` vert.**
- **9 fichiers de test / 38 tests verts** : unités des helpers purs + **test de montage des 8 composants** du groupe (mocks/stubs ciblés, aucun fichier source modifié par les tests).
- Tests G8 préexistants (visioLeave, heartbeat, calendar, CalendarFilters) toujours verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)