### PR TITLE
refactor(H8): Calendrier & widgets — chaque fichier sous 300 lignes (éclatement complet)

### DIFF
--- a/src/assets/styles/_calendar-fc-dark.scss
+++ b/src/assets/styles/_calendar-fc-dark.scss
@@ -1,0 +1,188 @@
+// =============================================================================
+// Mode sombre du calendrier unifié — FullCalendar (H8 — décomposition
+// UniversalCalendar.vue sous 300 lignes).
+//
+// Bloc de styles *global* (non-scoped) déplacé VERBATIM depuis le second
+// `<style>` de UniversalCalendar.vue (lignes 963-1152). Il cible le rendu
+// FullCalendar (`.fc`) ainsi que la carte calendrier et le loader en thème
+// sombre. Importé une seule fois via `@use` depuis CalendarView.vue (qui rend
+// FullCalendar). Aucune règle modifiée — relocalisation pure.
+// =============================================================================
+
+// Couleurs LMS pour le mode sombre
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+html[data-theme="dark"] {
+  // Calendrier en mode sombre
+  .calendar-card {
+    background: var(--card-bg) !important;
+  }
+
+  .loading-container {
+    color: rgba($white, 0.7);
+
+    .material-icons {
+      color: $lms-blue-light;
+    }
+
+    p {
+      color: rgba($white, 0.7);
+    }
+  }
+
+  // FullCalendar en mode sombre
+  .fc {
+    color: $white;
+
+    .fc-button-primary {
+      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
+      border-color: $lms-blue-light;
+      color: $white;
+
+      &:hover:not(:disabled) {
+        background: $lms-blue;
+        border-color: $lms-blue;
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.3);
+      }
+    }
+
+    .fc-col-header-cell {
+      background: linear-gradient(180deg, #0a1929 0%, #001e3c 100%) !important;
+      border-color: #001e3c !important;
+
+      .fc-col-header-cell-cushion {
+        color: $white !important;
+        font-weight: 600;
+      }
+    }
+
+    .fc-daygrid-day,
+    .fc-timegrid-slot {
+      background: var(--bg-secondary) !important;
+      border-color: var(--border-primary) !important;
+    }
+
+    .fc-daygrid-day-number,
+    .fc-timegrid-slot-label {
+      color: var(--text-primary) !important;
+    }
+
+    .fc-daygrid-day.fc-day-today {
+      background: linear-gradient(135deg, rgba($lms-blue-light, 0.3) 0%, rgba($lms-blue-light, 0.15) 100%) !important;
+      border: 2px solid $lms-blue-light !important;
+
+      .fc-daygrid-day-number {
+        color: $lms-blue-light !important;
+        font-weight: 700;
+      }
+    }
+
+    .fc-daygrid-day.fc-day-other {
+      background: var(--bg-tertiary) !important;
+      opacity: 0.6;
+
+      .fc-daygrid-day-number {
+        color: var(--text-tertiary) !important;
+      }
+    }
+
+    .fc-timegrid-now-indicator-line {
+      border-color: $lms-blue-light;
+    }
+
+    .fc-timegrid-now-indicator-arrow {
+      border-color: $lms-blue-light;
+    }
+
+    // Événements en mode sombre
+    .fc-event {
+      border-width: 2px;
+      font-weight: 500;
+    }
+
+    .event-seance {
+      background: rgba($lms-blue, 0.9);
+      border-color: $lms-blue;
+      color: $white;
+
+      &:hover {
+        background: $lms-blue;
+        box-shadow: 0 2px 8px rgba($lms-blue, 0.5);
+      }
+    }
+
+    .event-evaluation {
+      background: rgba(#06b6d4, 0.9);
+      border-color: #06b6d4;
+      color: $white;
+      font-weight: 600;
+
+      &:hover {
+        background: #06b6d4;
+        box-shadow: 0 2px 8px rgba(#06b6d4, 0.5);
+      }
+    }
+
+    .event-urgent {
+      background: #ef4444 !important;
+      border-color: #ef4444 !important;
+      color: $white !important;
+      animation: pulse-urgent-dark 2s infinite;
+
+      &:hover {
+        box-shadow: 0 2px 8px rgba(#ef4444, 0.5);
+      }
+    }
+
+    // Grille horaire en mode sombre
+    .fc-scrollgrid {
+      border-color: var(--border-primary) !important;
+    }
+
+    .fc-scrollgrid-section > * {
+      border-color: var(--border-primary) !important;
+    }
+
+    // Conteneurs FullCalendar en mode sombre
+    .fc-view-harness,
+    .fc-scrollgrid-sync-table,
+    .fc-timegrid-body,
+    .fc-timegrid-slots,
+    .fc-daygrid-body {
+      background: var(--bg-secondary) !important;
+    }
+
+    // Cellules de la grille temporelle
+    .fc-timegrid-slot-lane {
+      background: var(--bg-secondary) !important;
+      border-color: var(--border-primary) !important;
+    }
+
+    // Zone vide du calendrier
+    .fc-daygrid-day-frame,
+    .fc-daygrid-day-bg {
+      background: transparent !important;
+    }
+
+    // Table et corps du calendrier
+    table, tbody, tr, td, th {
+      border-color: var(--border-primary) !important;
+    }
+  }
+
+  @keyframes pulse-urgent-dark {
+    0%, 100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.85;
+      transform: scale(1.02);
+    }
+  }
+}

--- a/src/assets/styles/_calendar-shell-dark.scss
+++ b/src/assets/styles/_calendar-shell-dark.scss
@@ -1,0 +1,91 @@
+// =============================================================================
+// Mode sombre de la coque du calendrier unifié (H8 — décomposition
+// UniversalCalendar.vue sous 300 lignes).
+//
+// Bloc de styles *global* (non-scoped) déplacé VERBATIM depuis le second
+// `<style>` de UniversalCalendar.vue. Couvre le conteneur, la base `.card` et le
+// dark mode des filtres (`.filters-card` appartient à CalendarFilters.vue, hors
+// lot H8 : son dark mode global est conservé ici plutôt que de modifier un fichier
+// hors périmètre). Importé une seule fois via `@use` depuis UniversalCalendar.vue.
+// Aucune règle modifiée — relocalisation pure.
+// =============================================================================
+
+// Couleurs LMS pour le mode sombre
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+html[data-theme="dark"] {
+  .calendar-container {
+    background: transparent;
+  }
+
+  // Cards en mode sombre
+  .card {
+    background: var(--card-bg) !important;
+    border: 1px solid var(--card-border) !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  // Filtres en mode sombre — `.filters-card` appartient à CalendarFilters.vue (hors
+  // lot H8) ; son dark mode global est conservé ici (verbatim).
+  .filters-card {
+    .filters-title {
+      .material-icons {
+        color: $lms-blue-light;
+      }
+
+      h3 {
+        color: $white;
+      }
+    }
+
+    .reset-button {
+      color: rgba($white, 0.7);
+
+      &:hover {
+        background: rgba($lms-blue-light, 0.3);
+        color: $lms-blue-light;
+      }
+    }
+
+    .filter-field {
+      label {
+        color: rgba($white, 0.8);
+
+        .icon-label {
+          color: $lms-blue-light;
+        }
+      }
+
+      select {
+        background: var(--input-bg);
+        border-color: var(--input-border);
+        color: var(--input-text);
+
+        &:hover {
+          border-color: $lms-blue-light;
+        }
+
+        &:focus {
+          border-color: $lms-blue-light;
+          box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.2);
+        }
+
+        option {
+          background: var(--bg-primary);
+          color: var(--text-primary);
+        }
+      }
+    }
+
+    .filter-count {
+      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
+      color: $white;
+
+      .material-icons {
+        color: $white;
+      }
+    }
+  }
+}

--- a/src/components/calendar/CalendarLegend.vue
+++ b/src/components/calendar/CalendarLegend.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="legend-card card">
+    <h3>
+      <i class="material-icons">info</i>
+      Légende
+    </h3>
+    <div class="legend-items">
+      <div class="legend-item">
+        <div class="color-dot" style="background: #2563eb; /* LMS blue (séances) */"></div>
+        <span>Séances</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot" style="background: #10b981"></div>
+        <span>Visio active</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot" style="background: #ea580c; /* LMS orange (évaluations) */"></div>
+        <span>Évaluations</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot" style="background: #ef4444"></div>
+        <span>Urgent (&lt; 24h)</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Légende du calendrier unifié (H8 — décomposition UniversalCalendar).
+ * Composant purement statique (aucune prop, aucun état). CSS déplacé verbatim
+ * depuis UniversalCalendar (clair scoped + dark mode global non-scoped).
+ */
+</script>
+
+<style lang="scss" scoped>
+// Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
+$lms-blue: #2563eb;
+$white: #ffffff;
+$text-primary: #1E293B;
+$gray-lightest: #F9FAFB;
+$gray-border: #E5E7EB;
+$gray-dark: #374151;
+$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
+$border-radius-lg: 8px;
+
+// ========== CARD BASE ==========
+.card {
+  background: var(--card-bg, $white);
+  border: 1px solid var(--card-border, transparent);
+  border-radius: $border-radius-lg;
+  box-shadow: var(--card-shadow, $shadow-light);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+// ========== LEGEND ==========
+.legend-card {
+  h3 {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: $lms-blue;
+
+    .material-icons {
+      color: $lms-blue;
+      font-size: 1.5rem;
+    }
+  }
+
+  .legend-items {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    background: var(--bg-tertiary, $gray-lightest);
+    border-radius: $border-radius-lg;
+    border: 1px solid var(--border-primary, $gray-border);
+
+    .color-dot {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+    }
+
+    span {
+      font-size: 0.875rem;
+      color: var(--text-primary, $gray-dark);
+      font-weight: 500;
+    }
+  }
+}
+</style>
+
+<!-- Styles mode sombre non-scoped pour fonctionner avec data-theme -->
+<style lang="scss">
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+// ========== DARK MODE ==========
+html[data-theme="dark"] {
+  .legend-card {
+    h3 {
+      color: $white;
+
+      .material-icons {
+        color: $lms-blue-light;
+      }
+    }
+
+    .legend-item {
+      background: var(--bg-tertiary);
+      border-color: var(--border-primary);
+
+      span {
+        color: var(--text-primary);
+      }
+    }
+  }
+}
+</style>

--- a/src/components/calendar/CalendarNavigation.vue
+++ b/src/components/calendar/CalendarNavigation.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="navigation-card card">
+    <div class="navigation-controls">
+      <button class="nav-button" @click="$emit('previous')" title="Mois précédent">
+        <i class="material-icons">chevron_left</i>
+      </button>
+
+      <div class="current-month">
+        <i class="material-icons">calendar_today</i>
+        <span>{{ currentMonthLabel }}</span>
+      </div>
+
+      <button class="nav-button" @click="$emit('next')" title="Mois suivant">
+        <i class="material-icons">chevron_right</i>
+      </button>
+
+      <button class="today-button" @click="$emit('today')" title="Revenir à aujourd'hui">
+        <i class="material-icons">today</i>
+        Aujourd'hui
+      </button>
+
+      <button class="refresh-button" @click="$emit('refresh')" :disabled="refreshing" title="Actualiser les donnees depuis KLASSCI">
+        <i class="material-icons" :class="{ 'spin': refreshing }">sync</i>
+        {{ refreshing ? 'Chargement...' : 'Actualiser' }}
+      </button>
+
+      <CalendarViewSelector :current-view="currentView" @change-view="$emit('change-view', $event)" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Barre de navigation du calendrier unifié (H8 — décomposition UniversalCalendar).
+ * Sous-composant présentationnel : le mois courant, la vue active et l'état
+ * « rafraîchissement » sont des props ; toutes les actions sont émises
+ * (previous/next/today/refresh/change-view). Le sélecteur de vue est délégué à
+ * <CalendarViewSelector>. CSS déplacé verbatim (clair scoped + dark global).
+ */
+import CalendarViewSelector from './CalendarViewSelector.vue'
+
+defineProps({
+  currentMonthLabel: { type: String, default: '' },
+  currentView: { type: String, default: 'dayGridMonth' },
+  refreshing: { type: Boolean, default: false }
+})
+
+defineEmits(['previous', 'next', 'today', 'refresh', 'change-view'])
+</script>
+
+<style lang="scss" scoped>
+// Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
+$lms-blue: #2563eb;
+$white: #ffffff;
+$text-primary: #1E293B;
+$text-tertiary: #6B7280;
+$gray-light: #F8FAFC;
+$gray-border: #E5E7EB;
+$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
+$transition-fast: all 0.2s ease;
+$border-radius-md: 6px;
+$border-radius-lg: 8px;
+
+// ========== CARD BASE ==========
+.card {
+  background: var(--card-bg, $white);
+  border: 1px solid var(--card-border, transparent);
+  border-radius: $border-radius-lg;
+  box-shadow: var(--card-shadow, $shadow-light);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+// ========== NAVIGATION ==========
+.navigation-card {
+  padding: 1rem 1.5rem;
+
+  .navigation-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    .nav-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border: 1px solid var(--border-primary, $gray-border);
+      border-radius: $border-radius-md;
+      background: transparent;
+      color: var(--text-primary, $text-primary);
+      cursor: pointer;
+      transition: $transition-fast;
+
+      .material-icons {
+        font-size: 1.5rem;
+        color: var(--text-primary, $text-primary);
+      }
+
+      &:hover {
+        background: var(--bg-hover, $gray-light);
+        border-color: $lms-blue;
+        color: $lms-blue;
+
+        .material-icons {
+          color: $lms-blue;
+        }
+      }
+    }
+
+    .current-month {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: $lms-blue;
+      text-transform: capitalize;
+
+      .material-icons {
+        color: $lms-blue;
+      }
+    }
+
+    .today-button {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: 1px solid $lms-blue;
+      color: $lms-blue;
+      padding: 0.5rem 1rem;
+      border-radius: $border-radius-md;
+      background: transparent;
+      transition: $transition-fast;
+      font-weight: 500;
+      cursor: pointer;
+
+      &:hover {
+        background: $lms-blue;
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+    }
+
+    .refresh-button {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: 1px solid #10b981;
+      color: #10b981;
+      padding: 0.5rem 1rem;
+      border-radius: $border-radius-md;
+      background: transparent;
+      transition: $transition-fast;
+      font-weight: 500;
+      cursor: pointer;
+
+      &:hover:not(:disabled) {
+        background: #10b981;
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+
+      .material-icons.spin {
+        animation: spin 1s linear infinite;
+      }
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+  }
+}
+
+// ========== RESPONSIVE ==========
+// (la règle `.view-selector` mobile est déplacée dans CalendarViewSelector.vue,
+//  le sélecteur étant désormais un sous-composant — CSS scoped n'atteint pas l'enfant)
+@media (max-width: 768px) {
+  .navigation-controls {
+    flex-wrap: wrap;
+
+    .current-month {
+      order: -1;
+      flex-basis: 100%;
+      margin-bottom: 1rem;
+    }
+
+    .today-button {
+      flex-basis: 100%;
+    }
+  }
+}
+</style>
+
+<!-- Styles mode sombre non-scoped pour fonctionner avec data-theme -->
+<style lang="scss">
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+// ========== DARK MODE ==========
+html[data-theme="dark"] {
+  .navigation-card {
+    .nav-button {
+      border-color: rgba($lms-blue-light, 0.5);
+      color: $white;
+      background: transparent;
+
+      .material-icons {
+        color: $white !important;
+      }
+
+      &:hover {
+        background: rgba($lms-blue-light, 0.3);
+        border-color: $lms-blue-light;
+        color: $lms-blue-light;
+
+        .material-icons {
+          color: $lms-blue-light !important;
+        }
+      }
+    }
+
+    .current-month {
+      color: $white;
+
+      .material-icons {
+        color: $lms-blue-light;
+      }
+    }
+
+    .today-button {
+      border-color: $lms-blue-light;
+      color: $white;
+      background: rgba($lms-blue-light, 0.2);
+
+      &:hover {
+        background: $lms-blue-light;
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/calendar/CalendarView.vue
+++ b/src/components/calendar/CalendarView.vue
@@ -1,0 +1,221 @@
+<template>
+  <div class="calendar-card card">
+    <ContentLoader v-if="loading" text="Chargement du calendrier..." />
+
+    <div v-else class="calendar-wrapper">
+      <FullCalendar
+        ref="calendarRef"
+        :options="options"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Carte calendrier du calendrier unifié (H8 — décomposition UniversalCalendar).
+ * Encapsule l'instance FullCalendar et son loader. Reçoit la configuration via la
+ * prop `options` et l'état `loading` ; expose `getApi()` pour que l'orchestrateur
+ * (via useCalendarView) pilote la navigation impérative — parité exacte avec
+ * l'ancien `calendarRef.getApi()`. CSS `.fc` clair déplacé verbatim (`:deep`),
+ * le bloc `.fc` sombre vit dans le partial `_calendar-fc-dark.scss`.
+ */
+import { ref } from 'vue'
+import FullCalendar from '@fullcalendar/vue3'
+import ContentLoader from '@/components/common/ContentLoader.vue'
+
+defineProps({
+  options: { type: Object, required: true },
+  loading: { type: Boolean, default: false }
+})
+
+const calendarRef = ref(null)
+
+defineExpose({
+  getApi: () => calendarRef.value?.getApi()
+})
+</script>
+
+<style lang="scss" scoped>
+// Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+$text-primary: #1E293B;
+$text-secondary: #64748B;
+$text-tertiary: #6B7280;
+$gray-border: #E5E7EB;
+$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
+$shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
+$transition-fast: all 0.2s ease;
+$border-radius-lg: 8px;
+
+// ========== CARD BASE ==========
+.card {
+  background: var(--card-bg, $white);
+  border: 1px solid var(--card-border, transparent);
+  border-radius: $border-radius-lg;
+  box-shadow: var(--card-shadow, $shadow-light);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+// ========== CALENDAR CARD ==========
+.calendar-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.calendar-wrapper {
+  padding: 1rem;
+}
+
+.loading-container {
+  padding: 4rem;
+  text-align: center;
+  color: var(--text-tertiary, $text-tertiary);
+
+  .material-icons {
+    font-size: 3rem;
+    color: $lms-blue;
+    margin-bottom: 1rem;
+
+    &.spin {
+      animation: spin 1s linear infinite;
+    }
+  }
+
+  p {
+    font-size: 1rem;
+    color: var(--text-secondary, $text-secondary);
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+// ========== FULLCALENDAR CUSTOM STYLES ==========
+:deep(.fc) {
+  font-family: inherit;
+
+  .fc-toolbar-title {
+    display: none;
+  }
+
+  .fc-header-toolbar {
+    margin-bottom: 1rem;
+  }
+
+  .fc-button-primary {
+    background: $lms-blue;
+    border-color: $lms-blue;
+    transition: $transition-fast;
+
+    &:hover:not(:disabled) {
+      background: $lms-blue-light;
+      border-color: $lms-blue-light;
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 3px rgba($lms-blue, 0.2);
+    }
+  }
+
+  // En-tête des jours (lun, mar, mer, etc.) - Couleur sidebar
+  .fc-col-header-cell {
+    background: linear-gradient(180deg, #0052cc 0%, #0747a6 100%);
+    border-color: #0747a6;
+
+    .fc-col-header-cell-cushion {
+      color: $white;
+      font-weight: 600;
+      padding: 0.75rem 0.5rem;
+    }
+  }
+
+  // Cases des jours
+  .fc-daygrid-day,
+  .fc-timegrid-slot {
+    background: var(--bg-secondary, $white);
+    border-color: var(--border-primary, $gray-border);
+  }
+
+  // Numéros des jours
+  .fc-daygrid-day-number,
+  .fc-timegrid-slot-label {
+    color: var(--text-primary, $text-primary);
+    padding: 0.5rem;
+  }
+
+  // Jour actuel (aujourd'hui)
+  .fc-daygrid-day.fc-day-today {
+    background: linear-gradient(135deg, rgba($lms-blue, 0.15) 0%, rgba($lms-blue, 0.08) 100%);
+    border: 2px solid $lms-blue;
+
+    .fc-daygrid-day-number {
+      color: $lms-blue;
+      font-weight: 700;
+    }
+  }
+
+  // Ligne de l'heure actuelle (time grid)
+  .fc-timegrid-now-indicator-line {
+    border-color: $lms-blue;
+    border-width: 2px;
+  }
+
+  .fc-timegrid-now-indicator-arrow {
+    border-color: $lms-blue;
+  }
+
+  .fc-timegrid-slot {
+    height: 3rem;
+  }
+
+  // Couleurs des événements
+  .event-seance {
+    background: #2563eb; /* LMS blue (séances) */;
+    border-color: #2563eb; /* LMS blue */
+  }
+
+  .event-evaluation {
+    background: #06b6d4; /* Cyan (évaluations) */;
+    border-color: #06b6d4; /* Cyan */
+  }
+
+  .event-urgent {
+    background: #ef4444 !important;
+    border-color: #ef4444 !important;
+    animation: pulse 2s infinite;
+  }
+
+  // Événements en mode clair
+  .fc-event {
+    cursor: pointer;
+    transition: $transition-fast;
+
+    &:hover {
+      opacity: 0.9;
+      transform: translateY(-1px);
+      box-shadow: $shadow-hover;
+    }
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+</style>
+
+<!-- Styles mode sombre non-scoped (FullCalendar) — relocalisés dans un partial -->
+<style lang="scss">
+@use '../../assets/styles/calendar-fc-dark';
+</style>

--- a/src/components/calendar/CalendarViewSelector.vue
+++ b/src/components/calendar/CalendarViewSelector.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="view-selector">
+    <button
+      :class="{ active: currentView === 'dayGridMonth' }"
+      @click="$emit('change-view', 'dayGridMonth')"
+      title="Vue mensuelle"
+    >
+      <i class="material-icons">view_module</i>
+      Mois
+    </button>
+    <button
+      :class="{ active: currentView === 'timeGridWeek' }"
+      @click="$emit('change-view', 'timeGridWeek')"
+      title="Vue hebdomadaire"
+    >
+      <i class="material-icons">view_week</i>
+      Semaine
+    </button>
+    <button
+      :class="{ active: currentView === 'timeGridDay' }"
+      @click="$emit('change-view', 'timeGridDay')"
+      title="Vue journalière"
+    >
+      <i class="material-icons">view_day</i>
+      Jour
+    </button>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Sélecteur de vue du calendrier unifié (H8 — décomposition UniversalCalendar).
+ * Sous-composant présentationnel : la vue active est une prop, le changement est
+ * émis (`change-view`). Aucun état ni appel API. CSS déplacé verbatim depuis
+ * UniversalCalendar (clair scoped + dark mode global non-scoped).
+ */
+defineProps({
+  currentView: { type: String, default: 'dayGridMonth' }
+})
+
+defineEmits(['change-view'])
+</script>
+
+<style lang="scss" scoped>
+// Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
+$lms-blue: #2563eb;
+$lms-blue-dark: #1e3a8a;
+$white: #ffffff;
+$text-tertiary: #6B7280;
+$gray-lightest: #F9FAFB;
+$gray-medium: #E2E8F0;
+$gray-border: #E5E7EB;
+$gray-dark: #374151;
+$transition-fast: all 0.2s ease;
+$border-radius-md: 6px;
+$border-radius-lg: 8px;
+
+.view-selector {
+  display: flex;
+  gap: 0.5rem;
+  border: 1px solid var(--border-primary, $gray-border);
+  border-radius: $border-radius-lg;
+  padding: 0.25rem;
+  background: var(--bg-tertiary, $gray-lightest);
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: $border-radius-md;
+    border: none;
+    transition: $transition-fast;
+    color: var(--text-tertiary, $text-tertiary);
+    font-weight: 500;
+    font-size: 0.875rem;
+    cursor: pointer;
+    background: transparent;
+
+    &:hover {
+      background: var(--bg-hover, $gray-medium);
+      color: var(--text-primary, $gray-dark);
+    }
+
+    &.active {
+      background: $lms-blue-dark;
+      color: $white;
+      font-weight: 600;
+      box-shadow: 0 2px 4px rgba($lms-blue-dark, 0.2);
+
+      .material-icons {
+        color: $white;
+      }
+    }
+  }
+}
+
+// ========== RESPONSIVE ==========
+@media (max-width: 768px) {
+  .view-selector {
+    flex-basis: 100%;
+  }
+}
+</style>
+
+<!-- Styles mode sombre non-scoped pour fonctionner avec data-theme -->
+<style lang="scss">
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+// ========== DARK MODE ==========
+html[data-theme="dark"] {
+  .view-selector {
+    background: var(--bg-tertiary);
+    border-color: var(--border-primary);
+
+    button {
+      color: rgba($white, 0.7);
+
+      &:hover {
+        background: rgba($lms-blue-light, 0.3);
+        color: $white;
+      }
+
+      &.active {
+        background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/calendar/EventDetailActions.vue
+++ b/src/components/calendar/EventDetailActions.vue
@@ -1,0 +1,237 @@
+<template>
+  <div class="modal-footer">
+    <div class="action-buttons">
+      <!-- Actions étudiant -->
+      <template v-if="userRole === 'student'">
+        <!-- Bouton rejoindre si visio active -->
+        <button
+          v-if="canJoinVisio"
+          @click="$emit('action', 'joinVisio')"
+          class="action-btn primary"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
+          </svg>
+          Rejoindre la visio
+        </button>
+        <!-- Message si visio programmée mais pas encore démarrée -->
+        <div v-else-if="isSeance && eventData.visio?.status === 'programmee'" class="waiting-message">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span>En attente du démarrage par l'enseignant</span>
+        </div>
+        <button
+          v-if="canStartEvaluation"
+          @click="$emit('action', 'startEvaluation')"
+          class="action-btn primary"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+          </svg>
+          Commencer l'évaluation
+        </button>
+        <button
+          v-if="isSeance"
+          @click="$emit('action', 'hideSeance')"
+          class="action-btn secondary"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+          </svg>
+          Masquer
+        </button>
+      </template>
+
+      <!-- Actions enseignant -->
+      <template v-if="userRole === 'teacher'">
+        <button
+          v-if="canActivateVisio"
+          @click="$emit('action', 'activateVisio')"
+          class="action-btn primary"
+        >
+          Activer la visio
+        </button>
+        <button
+          v-if="canStartVisio"
+          @click="$emit('action', 'startVisio')"
+          class="action-btn success"
+        >
+          Démarrer la visio
+        </button>
+        <button
+          v-if="canEndVisio"
+          @click="$emit('action', 'endVisio')"
+          class="action-btn danger"
+        >
+          Terminer la visio
+        </button>
+        <button
+          @click="$emit('action', 'viewParticipants')"
+          class="action-btn secondary"
+        >
+          Voir participants
+        </button>
+        <button
+          @click="$emit('action', 'exportAttendance')"
+          class="action-btn secondary"
+        >
+          Exporter présences
+        </button>
+      </template>
+
+      <!-- Actions admin/coordinateur -->
+      <template v-if="['admin', 'coordinator'].includes(userRole)">
+        <button
+          v-if="isSeance"
+          @click="$emit('action', 'toggleVisio')"
+          class="action-btn primary"
+        >
+          {{ (eventData.visio?.enabled || eventData.visio_enabled) ? 'Désactiver' : 'Activer' }} visio
+        </button>
+        <button
+          @click="$emit('action', 'delete')"
+          class="action-btn danger"
+        >
+          Supprimer
+        </button>
+      </template>
+
+      <!-- Voir détails complets (tous les rôles) -->
+      <button
+        @click="$emit('action', 'viewDetails')"
+        class="action-btn outline"
+      >
+        Voir détails complets
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Footer d'actions de la modale d'événement (H8 — décomposition EventDetailModal.vue).
+ * Sous-composant présentationnel : la visibilité des boutons dépend du rôle et des
+ * capacités (props calculées par le composable useEventDetail) ; chaque bouton émet
+ * `action` avec son type. CSS verbatim.
+ */
+defineProps({
+  userRole: { type: String, required: true },
+  isSeance: { type: Boolean, default: false },
+  eventData: { type: Object, required: true },
+  canJoinVisio: { type: Boolean, default: false },
+  canStartEvaluation: { type: Boolean, default: false },
+  canActivateVisio: { type: Boolean, default: false },
+  canStartVisio: { type: Boolean, default: false },
+  canEndVisio: { type: Boolean, default: false }
+})
+
+defineEmits(['action'])
+</script>
+
+<style scoped>
+.modal-footer {
+  padding: 1.5rem;
+  border-top: 1px solid var(--border-color, #e5e7eb);
+  background: var(--bg-secondary, #f9fafb);
+}
+
+.action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.action-btn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.action-btn.primary {
+  background: var(--color-primary, #3b82f6);
+  color: white;
+}
+
+.action-btn.primary:hover {
+  background: var(--color-primary-hover, #2563eb);
+}
+
+.action-btn.success {
+  background: #10b981;
+  color: white;
+}
+
+.action-btn.success:hover {
+  background: #059669;
+}
+
+.action-btn.danger {
+  background: #ef4444;
+  color: white;
+}
+
+.action-btn.danger:hover {
+  background: #dc2626;
+}
+
+.action-btn.secondary {
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-primary, #111827);
+  border: 1px solid var(--border-color, #e5e7eb);
+}
+
+.action-btn.secondary:hover {
+  background: var(--bg-primary, white);
+  border-color: var(--color-primary, #3b82f6);
+}
+
+.action-btn.outline {
+  background: transparent;
+  color: var(--color-primary, #3b82f6);
+  border: 1px solid var(--color-primary, #3b82f6);
+}
+
+.action-btn.outline:hover {
+  background: var(--color-primary, #3b82f6);
+  color: white;
+}
+
+/* Message d'attente pour l'étudiant */
+.waiting-message {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: #fef3c7;
+  color: #92400e;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.waiting-message svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .action-buttons {
+    flex-direction: column;
+  }
+
+  .action-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+</style>

--- a/src/components/calendar/EventDetailModal.vue
+++ b/src/components/calendar/EventDetailModal.vue
@@ -21,292 +21,48 @@
       <!-- Body -->
       <div class="modal-body">
         <!-- Détails séance -->
-        <div v-if="isSeance" class="details-section">
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-            </svg>
-            <div>
-              <p class="detail-label">Matière</p>
-              <p class="detail-value">{{ eventData.matiere?.nom || eventData.matiere_nom || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-            </svg>
-            <div>
-              <p class="detail-label">Enseignant</p>
-              <p class="detail-value">{{ eventData.enseignant?.nom || eventData.enseignant_nom || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
-            </svg>
-            <div>
-              <p class="detail-label">Classe</p>
-              <p class="detail-value">{{ eventData.classe?.nom || eventData.classe_nom || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
-            </svg>
-            <div>
-              <p class="detail-label">Date</p>
-              <p class="detail-value">{{ formatDate(event.start) }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div>
-              <p class="detail-label">Horaire</p>
-              <p class="detail-value">{{ formatTimeRange(event.start, event.end) }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 21v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21m0 0h4.5V3.545M12.75 21h7.5V10.75M2.25 21h1.5m18 0h-18M2.25 9l4.5-1.636M18.75 3l-1.5.545m0 6.205l3 1m1.5.5l-1.5-.5M6.75 7.364V3h-3v18m3-13.636l10.5-3.819" />
-            </svg>
-            <div>
-              <p class="detail-label">Salle</p>
-              <p class="detail-value">{{ eventData.programmation?.salle || eventData.salle || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <!-- Statut visio -->
-          <div v-if="eventData.visio?.enabled || eventData.visio_enabled" class="visio-section">
-            <h4 class="section-title">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                <path stroke-linecap="round" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
-              </svg>
-              Visioconférence
-            </h4>
-            <div class="detail-row">
-              <p class="detail-label">Statut</p>
-              <p class="detail-value">
-                <span :class="['visio-status', eventData.visio?.status || eventData.visio_status]">
-                  {{ formatVisioStatus(eventData.visio?.status || eventData.visio_status) }}
-                </span>
-              </p>
-            </div>
-            <div v-if="eventData.visio?.participants_count || eventData.visio_participants_count" class="detail-row">
-              <p class="detail-label">Participants</p>
-              <p class="detail-value">{{ eventData.visio?.participants_count || eventData.visio_participants_count }}</p>
-            </div>
-          </div>
-        </div>
+        <EventSeanceDetails
+          v-if="isSeance"
+          :event-data="eventData"
+          :formatted-date="formattedDate"
+          :formatted-time-range="formattedTimeRange"
+          :visio-status-text="visioStatusText"
+        />
 
         <!-- Détails évaluation -->
-        <div v-else class="details-section">
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
-            </svg>
-            <div>
-              <p class="detail-label">Matière</p>
-              <p class="detail-value">{{ eventData.matiere_nom || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
-            </svg>
-            <div>
-              <p class="detail-label">Classe</p>
-              <p class="detail-value">{{ eventData.classe_nom || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
-            </svg>
-            <div>
-              <p class="detail-label">Date</p>
-              <p class="detail-value">{{ formatDate(event.start) }}</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div>
-              <p class="detail-label">Durée</p>
-              <p class="detail-value">{{ eventData.duree_minutes || 0 }} minutes</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
-            </svg>
-            <div>
-              <p class="detail-label">Barème</p>
-              <p class="detail-value">{{ eventData.bareme || 20 }}/20</p>
-            </div>
-          </div>
-
-          <div class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0012 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 01-2.031.352 5.988 5.988 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 01-2.031.352 5.989 5.989 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971z" />
-            </svg>
-            <div>
-              <p class="detail-label">Coefficient</p>
-              <p class="detail-value">{{ eventData.coefficient || 1 }}</p>
-            </div>
-          </div>
-
-          <div v-if="eventData.questions_count" class="detail-row">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
-            </svg>
-            <div>
-              <p class="detail-label">Questions</p>
-              <p class="detail-value">{{ eventData.questions_count }}</p>
-            </div>
-          </div>
-
-          <!-- Résultat si soumis -->
-          <div v-if="eventData.student_submission?.note_sur_20 !== undefined && eventData.student_submission?.note_sur_20 !== null" class="result-section">
-            <h4 class="section-title">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
-              </svg>
-              Résultat
-            </h4>
-            <div class="result-score">
-              <span class="score-value">{{ eventData.student_submission.note_sur_20 }}</span>
-              <span class="score-total">/20</span>
-            </div>
-          </div>
-        </div>
+        <EventEvaluationDetails
+          v-else
+          :event-data="eventData"
+          :formatted-date="formattedDate"
+        />
       </div>
 
       <!-- Footer avec actions -->
-      <div class="modal-footer">
-        <div class="action-buttons">
-          <!-- Actions étudiant -->
-          <template v-if="userRole === 'student'">
-            <!-- Bouton rejoindre si visio active -->
-            <button
-              v-if="canJoinVisio"
-              @click="emitAction('joinVisio')"
-              class="action-btn primary"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                <path stroke-linecap="round" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
-              </svg>
-              Rejoindre la visio
-            </button>
-            <!-- Message si visio programmée mais pas encore démarrée -->
-            <div v-else-if="isSeance && eventData.visio?.status === 'programmee'" class="waiting-message">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <span>En attente du démarrage par l'enseignant</span>
-            </div>
-            <button
-              v-if="canStartEvaluation"
-              @click="emitAction('startEvaluation')"
-              class="action-btn primary"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
-              </svg>
-              Commencer l'évaluation
-            </button>
-            <button
-              v-if="isSeance"
-              @click="emitAction('hideSeance')"
-              class="action-btn secondary"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-              </svg>
-              Masquer
-            </button>
-          </template>
-
-          <!-- Actions enseignant -->
-          <template v-if="userRole === 'teacher'">
-            <button
-              v-if="canActivateVisio"
-              @click="emitAction('activateVisio')"
-              class="action-btn primary"
-            >
-              Activer la visio
-            </button>
-            <button
-              v-if="canStartVisio"
-              @click="emitAction('startVisio')"
-              class="action-btn success"
-            >
-              Démarrer la visio
-            </button>
-            <button
-              v-if="canEndVisio"
-              @click="emitAction('endVisio')"
-              class="action-btn danger"
-            >
-              Terminer la visio
-            </button>
-            <button
-              @click="emitAction('viewParticipants')"
-              class="action-btn secondary"
-            >
-              Voir participants
-            </button>
-            <button
-              @click="emitAction('exportAttendance')"
-              class="action-btn secondary"
-            >
-              Exporter présences
-            </button>
-          </template>
-
-          <!-- Actions admin/coordinateur -->
-          <template v-if="['admin', 'coordinator'].includes(userRole)">
-            <button
-              v-if="isSeance"
-              @click="emitAction('toggleVisio')"
-              class="action-btn primary"
-            >
-              {{ (eventData.visio?.enabled || eventData.visio_enabled) ? 'Désactiver' : 'Activer' }} visio
-            </button>
-            <button
-              @click="emitAction('delete')"
-              class="action-btn danger"
-            >
-              Supprimer
-            </button>
-          </template>
-
-          <!-- Voir détails complets (tous les rôles) -->
-          <button
-            @click="emitAction('viewDetails')"
-            class="action-btn outline"
-          >
-            Voir détails complets
-          </button>
-        </div>
-      </div>
+      <EventDetailActions
+        :user-role="userRole"
+        :is-seance="isSeance"
+        :event-data="eventData"
+        :can-join-visio="canJoinVisio"
+        :can-start-evaluation="canStartEvaluation"
+        :can-activate-visio="canActivateVisio"
+        :can-start-visio="canStartVisio"
+        :can-end-visio="canEndVisio"
+        @action="emitAction($event)"
+      />
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+/**
+ * Modale de détail d'un événement (H8 — orchestrateur ≤300). Computeds, capacités
+ * selon le rôle et formatage délégués au composable useEventDetail ; les sections
+ * (séance / évaluation / actions) sont rendues par des sous-composants présentationnels.
+ */
+import EventSeanceDetails from '@/components/calendar/EventSeanceDetails.vue'
+import EventEvaluationDetails from '@/components/calendar/EventEvaluationDetails.vue'
+import EventDetailActions from '@/components/calendar/EventDetailActions.vue'
+import { useEventDetail } from '@/composables/useEventDetail'
 
 const props = defineProps({
   event: {
@@ -321,128 +77,22 @@ const props = defineProps({
 
 const emit = defineEmits(['close', 'action'])
 
-const eventData = computed(() => props.event.extendedProps?.data || {})
-const isSeance = computed(() => props.event.extendedProps?.eventType === 'seance')
-
-const eventTitle = computed(() => {
-  return eventData.value.titre || props.event.title || 'Événement'
-})
-
-const statusClass = computed(() => {
-  if (isSeance.value) {
-    const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
-    if (visioStatus === 'active') return 'status-active'
-    if (visioStatus === 'programmee') return 'status-scheduled'
-    return 'status-ended'
-  } else {
-    const status = eventData.value.status
-    if (status === 'en_cours') return 'status-active'
-    if (status === 'terminee') return 'status-ended'
-    return 'status-scheduled'
-  }
-})
-
-const statusLabel = computed(() => {
-  if (isSeance.value) {
-    const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
-    return formatVisioStatus(visioStatus)
-  } else {
-    const status = eventData.value.status
-    if (status === 'en_cours') return 'En cours'
-    if (status === 'terminee') return 'Terminée'
-    return 'Programmée'
-  }
-})
-
-// Capacités selon le rôle
-const canJoinVisio = computed(() => {
-  // Debug log pour comprendre pourquoi le bouton n'apparaît pas
-  console.log('[EventDetailModal] canJoinVisio check:', {
-    isSeance: isSeance.value,
-    userRole: props.userRole,
-    visio: eventData.value.visio,
-    visioStatus: eventData.value.visio?.status
-  })
-
-  if (!isSeance.value) {
-    console.log('[EventDetailModal] Pas une séance')
-    return false
-  }
-  if (props.userRole !== 'student') {
-    console.log('[EventDetailModal] Pas un étudiant, role =', props.userRole)
-    return false
-  }
-
-  // Vérifier que la visio existe et est active
-  const visio = eventData.value.visio
-  if (!visio) {
-    console.log('[EventDetailModal] Pas de visio')
-    return false
-  }
-
-  // L'étudiant peut rejoindre seulement si la visio est en cours (status = 'active')
-  const canJoin = visio.status === 'active'
-  console.log('[EventDetailModal] canJoin =', canJoin, 'visio.status =', visio.status)
-  return canJoin
-})
-
-const canStartEvaluation = computed(() => {
-  if (isSeance.value || props.userRole !== 'student') return false
-  const status = eventData.value.status
-  return status !== 'terminee' && !eventData.value.student_submission?.note_sur_20
-})
-
-const canActivateVisio = computed(() => {
-  if (!isSeance.value || props.userRole !== 'teacher') return false
-  return !(eventData.value.visio?.enabled || eventData.value.visio_enabled)
-})
-
-const canStartVisio = computed(() => {
-  if (!isSeance.value || props.userRole !== 'teacher') return false
-  const visioEnabled = eventData.value.visio?.enabled || eventData.value.visio_enabled
-  const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
-  return visioEnabled && visioStatus !== 'active'
-})
-
-const canEndVisio = computed(() => {
-  if (!isSeance.value || props.userRole !== 'teacher') return false
-  const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
-  return visioStatus === 'active'
-})
-
-function formatDate(dateString) {
-  if (!dateString) return 'N/A'
-  const date = new Date(dateString)
-  return new Intl.DateTimeFormat('fr-FR', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
-  }).format(date)
-}
-
-function formatTimeRange(start, end) {
-  if (!start) return 'N/A'
-  const startTime = new Date(start).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
-  const endTime = end ? new Date(end).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' }) : ''
-  return endTime ? `${startTime} - ${endTime}` : startTime
-}
-
-function formatVisioStatus(status) {
-  const statusMap = {
-    'active': 'En direct',
-    'programmee': 'Programmée',
-    'terminee': 'Terminée'
-  }
-  return statusMap[status] || 'Non défini'
-}
-
-function emitAction(type) {
-  emit('action', {
-    type,
-    data: eventData.value
-  })
-}
+const {
+  eventData,
+  isSeance,
+  eventTitle,
+  statusClass,
+  statusLabel,
+  canJoinVisio,
+  canStartEvaluation,
+  canActivateVisio,
+  canStartVisio,
+  canEndVisio,
+  formattedDate,
+  formattedTimeRange,
+  visioStatusText,
+  emitAction
+} = useEventDetail(props, emit)
 </script>
 
 <style scoped>
@@ -541,204 +191,12 @@ function emitAction(type) {
   padding: 1.5rem;
 }
 
-.details-section {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.detail-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.detail-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  color: var(--color-primary, #3b82f6);
-  flex-shrink: 0;
-  margin-top: 0.125rem;
-}
-
-.detail-label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--text-secondary, #6b7280);
-  margin: 0 0 0.25rem 0;
-}
-
-.detail-value {
-  font-size: 0.875rem;
-  color: var(--text-primary, #111827);
-  margin: 0;
-}
-
-.visio-section,
-.result-section {
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--border-color, #e5e7eb);
-}
-
-.section-title {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text-primary, #111827);
-  margin: 0 0 1rem 0;
-}
-
-.visio-status {
-  display: inline-block;
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.visio-status.active {
-  background-color: #dcfce7;
-  color: #16a34a;
-}
-
-.visio-status.programmee {
-  background-color: #dbeafe;
-  color: #2563eb;
-}
-
-.visio-status.terminee {
-  background-color: #f3f4f6;
-  color: #6b7280;
-}
-
-.result-score {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--color-primary, #3b82f6);
-  text-align: center;
-  margin: 1rem 0;
-}
-
-.score-value {
-  color: var(--color-primary, #3b82f6);
-}
-
-.score-total {
-  font-size: 1.5rem;
-  color: var(--text-secondary, #6b7280);
-}
-
-.modal-footer {
-  padding: 1.5rem;
-  border-top: 1px solid var(--border-color, #e5e7eb);
-  background: var(--bg-secondary, #f9fafb);
-}
-
-.action-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.action-btn {
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.action-btn.primary {
-  background: var(--color-primary, #3b82f6);
-  color: white;
-}
-
-.action-btn.primary:hover {
-  background: var(--color-primary-hover, #2563eb);
-}
-
-.action-btn.success {
-  background: #10b981;
-  color: white;
-}
-
-.action-btn.success:hover {
-  background: #059669;
-}
-
-.action-btn.danger {
-  background: #ef4444;
-  color: white;
-}
-
-.action-btn.danger:hover {
-  background: #dc2626;
-}
-
-.action-btn.secondary {
-  background: var(--bg-secondary, #f3f4f6);
-  color: var(--text-primary, #111827);
-  border: 1px solid var(--border-color, #e5e7eb);
-}
-
-.action-btn.secondary:hover {
-  background: var(--bg-primary, white);
-  border-color: var(--color-primary, #3b82f6);
-}
-
-.action-btn.outline {
-  background: transparent;
-  color: var(--color-primary, #3b82f6);
-  border: 1px solid var(--color-primary, #3b82f6);
-}
-
-.action-btn.outline:hover {
-  background: var(--color-primary, #3b82f6);
-  color: white;
-}
-
-/* Message d'attente pour l'étudiant */
-.waiting-message {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: #fef3c7;
-  color: #92400e;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-}
-
-.waiting-message svg {
-  width: 1.25rem;
-  height: 1.25rem;
-  flex-shrink: 0;
-}
-
 /* Responsive */
 @media (max-width: 640px) {
   .modal-container {
     max-width: 100%;
     max-height: 100vh;
     border-radius: 0;
-  }
-
-  .action-buttons {
-    flex-direction: column;
-  }
-
-  .action-btn {
-    width: 100%;
-    justify-content: center;
   }
 }
 </style>

--- a/src/components/calendar/EventEvaluationDetails.vue
+++ b/src/components/calendar/EventEvaluationDetails.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="details-section">
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+      </svg>
+      <div>
+        <p class="detail-label">Matière</p>
+        <p class="detail-value">{{ eventData.matiere_nom || 'N/A' }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+      </svg>
+      <div>
+        <p class="detail-label">Classe</p>
+        <p class="detail-value">{{ eventData.classe_nom || 'N/A' }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+      </svg>
+      <div>
+        <p class="detail-label">Date</p>
+        <p class="detail-value">{{ formattedDate }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <div>
+        <p class="detail-label">Durée</p>
+        <p class="detail-value">{{ eventData.duree_minutes || 0 }} minutes</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+      </svg>
+      <div>
+        <p class="detail-label">Barème</p>
+        <p class="detail-value">{{ eventData.bareme || 20 }}/20</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0012 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 01-2.031.352 5.988 5.988 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0l2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 01-2.031.352 5.989 5.989 0 01-2.031-.352c-.483-.174-.711-.703-.59-1.202L5.25 4.971z" />
+      </svg>
+      <div>
+        <p class="detail-label">Coefficient</p>
+        <p class="detail-value">{{ eventData.coefficient || 1 }}</p>
+      </div>
+    </div>
+
+    <div v-if="eventData.questions_count" class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
+      </svg>
+      <div>
+        <p class="detail-label">Questions</p>
+        <p class="detail-value">{{ eventData.questions_count }}</p>
+      </div>
+    </div>
+
+    <!-- Résultat si soumis -->
+    <div v-if="eventData.student_submission?.note_sur_20 !== undefined && eventData.student_submission?.note_sur_20 !== null" class="result-section">
+      <h4 class="section-title">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
+        </svg>
+        Résultat
+      </h4>
+      <div class="result-score">
+        <span class="score-value">{{ eventData.student_submission.note_sur_20 }}</span>
+        <span class="score-total">/20</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Section "détails évaluation" de la modale d'événement (H8 — décomposition
+ * EventDetailModal.vue). Sous-composant présentationnel : reçoit `eventData` et la
+ * date déjà formatée. CSS verbatim.
+ */
+defineProps({
+  eventData: { type: Object, required: true },
+  formattedDate: { type: String, default: 'N/A' }
+})
+</script>
+
+<style scoped>
+.details-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detail-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.detail-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-primary, #3b82f6);
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.detail-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary, #6b7280);
+  margin: 0 0 0.25rem 0;
+}
+
+.detail-value {
+  font-size: 0.875rem;
+  color: var(--text-primary, #111827);
+  margin: 0;
+}
+
+.visio-section,
+.result-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color, #e5e7eb);
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary, #111827);
+  margin: 0 0 1rem 0;
+}
+
+.result-score {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--color-primary, #3b82f6);
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.score-value {
+  color: var(--color-primary, #3b82f6);
+}
+
+.score-total {
+  font-size: 1.5rem;
+  color: var(--text-secondary, #6b7280);
+}
+</style>

--- a/src/components/calendar/EventSeanceDetails.vue
+++ b/src/components/calendar/EventSeanceDetails.vue
@@ -1,0 +1,174 @@
+<template>
+  <div class="details-section">
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+      </svg>
+      <div>
+        <p class="detail-label">Matière</p>
+        <p class="detail-value">{{ eventData.matiere?.nom || eventData.matiere_nom || 'N/A' }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+      </svg>
+      <div>
+        <p class="detail-label">Enseignant</p>
+        <p class="detail-value">{{ eventData.enseignant?.nom || eventData.enseignant_nom || 'N/A' }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+      </svg>
+      <div>
+        <p class="detail-label">Classe</p>
+        <p class="detail-value">{{ eventData.classe?.nom || eventData.classe_nom || 'N/A' }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+      </svg>
+      <div>
+        <p class="detail-label">Date</p>
+        <p class="detail-value">{{ formattedDate }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <div>
+        <p class="detail-label">Horaire</p>
+        <p class="detail-value">{{ formattedTimeRange }}</p>
+      </div>
+    </div>
+
+    <div class="detail-row">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="detail-icon">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 21v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21m0 0h4.5V3.545M12.75 21h7.5V10.75M2.25 21h1.5m18 0h-18M2.25 9l4.5-1.636M18.75 3l-1.5.545m0 6.205l3 1m1.5.5l-1.5-.5M6.75 7.364V3h-3v18m3-13.636l10.5-3.819" />
+      </svg>
+      <div>
+        <p class="detail-label">Salle</p>
+        <p class="detail-value">{{ eventData.programmation?.salle || eventData.salle || 'N/A' }}</p>
+      </div>
+    </div>
+
+    <!-- Statut visio -->
+    <div v-if="eventData.visio?.enabled || eventData.visio_enabled" class="visio-section">
+      <h4 class="section-title">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" d="M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z" />
+        </svg>
+        Visioconférence
+      </h4>
+      <div class="detail-row">
+        <p class="detail-label">Statut</p>
+        <p class="detail-value">
+          <span :class="['visio-status', eventData.visio?.status || eventData.visio_status]">
+            {{ visioStatusText }}
+          </span>
+        </p>
+      </div>
+      <div v-if="eventData.visio?.participants_count || eventData.visio_participants_count" class="detail-row">
+        <p class="detail-label">Participants</p>
+        <p class="detail-value">{{ eventData.visio?.participants_count || eventData.visio_participants_count }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Section "détails séance" de la modale d'événement (H8 — décomposition
+ * EventDetailModal.vue). Sous-composant présentationnel : reçoit `eventData` et les
+ * valeurs déjà formatées (date, plage horaire, libellé statut visio). CSS verbatim.
+ */
+defineProps({
+  eventData: { type: Object, required: true },
+  formattedDate: { type: String, default: 'N/A' },
+  formattedTimeRange: { type: String, default: 'N/A' },
+  visioStatusText: { type: String, default: 'Non défini' }
+})
+</script>
+
+<style scoped>
+.details-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.detail-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.detail-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-primary, #3b82f6);
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.detail-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-secondary, #6b7280);
+  margin: 0 0 0.25rem 0;
+}
+
+.detail-value {
+  font-size: 0.875rem;
+  color: var(--text-primary, #111827);
+  margin: 0;
+}
+
+.visio-section,
+.result-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color, #e5e7eb);
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary, #111827);
+  margin: 0 0 1rem 0;
+}
+
+.visio-status {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.visio-status.active {
+  background-color: #dcfce7;
+  color: #16a34a;
+}
+
+.visio-status.programmee {
+  background-color: #dbeafe;
+  color: #2563eb;
+}
+
+.visio-status.terminee {
+  background-color: #f3f4f6;
+  color: #6b7280;
+}
+</style>

--- a/src/components/calendar/UniversalCalendar.vue
+++ b/src/components/calendar/UniversalCalendar.vue
@@ -1,59 +1,16 @@
 <template>
   <div class="calendar-container">
-    <!-- ========== NAVIGATION CARD ========== -->
-    <div class="navigation-card card">
-      <div class="navigation-controls">
-        <button class="nav-button" @click="previousMonth()" title="Mois précédent">
-          <i class="material-icons">chevron_left</i>
-        </button>
-
-        <div class="current-month">
-          <i class="material-icons">calendar_today</i>
-          <span>{{ currentMonthLabel }}</span>
-        </div>
-
-        <button class="nav-button" @click="nextMonth()" title="Mois suivant">
-          <i class="material-icons">chevron_right</i>
-        </button>
-
-        <button class="today-button" @click="goToToday()" title="Revenir à aujourd'hui">
-          <i class="material-icons">today</i>
-          Aujourd'hui
-        </button>
-
-        <button class="refresh-button" @click="refreshData()" :disabled="refreshing" title="Actualiser les donnees depuis KLASSCI">
-          <i class="material-icons" :class="{ 'spin': refreshing }">sync</i>
-          {{ refreshing ? 'Chargement...' : 'Actualiser' }}
-        </button>
-
-        <div class="view-selector">
-          <button
-            :class="{ active: currentView === 'dayGridMonth' }"
-            @click="changeView('dayGridMonth')"
-            title="Vue mensuelle"
-          >
-            <i class="material-icons">view_module</i>
-            Mois
-          </button>
-          <button
-            :class="{ active: currentView === 'timeGridWeek' }"
-            @click="changeView('timeGridWeek')"
-            title="Vue hebdomadaire"
-          >
-            <i class="material-icons">view_week</i>
-            Semaine
-          </button>
-          <button
-            :class="{ active: currentView === 'timeGridDay' }"
-            @click="changeView('timeGridDay')"
-            title="Vue journalière"
-          >
-            <i class="material-icons">view_day</i>
-            Jour
-          </button>
-        </div>
-      </div>
-    </div>
+    <!-- ========== NAVIGATION (H8 : extraite en sous-composant) ========== -->
+    <CalendarNavigation
+      :current-month-label="currentMonthLabel"
+      :current-view="currentView"
+      :refreshing="refreshing"
+      @previous="previousMonth"
+      @next="nextMonth"
+      @today="goToToday"
+      @refresh="refreshData"
+      @change-view="changeView"
+    />
 
     <!-- ========== FILTERS CARD (#28bis : extraite en sous-composant) ========== -->
     <CalendarFilters
@@ -73,43 +30,15 @@
       @apply-preset="applyDateRangePreset"
     />
 
-    <!-- ========== CALENDAR CARD ========== -->
-    <div class="calendar-card card">
-      <ContentLoader v-if="loading" text="Chargement du calendrier..." />
+    <!-- ========== CALENDAR CARD (H8 : extraite en sous-composant) ========== -->
+    <CalendarView
+      ref="calendarViewRef"
+      :options="calendarOptions"
+      :loading="loading"
+    />
 
-      <div v-else class="calendar-wrapper">
-        <FullCalendar
-          ref="calendarRef"
-          :options="calendarOptions"
-        />
-      </div>
-    </div>
-
-    <!-- ========== LEGEND CARD ========== -->
-    <div class="legend-card card">
-      <h3>
-        <i class="material-icons">info</i>
-        Légende
-      </h3>
-      <div class="legend-items">
-        <div class="legend-item">
-          <div class="color-dot" style="background: #2563eb; /* LMS blue (séances) */"></div>
-          <span>Séances</span>
-        </div>
-        <div class="legend-item">
-          <div class="color-dot" style="background: #10b981"></div>
-          <span>Visio active</span>
-        </div>
-        <div class="legend-item">
-          <div class="color-dot" style="background: #ea580c; /* LMS orange (évaluations) */"></div>
-          <span>Évaluations</span>
-        </div>
-        <div class="legend-item">
-          <div class="color-dot" style="background: #ef4444"></div>
-          <span>Urgent (&lt; 24h)</span>
-        </div>
-      </div>
-    </div>
+    <!-- ========== LEGEND CARD (H8 : extraite en sous-composant) ========== -->
+    <CalendarLegend />
 
     <!-- Modal de détails -->
     <EventDetailModal
@@ -123,19 +52,29 @@
 </template>
 
 <script setup>
+/**
+ * Calendrier unifié (séances + évaluations) — orchestrateur (H8 ≤300).
+ * La donnée et le chargement vivent dans useCalendarEvents (#28bis) ; l'état de la
+ * vue FullCalendar (options, navigation, sync) dans useCalendarView (H8). L'UI est
+ * composée de CalendarNavigation, CalendarFilters, CalendarView, CalendarLegend et
+ * EventDetailModal. La vue ne garde que le câblage filtres ↔ rôle.
+ *
+ * Dette pré-existante conservée à l'identique : `router` (useRouter) reste déclaré
+ * sans usage (dead var d'origine) ; la règle media `.filters-content` du CSS scoped
+ * ne cible plus rien depuis l'extraction de CalendarFilters (#28bis) — conservée.
+ */
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import FullCalendar from '@fullcalendar/vue3'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import timeGridPlugin from '@fullcalendar/timegrid'
-import interactionPlugin from '@fullcalendar/interaction'
-import frLocale from '@fullcalendar/core/locales/fr'
-import EventDetailModal from './EventDetailModal.vue'
+import CalendarNavigation from './CalendarNavigation.vue'
 import CalendarFilters from './CalendarFilters.vue'
-import ContentLoader from '@/components/common/ContentLoader.vue'
+import CalendarView from './CalendarView.vue'
+import CalendarLegend from './CalendarLegend.vue'
+import EventDetailModal from './EventDetailModal.vue'
 // #28bis : données + chargement extraits dans le composable (couleurs/urgence/bornes
 // pures dans @/utils/calendar, testées dans tests/unit/calendar.test.js)
 import { useCalendarEvents } from '@/composables/useCalendarEvents'
+// H8 : état de la vue (options FullCalendar, navigation, sync impérative)
+import { useCalendarView } from '@/composables/useCalendarView'
 
 const props = defineProps({
   userRole: {
@@ -152,9 +91,7 @@ const props = defineProps({
 const emit = defineEmits(['event-action'])
 
 const router = useRouter()
-const calendarRef = ref(null)
-const currentView = ref('dayGridMonth')
-const currentDate = ref(new Date())  // Pour forcer la réactivité du label
+const calendarViewRef = ref(null)
 const selectedEvent = ref(null)
 
 // Filtres
@@ -170,11 +107,6 @@ const { events, matieres, classes, enseignants, loading, refreshing, loadEvents,
   getUserId: () => props.userId,
   eventTypeFilter,
   dateRangePreset
-})
-
-// Computed - Label mois courant
-const currentMonthLabel = computed(() => {
-  return currentDate.value.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
 })
 
 // Filtres conditionnels selon le rôle
@@ -217,106 +149,16 @@ const filteredEvents = computed(() => {
   return filtered
 })
 
-// Configuration FullCalendar
-const calendarOptions = computed(() => ({
-  plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
-  initialView: currentView.value,
-  initialDate: new Date(), // Forcer le calendrier à afficher le mois actuel
-  locale: frLocale,
-  headerToolbar: {
-    left: 'prev,next today',
-    center: 'title',
-    right: ''
-  },
-  buttonText: {
-    today: "Aujourd'hui",
-    month: 'Mois',
-    week: 'Semaine',
-    day: 'Jour'
-  },
-  events: filteredEvents.value,
-  eventClick: handleEventClick,
-  dateClick: handleDateClick,
-  datesSet: (dateInfo) => {
-    // Utiliser le milieu de la plage visible pour déterminer le mois affiché
-    // (dateInfo.start peut être un jour du mois précédent en vue mensuelle)
-    const mid = new Date((dateInfo.start.getTime() + dateInfo.end.getTime()) / 2)
-    currentDate.value = mid
-  },
-  nowIndicator: true,
-  slotMinTime: '07:00:00',
-  slotMaxTime: '20:00:00',
-  allDaySlot: false,
-  height: 'auto',
-  eventTimeFormat: {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  },
-  slotLabelFormat: {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  },
-  eventClassNames: (arg) => {
-    const classes = ['event-item']
-    if (arg.event.extendedProps.eventType) {
-      classes.push(`event-${arg.event.extendedProps.eventType}`)
-    }
-    if (arg.event.extendedProps.isUrgent) {
-      classes.push('event-urgent')
-    }
-    return classes
-  }
-}))
+// État de la vue FullCalendar (options, navigation, sync) délégué au composable (H8)
+const { currentView, currentMonthLabel, calendarOptions, changeView, previousMonth, nextMonth, goToToday } = useCalendarView({
+  calendarRef: calendarViewRef,
+  filteredEvents,
+  onEventClick: (event) => { selectedEvent.value = event }
+})
 
 // Charger les données
 function applyDateRangePreset() {
   loadEvents()
-}
-
-function changeView(view) {
-  currentView.value = view
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.changeView(view)
-  }
-}
-
-function previousMonth() {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.prev()
-  }
-}
-
-function nextMonth() {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.next()
-  }
-}
-
-function goToToday() {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.today()
-  }
-}
-
-function handleEventClick(info) {
-  selectedEvent.value = info.event
-}
-
-function handleDateClick(info) {
-  // Naviguer vers la vue jour si clic sur une date en vue mois
-  if (currentView.value === 'dayGridMonth') {
-    const calendarApi = calendarRef.value?.getApi()
-    if (calendarApi) {
-      calendarApi.changeView('timeGridDay', info.dateStr)
-      currentView.value = 'timeGridDay'
-    }
-  }
 }
 
 function handleEventAction(action) {
@@ -343,19 +185,6 @@ watch([eventTypeFilter], () => {
   loadEvents()
 })
 
-// IMPORTANT: Forcer FullCalendar a mettre a jour quand les evenements changent
-watch(filteredEvents, (newEvents) => {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    // Supprimer tous les evenements existants
-    calendarApi.removeAllEvents()
-    // Ajouter les nouveaux evenements
-    newEvents.forEach(event => {
-      calendarApi.addEvent(event)
-    })
-  }
-}, { deep: true, immediate: true })
-
 // Exposer les methodes pour le parent (force le bypass cache KLASSCI des 2 sources)
 async function refreshEvents() {
   await refreshData()
@@ -367,411 +196,10 @@ defineExpose({
 </script>
 
 <style lang="scss" scoped>
-// Couleurs LMS
-$lms-blue: #2563eb;
-$lms-blue-light: #3b82f6;
-$lms-blue-dark: #1e3a8a;
-$lms-orange: #ea580c;
-$lms-green: #10b981;
-$lms-red: #ef4444;
-
-// Couleurs système
-$white: #ffffff;
-$text-primary: #1E293B;
-$text-secondary: #64748B;
-$text-tertiary: #6B7280;
-$gray-lightest: #F9FAFB;
-$gray-light: #F8FAFC;
-$gray-medium: #E2E8F0;
-$gray-border: #E5E7EB;
-$gray-dark: #374151;
-
-// Ombres
-$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
-$shadow-medium: 0 2px 8px rgba(0, 0, 0, 0.1);
-$shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
-
-// Transitions
-$transition-fast: all 0.2s ease;
-
-// Bordures
-$border-radius-sm: 4px;
-$border-radius-md: 6px;
-$border-radius-lg: 8px;
-$border-radius-xl: 12px;
-$border-radius-full: 9999px;
-
 .calendar-container {
   padding: 2rem;
   max-width: 1600px;
   margin: 0 auto;
-}
-
-// ========== CARD BASE ==========
-.card {
-  background: var(--card-bg, $white);
-  border: 1px solid var(--card-border, transparent);
-  border-radius: $border-radius-lg;
-  box-shadow: var(--card-shadow, $shadow-light);
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
-
-// ========== NAVIGATION ==========
-.navigation-card {
-  padding: 1rem 1.5rem;
-
-  .navigation-controls {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-
-    .nav-button {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 40px;
-      height: 40px;
-      border: 1px solid var(--border-primary, $gray-border);
-      border-radius: $border-radius-md;
-      background: transparent;
-      color: var(--text-primary, $text-primary);
-      cursor: pointer;
-      transition: $transition-fast;
-
-      .material-icons {
-        font-size: 1.5rem;
-        color: var(--text-primary, $text-primary);
-      }
-
-      &:hover {
-        background: var(--bg-hover, $gray-light);
-        border-color: $lms-blue;
-        color: $lms-blue;
-
-        .material-icons {
-          color: $lms-blue;
-        }
-      }
-    }
-
-    .current-month {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.75rem;
-      font-size: 1.5rem;
-      font-weight: 600;
-      color: $lms-blue;
-      text-transform: capitalize;
-
-      .material-icons {
-        color: $lms-blue;
-      }
-    }
-
-    .today-button {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 1px solid $lms-blue;
-      color: $lms-blue;
-      padding: 0.5rem 1rem;
-      border-radius: $border-radius-md;
-      background: transparent;
-      transition: $transition-fast;
-      font-weight: 500;
-      cursor: pointer;
-
-      &:hover {
-        background: $lms-blue;
-        color: $white;
-
-        .material-icons {
-          color: $white;
-        }
-      }
-    }
-
-    .refresh-button {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 1px solid #10b981;
-      color: #10b981;
-      padding: 0.5rem 1rem;
-      border-radius: $border-radius-md;
-      background: transparent;
-      transition: $transition-fast;
-      font-weight: 500;
-      cursor: pointer;
-
-      &:hover:not(:disabled) {
-        background: #10b981;
-        color: $white;
-
-        .material-icons {
-          color: $white;
-        }
-      }
-
-      &:disabled {
-        opacity: 0.7;
-        cursor: not-allowed;
-      }
-
-      .material-icons.spin {
-        animation: spin 1s linear infinite;
-      }
-    }
-
-    @keyframes spin {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
-    }
-
-    .view-selector {
-      display: flex;
-      gap: 0.5rem;
-      border: 1px solid var(--border-primary, $gray-border);
-      border-radius: $border-radius-lg;
-      padding: 0.25rem;
-      background: var(--bg-tertiary, $gray-lightest);
-
-      button {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 1rem;
-        border-radius: $border-radius-md;
-        border: none;
-        transition: $transition-fast;
-        color: var(--text-tertiary, $text-tertiary);
-        font-weight: 500;
-        font-size: 0.875rem;
-        cursor: pointer;
-        background: transparent;
-
-        &:hover {
-          background: var(--bg-hover, $gray-medium);
-          color: var(--text-primary, $gray-dark);
-        }
-
-        &.active {
-          background: $lms-blue-dark;
-          color: $white;
-          font-weight: 600;
-          box-shadow: 0 2px 4px rgba($lms-blue-dark, 0.2);
-
-          .material-icons {
-            color: $white;
-          }
-        }
-      }
-    }
-  }
-}
-
-// ========== CALENDAR CARD ==========
-.calendar-card {
-  padding: 0;
-  overflow: hidden;
-}
-
-.calendar-wrapper {
-  padding: 1rem;
-}
-
-.loading-container {
-  padding: 4rem;
-  text-align: center;
-  color: var(--text-tertiary, $text-tertiary);
-
-  .material-icons {
-    font-size: 3rem;
-    color: $lms-blue;
-    margin-bottom: 1rem;
-
-    &.spin {
-      animation: spin 1s linear infinite;
-    }
-  }
-
-  p {
-    font-size: 1rem;
-    color: var(--text-secondary, $text-secondary);
-  }
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-// ========== LEGEND ==========
-.legend-card {
-  h3 {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin: 0 0 1rem 0;
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: $lms-blue;
-
-    .material-icons {
-      color: $lms-blue;
-      font-size: 1.5rem;
-    }
-  }
-
-  .legend-items {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-  }
-
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    background: var(--bg-tertiary, $gray-lightest);
-    border-radius: $border-radius-lg;
-    border: 1px solid var(--border-primary, $gray-border);
-
-    .color-dot {
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-    }
-
-    span {
-      font-size: 0.875rem;
-      color: var(--text-primary, $gray-dark);
-      font-weight: 500;
-    }
-  }
-}
-
-// ========== FULLCALENDAR CUSTOM STYLES ==========
-:deep(.fc) {
-  font-family: inherit;
-
-  .fc-toolbar-title {
-    display: none;
-  }
-
-  .fc-header-toolbar {
-    margin-bottom: 1rem;
-  }
-
-  .fc-button-primary {
-    background: $lms-blue;
-    border-color: $lms-blue;
-    transition: $transition-fast;
-
-    &:hover:not(:disabled) {
-      background: $lms-blue-light;
-      border-color: $lms-blue-light;
-    }
-
-    &:focus {
-      box-shadow: 0 0 0 3px rgba($lms-blue, 0.2);
-    }
-  }
-
-  // En-tête des jours (lun, mar, mer, etc.) - Couleur sidebar
-  .fc-col-header-cell {
-    background: linear-gradient(180deg, #0052cc 0%, #0747a6 100%);
-    border-color: #0747a6;
-
-    .fc-col-header-cell-cushion {
-      color: $white;
-      font-weight: 600;
-      padding: 0.75rem 0.5rem;
-    }
-  }
-
-  // Cases des jours
-  .fc-daygrid-day,
-  .fc-timegrid-slot {
-    background: var(--bg-secondary, $white);
-    border-color: var(--border-primary, $gray-border);
-  }
-
-  // Numéros des jours
-  .fc-daygrid-day-number,
-  .fc-timegrid-slot-label {
-    color: var(--text-primary, $text-primary);
-    padding: 0.5rem;
-  }
-
-  // Jour actuel (aujourd'hui)
-  .fc-daygrid-day.fc-day-today {
-    background: linear-gradient(135deg, rgba($lms-blue, 0.15) 0%, rgba($lms-blue, 0.08) 100%);
-    border: 2px solid $lms-blue;
-
-    .fc-daygrid-day-number {
-      color: $lms-blue;
-      font-weight: 700;
-    }
-  }
-
-  // Ligne de l'heure actuelle (time grid)
-  .fc-timegrid-now-indicator-line {
-    border-color: $lms-blue;
-    border-width: 2px;
-  }
-
-  .fc-timegrid-now-indicator-arrow {
-    border-color: $lms-blue;
-  }
-
-  .fc-timegrid-slot {
-    height: 3rem;
-  }
-
-  // Couleurs des événements
-  .event-seance {
-    background: #2563eb; /* LMS blue (séances) */;
-    border-color: #2563eb; /* LMS blue */
-  }
-
-  .event-evaluation {
-    background: #06b6d4; /* Cyan (évaluations) */;
-    border-color: #06b6d4; /* Cyan */
-  }
-
-  .event-urgent {
-    background: #ef4444 !important;
-    border-color: #ef4444 !important;
-    animation: pulse 2s infinite;
-  }
-
-  // Événements en mode clair
-  .fc-event {
-    cursor: pointer;
-    transition: $transition-fast;
-
-    &:hover {
-      opacity: 0.9;
-      transform: translateY(-1px);
-      box-shadow: $shadow-hover;
-    }
-  }
-}
-
-@keyframes pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.8;
-  }
 }
 
 // ========== RESPONSIVE ==========
@@ -780,21 +208,9 @@ $border-radius-full: 9999px;
     padding: 1rem;
   }
 
-  .navigation-controls {
-    flex-wrap: wrap;
-
-    .current-month {
-      order: -1;
-      flex-basis: 100%;
-      margin-bottom: 1rem;
-    }
-
-    .today-button,
-    .view-selector {
-      flex-basis: 100%;
-    }
-  }
-
+  // Dette pré-existante : depuis l'extraction de CalendarFilters (#28bis), ce bloc
+  // scoped ne cible plus le DOM de l'enfant (`.filters-content` vit dans CalendarFilters).
+  // Conservé verbatim, sans correction.
   .filters-content {
     grid-template-columns: 1fr !important;
 
@@ -806,349 +222,7 @@ $border-radius-full: 9999px;
 }
 </style>
 
-<!-- Styles mode sombre non-scoped pour fonctionner avec data-theme -->
+<!-- Styles mode sombre non-scoped (coque + filtres) — relocalisés dans un partial -->
 <style lang="scss">
-// Couleurs LMS pour le mode sombre
-$lms-blue: #2563eb;
-$lms-blue-light: #3b82f6;
-$lms-blue-dark: #1e3a8a;
-$lms-orange: #ea580c;
-$lms-green: #10b981;
-$lms-red: #ef4444;
-$white: #ffffff;
-
-// ========== DARK MODE ==========
-html[data-theme="dark"] {
-  .calendar-container {
-    background: transparent;
-  }
-
-  // Cards en mode sombre
-  .card {
-    background: var(--card-bg) !important;
-    border: 1px solid var(--card-border) !important;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
-
-  // Navigation en mode sombre
-  .navigation-card {
-    .nav-button {
-      border-color: rgba($lms-blue-light, 0.5);
-      color: $white;
-      background: transparent;
-
-      .material-icons {
-        color: $white !important;
-      }
-
-      &:hover {
-        background: rgba($lms-blue-light, 0.3);
-        border-color: $lms-blue-light;
-        color: $lms-blue-light;
-
-        .material-icons {
-          color: $lms-blue-light !important;
-        }
-      }
-    }
-
-    .current-month {
-      color: $white;
-
-      .material-icons {
-        color: $lms-blue-light;
-      }
-    }
-
-    .today-button {
-      border-color: $lms-blue-light;
-      color: $white;
-      background: rgba($lms-blue-light, 0.2);
-
-      &:hover {
-        background: $lms-blue-light;
-        color: $white;
-
-        .material-icons {
-          color: $white;
-        }
-      }
-    }
-
-    .view-selector {
-      background: var(--bg-tertiary);
-      border-color: var(--border-primary);
-
-      button {
-        color: rgba($white, 0.7);
-
-        &:hover {
-          background: rgba($lms-blue-light, 0.3);
-          color: $white;
-        }
-
-        &.active {
-          background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
-          color: $white;
-
-          .material-icons {
-            color: $white;
-          }
-        }
-      }
-    }
-  }
-
-  // Filtres en mode sombre
-  .filters-card {
-    .filters-title {
-      .material-icons {
-        color: $lms-blue-light;
-      }
-
-      h3 {
-        color: $white;
-      }
-    }
-
-    .reset-button {
-      color: rgba($white, 0.7);
-
-      &:hover {
-        background: rgba($lms-blue-light, 0.3);
-        color: $lms-blue-light;
-      }
-    }
-
-    .filter-field {
-      label {
-        color: rgba($white, 0.8);
-
-        .icon-label {
-          color: $lms-blue-light;
-        }
-      }
-
-      select {
-        background: var(--input-bg);
-        border-color: var(--input-border);
-        color: var(--input-text);
-
-        &:hover {
-          border-color: $lms-blue-light;
-        }
-
-        &:focus {
-          border-color: $lms-blue-light;
-          box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.2);
-        }
-
-        option {
-          background: var(--bg-primary);
-          color: var(--text-primary);
-        }
-      }
-    }
-
-    .filter-count {
-      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
-      color: $white;
-
-      .material-icons {
-        color: $white;
-      }
-    }
-  }
-
-  // Calendrier en mode sombre
-  .calendar-card {
-    background: var(--card-bg) !important;
-  }
-
-  .loading-container {
-    color: rgba($white, 0.7);
-
-    .material-icons {
-      color: $lms-blue-light;
-    }
-
-    p {
-      color: rgba($white, 0.7);
-    }
-  }
-
-  // Légende en mode sombre
-  .legend-card {
-    h3 {
-      color: $white;
-
-      .material-icons {
-        color: $lms-blue-light;
-      }
-    }
-
-    .legend-item {
-      background: var(--bg-tertiary);
-      border-color: var(--border-primary);
-
-      span {
-        color: var(--text-primary);
-      }
-    }
-  }
-
-  // FullCalendar en mode sombre
-  .fc {
-    color: $white;
-
-    .fc-button-primary {
-      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
-      border-color: $lms-blue-light;
-      color: $white;
-
-      &:hover:not(:disabled) {
-        background: $lms-blue;
-        border-color: $lms-blue;
-      }
-
-      &:focus {
-        box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.3);
-      }
-    }
-
-    .fc-col-header-cell {
-      background: linear-gradient(180deg, #0a1929 0%, #001e3c 100%) !important;
-      border-color: #001e3c !important;
-
-      .fc-col-header-cell-cushion {
-        color: $white !important;
-        font-weight: 600;
-      }
-    }
-
-    .fc-daygrid-day,
-    .fc-timegrid-slot {
-      background: var(--bg-secondary) !important;
-      border-color: var(--border-primary) !important;
-    }
-
-    .fc-daygrid-day-number,
-    .fc-timegrid-slot-label {
-      color: var(--text-primary) !important;
-    }
-
-    .fc-daygrid-day.fc-day-today {
-      background: linear-gradient(135deg, rgba($lms-blue-light, 0.3) 0%, rgba($lms-blue-light, 0.15) 100%) !important;
-      border: 2px solid $lms-blue-light !important;
-
-      .fc-daygrid-day-number {
-        color: $lms-blue-light !important;
-        font-weight: 700;
-      }
-    }
-
-    .fc-daygrid-day.fc-day-other {
-      background: var(--bg-tertiary) !important;
-      opacity: 0.6;
-
-      .fc-daygrid-day-number {
-        color: var(--text-tertiary) !important;
-      }
-    }
-
-    .fc-timegrid-now-indicator-line {
-      border-color: $lms-blue-light;
-    }
-
-    .fc-timegrid-now-indicator-arrow {
-      border-color: $lms-blue-light;
-    }
-
-    // Événements en mode sombre
-    .fc-event {
-      border-width: 2px;
-      font-weight: 500;
-    }
-
-    .event-seance {
-      background: rgba($lms-blue, 0.9);
-      border-color: $lms-blue;
-      color: $white;
-
-      &:hover {
-        background: $lms-blue;
-        box-shadow: 0 2px 8px rgba($lms-blue, 0.5);
-      }
-    }
-
-    .event-evaluation {
-      background: rgba(#06b6d4, 0.9);
-      border-color: #06b6d4;
-      color: $white;
-      font-weight: 600;
-
-      &:hover {
-        background: #06b6d4;
-        box-shadow: 0 2px 8px rgba(#06b6d4, 0.5);
-      }
-    }
-
-    .event-urgent {
-      background: #ef4444 !important;
-      border-color: #ef4444 !important;
-      color: $white !important;
-      animation: pulse-urgent-dark 2s infinite;
-
-      &:hover {
-        box-shadow: 0 2px 8px rgba(#ef4444, 0.5);
-      }
-    }
-
-    // Grille horaire en mode sombre
-    .fc-scrollgrid {
-      border-color: var(--border-primary) !important;
-    }
-
-    .fc-scrollgrid-section > * {
-      border-color: var(--border-primary) !important;
-    }
-
-    // Conteneurs FullCalendar en mode sombre
-    .fc-view-harness,
-    .fc-scrollgrid-sync-table,
-    .fc-timegrid-body,
-    .fc-timegrid-slots,
-    .fc-daygrid-body {
-      background: var(--bg-secondary) !important;
-    }
-
-    // Cellules de la grille temporelle
-    .fc-timegrid-slot-lane {
-      background: var(--bg-secondary) !important;
-      border-color: var(--border-primary) !important;
-    }
-
-    // Zone vide du calendrier
-    .fc-daygrid-day-frame,
-    .fc-daygrid-day-bg {
-      background: transparent !important;
-    }
-
-    // Table et corps du calendrier
-    table, tbody, tr, td, th {
-      border-color: var(--border-primary) !important;
-    }
-  }
-
-  @keyframes pulse-urgent-dark {
-    0%, 100% {
-      opacity: 1;
-      transform: scale(1);
-    }
-    50% {
-      opacity: 0.85;
-      transform: scale(1.02);
-    }
-  }
-}
+@use '../../assets/styles/calendar-shell-dark';
 </style>

--- a/src/components/widgets/CalendarEventModal.vue
+++ b/src/components/widgets/CalendarEventModal.vue
@@ -1,0 +1,213 @@
+<template>
+  <div class="event-modal-overlay" @click="$emit('close')">
+    <div class="event-modal" @click.stop>
+      <div class="modal-header">
+        <h3 class="modal-title">{{ event.title }}</h3>
+        <button class="close-btn" @click="$emit('close')">
+          <XMarkIcon class="w-5 h-5" />
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="event-detail">
+          <ClockIcon class="detail-icon" />
+          <div>
+            <p class="detail-label">Horaire</p>
+            <p class="detail-value">
+              {{ formatEventTime(event.start) }}
+              <template v-if="event.end">
+                - {{ formatEventTime(event.end) }}
+              </template>
+            </p>
+          </div>
+        </div>
+
+        <div v-if="event.extendedProps.classe" class="event-detail">
+          <BuildingLibraryIcon class="detail-icon" />
+          <div>
+            <p class="detail-label">Classe</p>
+            <p class="detail-value">{{ event.extendedProps.classe }}</p>
+          </div>
+        </div>
+
+        <div v-if="event.extendedProps.matiere" class="event-detail">
+          <BookOpenIcon class="detail-icon" />
+          <div>
+            <p class="detail-label">Matière</p>
+            <p class="detail-value">{{ event.extendedProps.matiere }}</p>
+          </div>
+        </div>
+
+        <div v-if="event.extendedProps.enseignant" class="event-detail">
+          <UserIcon class="detail-icon" />
+          <div>
+            <p class="detail-label">Enseignant</p>
+            <p class="detail-value">{{ event.extendedProps.enseignant }}</p>
+          </div>
+        </div>
+
+        <div v-if="event.extendedProps.description" class="event-detail">
+          <InformationCircleIcon class="detail-icon" />
+          <div>
+            <p class="detail-label">Description</p>
+            <p class="detail-value">{{ event.extendedProps.description }}</p>
+          </div>
+        </div>
+      </div>
+      <div v-if="event.extendedProps.url" class="modal-footer">
+        <button class="action-btn primary" @click="$emit('go')">
+          Voir les détails
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Modale de détail d'un événement du widget calendrier (H8 — décomposition
+ * CalendarWidget.vue). Sous-composant présentationnel : reçoit l'`event` en prop,
+ * émet `close` et `go` (navigation pilotée par le parent). Le formatage d'heure
+ * (pur) reste local. CSS déplacé verbatim.
+ */
+import {
+  ClockIcon,
+  BuildingLibraryIcon,
+  BookOpenIcon,
+  UserIcon,
+  InformationCircleIcon,
+  XMarkIcon
+} from '@heroicons/vue/24/outline'
+
+defineProps({
+  event: {
+    type: Object,
+    required: true
+  }
+})
+
+defineEmits(['close', 'go'])
+
+function formatEventTime(date) {
+  if (!date) return ''
+  const d = new Date(date)
+  const hours = d.getHours().toString().padStart(2, '0')
+  const minutes = d.getMinutes().toString().padStart(2, '0')
+  return `${hours}:${minutes}`
+}
+</script>
+
+<style scoped>
+/* Event Modal */
+.event-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 1rem;
+}
+
+.event-modal {
+  background: var(--bg-primary);
+  border-radius: 1rem;
+  max-width: 500px;
+  width: 100%;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.modal-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: transparent;
+  border: none;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.close-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.modal-body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.event-detail {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.detail-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--color-primary);
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.detail-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  margin: 0 0 0.25rem 0;
+}
+
+.detail-value {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.modal-footer {
+  padding: 1.5rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.action-btn {
+  width: 100%;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.action-btn:hover {
+  background: #2563eb;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+</style>

--- a/src/components/widgets/CalendarWidget.vue
+++ b/src/components/widgets/CalendarWidget.vue
@@ -40,108 +40,29 @@
     </div>
 
     <!-- Legend -->
-    <div class="calendar-legend">
-      <div class="legend-item">
-        <span class="legend-dot seance"></span>
-        <span class="legend-label">Séances</span>
-      </div>
-      <div class="legend-item">
-        <span class="legend-dot evaluation"></span>
-        <span class="legend-label">Évaluations</span>
-      </div>
-      <div class="legend-item">
-        <span class="legend-dot visio"></span>
-        <span class="legend-label">Visioconférences</span>
-      </div>
-    </div>
+    <CalendarWidgetLegend />
 
     <!-- Event Detail Modal -->
-    <div v-if="selectedEvent" class="event-modal-overlay" @click="closeEventModal">
-      <div class="event-modal" @click.stop>
-        <div class="modal-header">
-          <h3 class="modal-title">{{ selectedEvent.title }}</h3>
-          <button class="close-btn" @click="closeEventModal">
-            <XMarkIcon class="w-5 h-5" />
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="event-detail">
-            <ClockIcon class="detail-icon" />
-            <div>
-              <p class="detail-label">Horaire</p>
-              <p class="detail-value">
-                {{ formatEventTime(selectedEvent.start) }}
-                <template v-if="selectedEvent.end">
-                  - {{ formatEventTime(selectedEvent.end) }}
-                </template>
-              </p>
-            </div>
-          </div>
-
-          <div v-if="selectedEvent.extendedProps.classe" class="event-detail">
-            <BuildingLibraryIcon class="detail-icon" />
-            <div>
-              <p class="detail-label">Classe</p>
-              <p class="detail-value">{{ selectedEvent.extendedProps.classe }}</p>
-            </div>
-          </div>
-
-          <div v-if="selectedEvent.extendedProps.matiere" class="event-detail">
-            <BookOpenIcon class="detail-icon" />
-            <div>
-              <p class="detail-label">Matière</p>
-              <p class="detail-value">{{ selectedEvent.extendedProps.matiere }}</p>
-            </div>
-          </div>
-
-          <div v-if="selectedEvent.extendedProps.enseignant" class="event-detail">
-            <UserIcon class="detail-icon" />
-            <div>
-              <p class="detail-label">Enseignant</p>
-              <p class="detail-value">{{ selectedEvent.extendedProps.enseignant }}</p>
-            </div>
-          </div>
-
-          <div v-if="selectedEvent.extendedProps.description" class="event-detail">
-            <InformationCircleIcon class="detail-icon" />
-            <div>
-              <p class="detail-label">Description</p>
-              <p class="detail-value">{{ selectedEvent.extendedProps.description }}</p>
-            </div>
-          </div>
-        </div>
-        <div v-if="selectedEvent.extendedProps.url" class="modal-footer">
-          <button class="action-btn primary" @click="goToEvent">
-            Voir les détails
-          </button>
-        </div>
-      </div>
-    </div>
+    <CalendarEventModal
+      v-if="selectedEvent"
+      :event="selectedEvent"
+      @close="closeEventModal"
+      @go="goToEvent"
+    />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
-import { useRouter } from 'vue-router'
+/**
+ * Widget calendrier (H8 — orchestrateur ≤300). État + config FullCalendar +
+ * handlers délégués au composable useCalendarWidget ; légende et modale de détail
+ * rendues par CalendarWidgetLegend / CalendarEventModal.
+ */
 import FullCalendar from '@fullcalendar/vue3'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import timeGridPlugin from '@fullcalendar/timegrid'
-import interactionPlugin from '@fullcalendar/interaction'
-import frLocale from '@fullcalendar/core/locales/fr'
-import {
-  CalendarIcon,
-  ClockIcon,
-  BuildingLibraryIcon,
-  BookOpenIcon,
-  UserIcon,
-  InformationCircleIcon,
-  XMarkIcon
-} from '@heroicons/vue/24/outline'
-
-const router = useRouter()
-const calendarRef = ref(null)
-const currentView = ref('dayGridMonth')
-const selectedEvent = ref(null)
+import { CalendarIcon } from '@heroicons/vue/24/outline'
+import CalendarWidgetLegend from '@/components/widgets/CalendarWidgetLegend.vue'
+import CalendarEventModal from '@/components/widgets/CalendarEventModal.vue'
+import { useCalendarWidget } from '@/composables/useCalendarWidget'
 
 const props = defineProps({
   events: {
@@ -156,90 +77,15 @@ const props = defineProps({
 
 const emit = defineEmits(['event-click', 'date-click'])
 
-const calendarOptions = computed(() => ({
-  plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
-  initialView: currentView.value,
-  locale: frLocale,
-  headerToolbar: {
-    left: 'prev,next today',
-    center: 'title',
-    right: ''
-  },
-  buttonText: {
-    today: 'Aujourd\'hui',
-    month: 'Mois',
-    week: 'Semaine',
-    day: 'Jour'
-  },
-  height: props.height,
-  events: props.events,
-  eventClick: handleEventClick,
-  dateClick: handleDateClick,
-  eventColor: '#3b82f6',
-  eventTimeFormat: {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  },
-  slotLabelFormat: {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  },
-  nowIndicator: true,
-  editable: false,
-  selectable: true,
-  selectMirror: true,
-  dayMaxEvents: true,
-  weekends: true,
-  eventClassNames: (arg) => {
-    const classes = ['event-item']
-    if (arg.event.extendedProps.type) {
-      classes.push(`event-${arg.event.extendedProps.type}`)
-    }
-    return classes
-  }
-}))
-
-function changeView(view) {
-  currentView.value = view
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.changeView(view)
-  }
-}
-
-function handleEventClick(info) {
-  selectedEvent.value = info.event
-  emit('event-click', info.event)
-}
-
-function handleDateClick(info) {
-  emit('date-click', info)
-}
-
-function closeEventModal() {
-  selectedEvent.value = null
-}
-
-function formatEventTime(date) {
-  if (!date) return ''
-  const d = new Date(date)
-  const hours = d.getHours().toString().padStart(2, '0')
-  const minutes = d.getMinutes().toString().padStart(2, '0')
-  return `${hours}:${minutes}`
-}
-
-function goToEvent() {
-  if (selectedEvent.value?.extendedProps?.url) {
-    router.push(selectedEvent.value.extendedProps.url)
-    closeEventModal()
-  }
-}
-
-onMounted(() => {
-  console.log('CalendarWidget mounted avec', props.events.length, 'événements')
-})
+const {
+  calendarRef,
+  currentView,
+  selectedEvent,
+  calendarOptions,
+  changeView,
+  closeEventModal,
+  goToEvent
+} = useCalendarWidget(props, emit)
 </script>
 
 <style scoped>
@@ -389,159 +235,6 @@ onMounted(() => {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2) !important;
 }
 
-/* Legend */
-.calendar-legend {
-  display: flex;
-  gap: 1.5rem;
-  padding: 1rem 1.25rem;
-  border-top: 1px solid var(--border-color);
-  flex-wrap: wrap;
-}
-
-.legend-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.legend-dot {
-  width: 1rem;
-  height: 1rem;
-  border-radius: 0.25rem;
-}
-
-.legend-dot.seance {
-  background: #3b82f6;
-}
-
-.legend-dot.evaluation {
-  background: #f59e0b;
-}
-
-.legend-dot.visio {
-  background: #10b981;
-}
-
-.legend-label {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
-/* Event Modal */
-.event-modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-  padding: 1rem;
-}
-
-.event-modal {
-  background: var(--bg-primary);
-  border-radius: 1rem;
-  max-width: 500px;
-  width: 100%;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-}
-
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1.5rem;
-  border-bottom: 1px solid var(--border-color);
-}
-
-.modal-title {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.close-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  background: transparent;
-  border: none;
-  border-radius: 0.5rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.close-btn:hover {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-}
-
-.modal-body {
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.event-detail {
-  display: flex;
-  align-items: flex-start;
-  gap: 1rem;
-}
-
-.detail-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  color: var(--color-primary);
-  flex-shrink: 0;
-  margin-top: 0.125rem;
-}
-
-.detail-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.025em;
-  margin: 0 0 0.25rem 0;
-}
-
-.detail-value {
-  font-size: 0.875rem;
-  color: var(--text-primary);
-  margin: 0;
-}
-
-.modal-footer {
-  padding: 1.5rem;
-  border-top: 1px solid var(--border-color);
-}
-
-.action-btn {
-  width: 100%;
-  padding: 0.75rem 1.5rem;
-  background: var(--color-primary);
-  color: white;
-  border: none;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.action-btn:hover {
-  background: #2563eb;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-}
-
 /* Responsive */
 @media (max-width: 768px) {
   .calendar-container {
@@ -550,11 +243,6 @@ onMounted(() => {
 
   .header-actions {
     display: none;
-  }
-
-  .calendar-legend {
-    flex-direction: column;
-    gap: 0.75rem;
   }
 
   :deep(.fc-toolbar) {

--- a/src/components/widgets/CalendarWidgetLegend.vue
+++ b/src/components/widgets/CalendarWidgetLegend.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="calendar-legend">
+    <div class="legend-item">
+      <span class="legend-dot seance"></span>
+      <span class="legend-label">Séances</span>
+    </div>
+    <div class="legend-item">
+      <span class="legend-dot evaluation"></span>
+      <span class="legend-label">Évaluations</span>
+    </div>
+    <div class="legend-item">
+      <span class="legend-dot visio"></span>
+      <span class="legend-label">Visioconférences</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Légende du widget calendrier (H8 — décomposition CalendarWidget.vue).
+ * Sous-composant purement statique : CSS déplacé verbatim.
+ */
+</script>
+
+<style scoped>
+/* Legend */
+.calendar-legend {
+  display: flex;
+  gap: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  flex-wrap: wrap;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-dot {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.25rem;
+}
+
+.legend-dot.seance {
+  background: #3b82f6;
+}
+
+.legend-dot.evaluation {
+  background: #f59e0b;
+}
+
+.legend-dot.visio {
+  background: #10b981;
+}
+
+.legend-label {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .calendar-legend {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}
+</style>

--- a/src/components/widgets/NotificationItem.vue
+++ b/src/components/widgets/NotificationItem.vue
@@ -1,0 +1,219 @@
+<template>
+  <div
+    class="notification-item"
+    :class="{ 'unread': notification.is_unread }"
+    @click="$emit('click', notification)"
+  >
+    <!-- Icon -->
+    <div class="notification-icon" :class="getTypeClass(notification.data.type)">
+      <component :is="getIconComponent(notification.data.icon)" class="w-5 h-5" />
+    </div>
+
+    <!-- Content -->
+    <div class="notification-content">
+      <p class="notification-title">{{ notification.data.title }}</p>
+      <p class="notification-message">{{ notification.data.message }}</p>
+      <span class="notification-time">{{ notification.time_ago }}</span>
+    </div>
+
+    <!-- Actions -->
+    <div class="notification-actions">
+      <button
+        v-if="notification.is_unread"
+        class="mark-read-btn"
+        @click.stop="$emit('mark-read', notification.id)"
+        title="Marquer comme lu"
+      >
+        <CheckIcon class="w-4 h-4" />
+      </button>
+      <button
+        class="delete-btn"
+        @click.stop="$emit('delete', notification.id)"
+        title="Supprimer"
+      >
+        <XMarkIcon class="w-4 h-4" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Item de notification (H8 — décomposition NotificationsWidget.vue).
+ * Sous-composant de présentation : reçoit une `notification` en prop, émet les
+ * actions (`click`, `mark-read`, `delete`). Les helpers de présentation
+ * (classe de type, composant d'icône) sont locaux et purs. Aucun appel API.
+ */
+import {
+  CheckIcon,
+  XMarkIcon,
+  InformationCircleIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  XCircleIcon,
+  BellIcon
+} from '@heroicons/vue/24/outline'
+
+defineProps({
+  notification: {
+    type: Object,
+    required: true
+  }
+})
+
+defineEmits(['click', 'mark-read', 'delete'])
+
+function getTypeClass(type) {
+  const classes = {
+    info: 'type-info',
+    success: 'type-success',
+    warning: 'type-warning',
+    danger: 'type-danger'
+  }
+  return classes[type] || 'type-info'
+}
+
+function getIconComponent(iconName) {
+  const icons = {
+    InformationCircleIcon,
+    CheckCircleIcon,
+    ExclamationCircleIcon,
+    XCircleIcon,
+    BellIcon
+  }
+  return icons[iconName] || BellIcon
+}
+</script>
+
+<style scoped>
+.notification-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.notification-item:hover {
+  background: var(--bg-secondary);
+}
+
+.notification-item.unread {
+  background: linear-gradient(90deg, #eff6ff 0%, transparent 100%);
+  border-left: 3px solid #3b82f6;
+}
+
+.notification-icon {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+.type-info {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.type-success {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.type-warning {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.type-danger {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.notification-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.25rem 0;
+}
+
+.notification-message {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0 0 0.5rem 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.notification-time {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.notification-actions {
+  display: flex;
+  gap: 0.25rem;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.notification-item:hover .notification-actions {
+  opacity: 1;
+}
+
+.mark-read-btn,
+.delete-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mark-read-btn {
+  color: #10b981;
+}
+
+.mark-read-btn:hover {
+  background: #d1fae5;
+  border-color: #10b981;
+}
+
+.delete-btn {
+  color: #ef4444;
+}
+
+.delete-btn:hover {
+  background: #fee2e2;
+  border-color: #ef4444;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .notification-item {
+    padding: 0.75rem 1rem;
+  }
+
+  .notification-actions {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/widgets/NotificationsWidget.vue
+++ b/src/components/widgets/NotificationsWidget.vue
@@ -32,44 +32,14 @@
 
     <!-- Notifications List -->
     <div v-else-if="notifications.length > 0" class="notifications-list">
-      <div
+      <NotificationItem
         v-for="notification in notifications"
         :key="notification.id"
-        class="notification-item"
-        :class="{ 'unread': notification.is_unread }"
-        @click="handleNotificationClick(notification)"
-      >
-        <!-- Icon -->
-        <div class="notification-icon" :class="getTypeClass(notification.data.type)">
-          <component :is="getIconComponent(notification.data.icon)" class="w-5 h-5" />
-        </div>
-
-        <!-- Content -->
-        <div class="notification-content">
-          <p class="notification-title">{{ notification.data.title }}</p>
-          <p class="notification-message">{{ notification.data.message }}</p>
-          <span class="notification-time">{{ notification.time_ago }}</span>
-        </div>
-
-        <!-- Actions -->
-        <div class="notification-actions">
-          <button
-            v-if="notification.is_unread"
-            class="mark-read-btn"
-            @click.stop="handleMarkAsRead(notification.id)"
-            title="Marquer comme lu"
-          >
-            <CheckIcon class="w-4 h-4" />
-          </button>
-          <button
-            class="delete-btn"
-            @click.stop="handleDelete(notification.id)"
-            title="Supprimer"
-          >
-            <XMarkIcon class="w-4 h-4" />
-          </button>
-        </div>
-      </div>
+        :notification="notification"
+        @click="handleNotificationClick"
+        @mark-read="handleMarkAsRead"
+        @delete="handleDelete"
+      />
     </div>
 
     <!-- Empty State -->
@@ -89,26 +59,19 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
-import { useRouter } from 'vue-router'
-import { notificationsService } from '@/services/notifications'
+/**
+ * Widget de notifications (H8 — orchestrateur ≤300). L'état et toute la logique
+ * métier (chargement, marquage, suppression, navigation) vivent dans le composable
+ * useNotificationsWidget ; chaque ligne est rendue par NotificationItem.
+ */
 import {
   BellIcon,
   CheckIcon,
-  ArrowPathIcon,
-  XMarkIcon,
-  InformationCircleIcon,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  XCircleIcon
+  ArrowPathIcon
 } from '@heroicons/vue/24/outline'
 import ContentLoader from '@/components/common/ContentLoader.vue'
-
-const router = useRouter()
-
-const notifications = ref([])
-const unreadCount = ref(0)
-const loading = ref(false)
+import NotificationItem from '@/components/widgets/NotificationItem.vue'
+import { useNotificationsWidget } from '@/composables/useNotificationsWidget'
 
 const props = defineProps({
   limit: {
@@ -127,119 +90,16 @@ const props = defineProps({
 
 const emit = defineEmits(['notification-click', 'notification-read', 'notification-deleted'])
 
-async function loadNotifications() {
-  loading.value = true
-  try {
-    // Charger les notifications récentes
-    const data = await notificationsService.getRecentNotifications(props.limit)
-    notifications.value = data
-
-    // Charger le count
-    const count = await notificationsService.getUnreadCount()
-    unreadCount.value = count
-
-    console.log('Notifications chargées:', { notifications: data, unreadCount: count })
-  } catch (error) {
-    console.error('Erreur chargement notifications:', error)
-  } finally {
-    loading.value = false
-  }
-}
-
-async function refreshNotifications() {
-  await loadNotifications()
-}
-
-async function handleMarkAsRead(notificationId) {
-  const success = await notificationsService.markAsRead(notificationId)
-  if (success) {
-    // Mettre à jour localement
-    const notification = notifications.value.find(n => n.id === notificationId)
-    if (notification) {
-      notification.is_unread = false
-    }
-    unreadCount.value = Math.max(0, unreadCount.value - 1)
-
-    emit('notification-read', notificationId)
-  }
-}
-
-async function handleMarkAllAsRead() {
-  const success = await notificationsService.markAllAsRead()
-  if (success) {
-    // Mettre à jour toutes les notifications
-    notifications.value.forEach(n => {
-      n.is_unread = false
-    })
-    unreadCount.value = 0
-
-    emit('notification-read', 'all')
-  }
-}
-
-async function handleDelete(notificationId) {
-  const success = await notificationsService.deleteNotification(notificationId)
-  if (success) {
-    // Retirer de la liste
-    const index = notifications.value.findIndex(n => n.id === notificationId)
-    if (index !== -1) {
-      const wasUnread = notifications.value[index].is_unread
-      notifications.value.splice(index, 1)
-
-      if (wasUnread) {
-        unreadCount.value = Math.max(0, unreadCount.value - 1)
-      }
-
-      emit('notification-deleted', notificationId)
-    }
-  }
-}
-
-function handleNotificationClick(notification) {
-  // Marquer comme lu si non lu
-  if (notification.is_unread) {
-    handleMarkAsRead(notification.id)
-  }
-
-  emit('notification-click', notification)
-
-  // Naviguer si action_url existe
-  if (notification.data.action_url) {
-    router.push(notification.data.action_url)
-  }
-}
-
-function getTypeClass(type) {
-  const classes = {
-    info: 'type-info',
-    success: 'type-success',
-    warning: 'type-warning',
-    danger: 'type-danger'
-  }
-  return classes[type] || 'type-info'
-}
-
-function getIconComponent(iconName) {
-  const icons = {
-    InformationCircleIcon,
-    CheckCircleIcon,
-    ExclamationCircleIcon,
-    XCircleIcon,
-    BellIcon
-  }
-  return icons[iconName] || BellIcon
-}
-
-onMounted(() => {
-  loadNotifications()
-
-  // Auto-refresh si activé
-  if (props.autoRefresh) {
-    setInterval(() => {
-      loadNotifications()
-    }, props.refreshInterval)
-  }
-})
+const {
+  notifications,
+  unreadCount,
+  loading,
+  refreshNotifications,
+  handleMarkAsRead,
+  handleMarkAllAsRead,
+  handleDelete,
+  handleNotificationClick
+} = useNotificationsWidget(props, emit)
 </script>
 
 <style scoped>
@@ -341,7 +201,8 @@ onMounted(() => {
   to { transform: rotate(360deg); }
 }
 
-/* Loading State */
+/* Loading State (dette pré-existante : styles non utilisés — le template emploie
+   <ContentLoader>, pas .loading-state/.spinner ; conservés verbatim pour parité) */
 .loading-state {
   display: flex;
   flex-direction: column;
@@ -364,126 +225,6 @@ onMounted(() => {
 .notifications-list {
   max-height: 400px;
   overflow-y: auto;
-}
-
-.notification-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 1rem;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border-color);
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.notification-item:hover {
-  background: var(--bg-secondary);
-}
-
-.notification-item.unread {
-  background: linear-gradient(90deg, #eff6ff 0%, transparent 100%);
-  border-left: 3px solid #3b82f6;
-}
-
-.notification-icon {
-  flex-shrink: 0;
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-}
-
-.type-info {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
-.type-success {
-  background: #d1fae5;
-  color: #065f46;
-}
-
-.type-warning {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.type-danger {
-  background: #fee2e2;
-  color: #991b1b;
-}
-
-.notification-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.notification-title {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0 0 0.25rem 0;
-}
-
-.notification-message {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  margin: 0 0 0.5rem 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.notification-time {
-  font-size: 0.75rem;
-  color: var(--text-tertiary);
-}
-
-.notification-actions {
-  display: flex;
-  gap: 0.25rem;
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-.notification-item:hover .notification-actions {
-  opacity: 1;
-}
-
-.mark-read-btn,
-.delete-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 0.375rem;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.mark-read-btn {
-  color: #10b981;
-}
-
-.mark-read-btn:hover {
-  background: #d1fae5;
-  border-color: #10b981;
-}
-
-.delete-btn {
-  color: #ef4444;
-}
-
-.delete-btn:hover {
-  background: #fee2e2;
-  border-color: #ef4444;
 }
 
 /* Empty State */
@@ -539,14 +280,6 @@ onMounted(() => {
 @media (max-width: 768px) {
   .notifications-list {
     max-height: 300px;
-  }
-
-  .notification-item {
-    padding: 0.75rem 1rem;
-  }
-
-  .notification-actions {
-    opacity: 1;
   }
 }
 </style>

--- a/src/composables/useCalendarView.js
+++ b/src/composables/useCalendarView.js
@@ -1,0 +1,150 @@
+import { ref, computed, watch } from 'vue'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import frLocale from '@fullcalendar/core/locales/fr'
+
+/**
+ * Couche « vue » du calendrier unifié (H8 — décomposition UniversalCalendar.vue
+ * sous 300 lignes). Encapsule l'état de la vue FullCalendar (type de vue + mois
+ * courant), la configuration `calendarOptions`, les actions de navigation
+ * (mois précédent/suivant, aujourd'hui, changement de vue, clic sur une date) et
+ * la synchronisation impérative des événements filtrés avec l'API FullCalendar.
+ *
+ * Le chargement des données vit dans `useCalendarEvents` (#28bis) ; ce composable
+ * ne fait que piloter l'affichage. L'orchestrateur reste un simple câblage.
+ *
+ * @param {Object} ctx
+ * @param {import('vue').Ref} ctx.calendarRef  ref vers <CalendarView> (expose getApi())
+ * @param {import('vue').ComputedRef<Array>} ctx.filteredEvents  événements à afficher
+ * @param {(event: Object) => void} ctx.onEventClick  callback de clic sur un événement
+ */
+export function useCalendarView({ calendarRef, filteredEvents, onEventClick }) {
+  const currentView = ref('dayGridMonth')
+  const currentDate = ref(new Date()) // Pour forcer la réactivité du label
+
+  // Computed - Label mois courant
+  const currentMonthLabel = computed(() => {
+    return currentDate.value.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
+  })
+
+  function handleEventClick(info) {
+    onEventClick(info.event)
+  }
+
+  function handleDateClick(info) {
+    // Naviguer vers la vue jour si clic sur une date en vue mois
+    if (currentView.value === 'dayGridMonth') {
+      const calendarApi = calendarRef.value?.getApi()
+      if (calendarApi) {
+        calendarApi.changeView('timeGridDay', info.dateStr)
+        currentView.value = 'timeGridDay'
+      }
+    }
+  }
+
+  // Configuration FullCalendar
+  const calendarOptions = computed(() => ({
+    plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+    initialView: currentView.value,
+    initialDate: new Date(), // Forcer le calendrier à afficher le mois actuel
+    locale: frLocale,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: ''
+    },
+    buttonText: {
+      today: "Aujourd'hui",
+      month: 'Mois',
+      week: 'Semaine',
+      day: 'Jour'
+    },
+    events: filteredEvents.value,
+    eventClick: handleEventClick,
+    dateClick: handleDateClick,
+    datesSet: (dateInfo) => {
+      // Utiliser le milieu de la plage visible pour déterminer le mois affiché
+      // (dateInfo.start peut être un jour du mois précédent en vue mensuelle)
+      const mid = new Date((dateInfo.start.getTime() + dateInfo.end.getTime()) / 2)
+      currentDate.value = mid
+    },
+    nowIndicator: true,
+    slotMinTime: '07:00:00',
+    slotMaxTime: '20:00:00',
+    allDaySlot: false,
+    height: 'auto',
+    eventTimeFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    },
+    slotLabelFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    },
+    eventClassNames: (arg) => {
+      const classes = ['event-item']
+      if (arg.event.extendedProps.eventType) {
+        classes.push(`event-${arg.event.extendedProps.eventType}`)
+      }
+      if (arg.event.extendedProps.isUrgent) {
+        classes.push('event-urgent')
+      }
+      return classes
+    }
+  }))
+
+  function changeView(view) {
+    currentView.value = view
+    const calendarApi = calendarRef.value?.getApi()
+    if (calendarApi) {
+      calendarApi.changeView(view)
+    }
+  }
+
+  function previousMonth() {
+    const calendarApi = calendarRef.value?.getApi()
+    if (calendarApi) {
+      calendarApi.prev()
+    }
+  }
+
+  function nextMonth() {
+    const calendarApi = calendarRef.value?.getApi()
+    if (calendarApi) {
+      calendarApi.next()
+    }
+  }
+
+  function goToToday() {
+    const calendarApi = calendarRef.value?.getApi()
+    if (calendarApi) {
+      calendarApi.today()
+    }
+  }
+
+  // IMPORTANT: Forcer FullCalendar a mettre a jour quand les evenements changent
+  watch(filteredEvents, (newEvents) => {
+    const calendarApi = calendarRef.value?.getApi()
+    if (calendarApi) {
+      // Supprimer tous les evenements existants
+      calendarApi.removeAllEvents()
+      // Ajouter les nouveaux evenements
+      newEvents.forEach(event => {
+        calendarApi.addEvent(event)
+      })
+    }
+  }, { deep: true, immediate: true })
+
+  return {
+    currentView,
+    currentMonthLabel,
+    calendarOptions,
+    changeView,
+    previousMonth,
+    nextMonth,
+    goToToday
+  }
+}

--- a/src/composables/useCalendarWidget.js
+++ b/src/composables/useCalendarWidget.js
@@ -1,0 +1,114 @@
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import frLocale from '@fullcalendar/core/locales/fr'
+
+/**
+ * Composable du widget calendrier (H8 — décomposition CalendarWidget.vue pour
+ * ramener le FICHIER ENTIER sous 300 lignes).
+ *
+ * Encapsule l'état (vue courante, événement sélectionné, ref FullCalendar), la
+ * configuration FullCalendar et les handlers (changement de vue, clics, navigation).
+ * Le rendu de la modale de détail et de la légende est délégué à des sous-composants
+ * présentationnels (CalendarEventModal / CalendarWidgetLegend).
+ *
+ * @param {{ events: Array, height: string }} props
+ * @param {(event: string, payload?: any) => void} emit
+ */
+export function useCalendarWidget(props, emit) {
+  const router = useRouter()
+  const calendarRef = ref(null)
+  const currentView = ref('dayGridMonth')
+  const selectedEvent = ref(null)
+
+  const calendarOptions = computed(() => ({
+    plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+    initialView: currentView.value,
+    locale: frLocale,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: ''
+    },
+    buttonText: {
+      today: 'Aujourd\'hui',
+      month: 'Mois',
+      week: 'Semaine',
+      day: 'Jour'
+    },
+    height: props.height,
+    events: props.events,
+    eventClick: handleEventClick,
+    dateClick: handleDateClick,
+    eventColor: '#3b82f6',
+    eventTimeFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    },
+    slotLabelFormat: {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    },
+    nowIndicator: true,
+    editable: false,
+    selectable: true,
+    selectMirror: true,
+    dayMaxEvents: true,
+    weekends: true,
+    eventClassNames: (arg) => {
+      const classes = ['event-item']
+      if (arg.event.extendedProps.type) {
+        classes.push(`event-${arg.event.extendedProps.type}`)
+      }
+      return classes
+    }
+  }))
+
+  function changeView(view) {
+    currentView.value = view
+    const calendarApi = calendarRef.value?.getApi()
+    if (calendarApi) {
+      calendarApi.changeView(view)
+    }
+  }
+
+  function handleEventClick(info) {
+    selectedEvent.value = info.event
+    emit('event-click', info.event)
+  }
+
+  function handleDateClick(info) {
+    emit('date-click', info)
+  }
+
+  function closeEventModal() {
+    selectedEvent.value = null
+  }
+
+  function goToEvent() {
+    if (selectedEvent.value?.extendedProps?.url) {
+      router.push(selectedEvent.value.extendedProps.url)
+      closeEventModal()
+    }
+  }
+
+  onMounted(() => {
+    console.log('CalendarWidget mounted avec', props.events.length, 'événements')
+  })
+
+  return {
+    calendarRef,
+    currentView,
+    selectedEvent,
+    calendarOptions,
+    changeView,
+    handleEventClick,
+    handleDateClick,
+    closeEventModal,
+    goToEvent
+  }
+}

--- a/src/composables/useEventDetail.js
+++ b/src/composables/useEventDetail.js
@@ -1,0 +1,162 @@
+import { computed } from 'vue'
+
+/**
+ * Composable de la modale de détail d'événement (H8 — décomposition
+ * EventDetailModal.vue pour ramener le FICHIER ENTIER sous 300 lignes).
+ *
+ * Centralise les computeds (données, type, titre, statut, capacités selon le rôle),
+ * le formatage (date / plage horaire / statut visio) et l'émission d'action. Les
+ * sections (séance / évaluation / actions) sont rendues par des sous-composants
+ * présentationnels qui reçoivent ces valeurs en props.
+ *
+ * @param {{ event: Object, userRole: string }} props
+ * @param {(event: string, payload?: any) => void} emit
+ */
+export function useEventDetail(props, emit) {
+  const eventData = computed(() => props.event.extendedProps?.data || {})
+  const isSeance = computed(() => props.event.extendedProps?.eventType === 'seance')
+
+  const eventTitle = computed(() => {
+    return eventData.value.titre || props.event.title || 'Événement'
+  })
+
+  const statusClass = computed(() => {
+    if (isSeance.value) {
+      const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
+      if (visioStatus === 'active') return 'status-active'
+      if (visioStatus === 'programmee') return 'status-scheduled'
+      return 'status-ended'
+    } else {
+      const status = eventData.value.status
+      if (status === 'en_cours') return 'status-active'
+      if (status === 'terminee') return 'status-ended'
+      return 'status-scheduled'
+    }
+  })
+
+  const statusLabel = computed(() => {
+    if (isSeance.value) {
+      const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
+      return formatVisioStatus(visioStatus)
+    } else {
+      const status = eventData.value.status
+      if (status === 'en_cours') return 'En cours'
+      if (status === 'terminee') return 'Terminée'
+      return 'Programmée'
+    }
+  })
+
+  // Capacités selon le rôle
+  const canJoinVisio = computed(() => {
+    // Debug log pour comprendre pourquoi le bouton n'apparaît pas
+    console.log('[EventDetailModal] canJoinVisio check:', {
+      isSeance: isSeance.value,
+      userRole: props.userRole,
+      visio: eventData.value.visio,
+      visioStatus: eventData.value.visio?.status
+    })
+
+    if (!isSeance.value) {
+      console.log('[EventDetailModal] Pas une séance')
+      return false
+    }
+    if (props.userRole !== 'student') {
+      console.log('[EventDetailModal] Pas un étudiant, role =', props.userRole)
+      return false
+    }
+
+    // Vérifier que la visio existe et est active
+    const visio = eventData.value.visio
+    if (!visio) {
+      console.log('[EventDetailModal] Pas de visio')
+      return false
+    }
+
+    // L'étudiant peut rejoindre seulement si la visio est en cours (status = 'active')
+    const canJoin = visio.status === 'active'
+    console.log('[EventDetailModal] canJoin =', canJoin, 'visio.status =', visio.status)
+    return canJoin
+  })
+
+  const canStartEvaluation = computed(() => {
+    if (isSeance.value || props.userRole !== 'student') return false
+    const status = eventData.value.status
+    return status !== 'terminee' && !eventData.value.student_submission?.note_sur_20
+  })
+
+  const canActivateVisio = computed(() => {
+    if (!isSeance.value || props.userRole !== 'teacher') return false
+    return !(eventData.value.visio?.enabled || eventData.value.visio_enabled)
+  })
+
+  const canStartVisio = computed(() => {
+    if (!isSeance.value || props.userRole !== 'teacher') return false
+    const visioEnabled = eventData.value.visio?.enabled || eventData.value.visio_enabled
+    const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
+    return visioEnabled && visioStatus !== 'active'
+  })
+
+  const canEndVisio = computed(() => {
+    if (!isSeance.value || props.userRole !== 'teacher') return false
+    const visioStatus = eventData.value.visio?.status || eventData.value.visio_status
+    return visioStatus === 'active'
+  })
+
+  function formatDate(dateString) {
+    if (!dateString) return 'N/A'
+    const date = new Date(dateString)
+    return new Intl.DateTimeFormat('fr-FR', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }).format(date)
+  }
+
+  function formatTimeRange(start, end) {
+    if (!start) return 'N/A'
+    const startTime = new Date(start).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+    const endTime = end ? new Date(end).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' }) : ''
+    return endTime ? `${startTime} - ${endTime}` : startTime
+  }
+
+  function formatVisioStatus(status) {
+    const statusMap = {
+      'active': 'En direct',
+      'programmee': 'Programmée',
+      'terminee': 'Terminée'
+    }
+    return statusMap[status] || 'Non défini'
+  }
+
+  // Valeurs formatées prêtes pour les sous-composants présentationnels
+  const formattedDate = computed(() => formatDate(props.event.start))
+  const formattedTimeRange = computed(() => formatTimeRange(props.event.start, props.event.end))
+  const visioStatusText = computed(() =>
+    formatVisioStatus(eventData.value.visio?.status || eventData.value.visio_status)
+  )
+
+  function emitAction(type) {
+    emit('action', {
+      type,
+      data: eventData.value
+    })
+  }
+
+  return {
+    eventData,
+    isSeance,
+    eventTitle,
+    statusClass,
+    statusLabel,
+    canJoinVisio,
+    canStartEvaluation,
+    canActivateVisio,
+    canStartVisio,
+    canEndVisio,
+    formattedDate,
+    formattedTimeRange,
+    visioStatusText,
+    emitAction
+  }
+}

--- a/src/composables/useNotificationsWidget.js
+++ b/src/composables/useNotificationsWidget.js
@@ -1,0 +1,128 @@
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { notificationsService } from '@/services/notifications'
+
+/**
+ * Composable du widget de notifications (H8 — décomposition NotificationsWidget.vue
+ * pour ramener le FICHIER ENTIER sous 300 lignes).
+ *
+ * Encapsule l'état (liste + compteur non-lus + loading) et toute la logique métier
+ * (chargement, rafraîchissement, marquage lu / tout lu, suppression, navigation au
+ * clic). Le rendu d'un item (icône/type) est délégué au sous-composant présentationnel
+ * NotificationItem.vue. Aucune logique de présentation ici.
+ *
+ * @param {{ limit: number, autoRefresh: boolean, refreshInterval: number }} props
+ * @param {(event: string, payload?: any) => void} emit
+ */
+export function useNotificationsWidget(props, emit) {
+  const router = useRouter()
+
+  const notifications = ref([])
+  const unreadCount = ref(0)
+  const loading = ref(false)
+
+  async function loadNotifications() {
+    loading.value = true
+    try {
+      // Charger les notifications récentes
+      const data = await notificationsService.getRecentNotifications(props.limit)
+      notifications.value = data
+
+      // Charger le count
+      const count = await notificationsService.getUnreadCount()
+      unreadCount.value = count
+
+      console.log('Notifications chargées:', { notifications: data, unreadCount: count })
+    } catch (error) {
+      console.error('Erreur chargement notifications:', error)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refreshNotifications() {
+    await loadNotifications()
+  }
+
+  async function handleMarkAsRead(notificationId) {
+    const success = await notificationsService.markAsRead(notificationId)
+    if (success) {
+      // Mettre à jour localement
+      const notification = notifications.value.find(n => n.id === notificationId)
+      if (notification) {
+        notification.is_unread = false
+      }
+      unreadCount.value = Math.max(0, unreadCount.value - 1)
+
+      emit('notification-read', notificationId)
+    }
+  }
+
+  async function handleMarkAllAsRead() {
+    const success = await notificationsService.markAllAsRead()
+    if (success) {
+      // Mettre à jour toutes les notifications
+      notifications.value.forEach(n => {
+        n.is_unread = false
+      })
+      unreadCount.value = 0
+
+      emit('notification-read', 'all')
+    }
+  }
+
+  async function handleDelete(notificationId) {
+    const success = await notificationsService.deleteNotification(notificationId)
+    if (success) {
+      // Retirer de la liste
+      const index = notifications.value.findIndex(n => n.id === notificationId)
+      if (index !== -1) {
+        const wasUnread = notifications.value[index].is_unread
+        notifications.value.splice(index, 1)
+
+        if (wasUnread) {
+          unreadCount.value = Math.max(0, unreadCount.value - 1)
+        }
+
+        emit('notification-deleted', notificationId)
+      }
+    }
+  }
+
+  function handleNotificationClick(notification) {
+    // Marquer comme lu si non lu
+    if (notification.is_unread) {
+      handleMarkAsRead(notification.id)
+    }
+
+    emit('notification-click', notification)
+
+    // Naviguer si action_url existe
+    if (notification.data.action_url) {
+      router.push(notification.data.action_url)
+    }
+  }
+
+  onMounted(() => {
+    loadNotifications()
+
+    // Auto-refresh si activé
+    if (props.autoRefresh) {
+      setInterval(() => {
+        loadNotifications()
+      }, props.refreshInterval)
+    }
+  })
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    loadNotifications,
+    refreshNotifications,
+    handleMarkAsRead,
+    handleMarkAllAsRead,
+    handleDelete,
+    handleNotificationClick
+  }
+}

--- a/tests/unit/CalendarEventModal.test.js
+++ b/tests/unit/CalendarEventModal.test.js
@@ -1,0 +1,44 @@
+/**
+ * Test de CalendarEventModal (H8 ≤300) : sous-composant présentationnel du widget
+ * calendrier. Rendu du titre/horaire, conditionnels (classe/url), émissions
+ * (close / go).
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import CalendarEventModal from '@/components/widgets/CalendarEventModal.vue'
+
+function mountModal(event = {}) {
+  return mount(CalendarEventModal, {
+    props: {
+      event: {
+        title: 'Cours de SVT',
+        start: '2025-10-20T09:05:00',
+        end: '2025-10-20T10:30:00',
+        extendedProps: { classe: '6e A', url: '/seances/1' },
+        ...event
+      }
+    }
+  })
+}
+
+describe('CalendarEventModal (H8)', () => {
+  it('affiche le titre et l’horaire formaté', () => {
+    const w = mountModal()
+    expect(w.find('.modal-title').text()).toBe('Cours de SVT')
+    expect(w.find('.detail-value').text()).toContain('09:05')
+    expect(w.find('.detail-value').text()).toContain('10:30')
+  })
+
+  it('émet `close` (overlay et bouton) et `go` (footer)', async () => {
+    const w = mountModal()
+    await w.find('.close-btn').trigger('click')
+    expect(w.emitted('close')).toBeTruthy()
+    await w.find('.action-btn.primary').trigger('click')
+    expect(w.emitted('go')).toBeTruthy()
+  })
+
+  it('masque le footer si aucune url', () => {
+    const w = mountModal({ extendedProps: { classe: '6e A' } })
+    expect(w.find('.modal-footer').exists()).toBe(false)
+  })
+})

--- a/tests/unit/CalendarLegend.test.js
+++ b/tests/unit/CalendarLegend.test.js
@@ -1,0 +1,22 @@
+/**
+ * Test de montage de CalendarLegend.vue (H8 — décomposition UniversalCalendar).
+ * Composant purement statique. On vérifie le montage + les 4 entrées de légende.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import CalendarLegend from '@/components/calendar/CalendarLegend.vue'
+
+describe('CalendarLegend.vue (H8) — montage', () => {
+  it('monte sans erreur (racine .legend-card présente)', () => {
+    const w = mount(CalendarLegend)
+    expect(w.find('.legend-card').exists()).toBe(true)
+  })
+
+  it('affiche les 4 entrées de légende', () => {
+    const w = mount(CalendarLegend)
+    const items = w.findAll('.legend-item')
+    expect(items).toHaveLength(4)
+    expect(w.text()).toContain('Séances')
+    expect(w.text()).toContain('Évaluations')
+  })
+})

--- a/tests/unit/CalendarNavigation.test.js
+++ b/tests/unit/CalendarNavigation.test.js
@@ -1,0 +1,53 @@
+/**
+ * Test de montage de CalendarNavigation.vue (H8 — décomposition UniversalCalendar).
+ * Sous-composant présentationnel (props + emits, aucun appel API). On vérifie :
+ *  - montage + racine .navigation-card + label mois rendu
+ *  - les boutons émettent previous/next/today/refresh
+ *  - le sélecteur de vue enfant relaie change-view
+ *  - l'état refreshing désactive le bouton d'actualisation
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import CalendarNavigation from '@/components/calendar/CalendarNavigation.vue'
+
+function mountNav(props = {}) {
+  return mount(CalendarNavigation, {
+    props: { currentMonthLabel: 'juin 2026', currentView: 'dayGridMonth', refreshing: false, ...props }
+  })
+}
+
+describe('CalendarNavigation.vue (H8) — montage', () => {
+  it('monte et affiche le label du mois courant', () => {
+    const w = mountNav()
+    expect(w.find('.navigation-card').exists()).toBe(true)
+    expect(w.find('.current-month').text()).toContain('juin 2026')
+  })
+
+  it('émet previous / next au clic sur les boutons de navigation', async () => {
+    const w = mountNav()
+    const navButtons = w.findAll('.nav-button')
+    await navButtons[0].trigger('click')
+    await navButtons[1].trigger('click')
+    expect(w.emitted('previous')).toBeTruthy()
+    expect(w.emitted('next')).toBeTruthy()
+  })
+
+  it('émet today et refresh', async () => {
+    const w = mountNav()
+    await w.find('.today-button').trigger('click')
+    await w.find('.refresh-button').trigger('click')
+    expect(w.emitted('today')).toBeTruthy()
+    expect(w.emitted('refresh')).toBeTruthy()
+  })
+
+  it('relaie change-view depuis le sélecteur de vue enfant', async () => {
+    const w = mountNav()
+    await w.findAll('.view-selector button')[1].trigger('click') // Semaine
+    expect(w.emitted('change-view')[0]).toEqual(['timeGridWeek'])
+  })
+
+  it('désactive le bouton actualiser quand refreshing est vrai', () => {
+    const w = mountNav({ refreshing: true })
+    expect(w.find('.refresh-button').attributes('disabled')).toBeDefined()
+  })
+})

--- a/tests/unit/CalendarView.test.js
+++ b/tests/unit/CalendarView.test.js
@@ -1,0 +1,40 @@
+/**
+ * Test de montage de CalendarView.vue (H8 — décomposition UniversalCalendar).
+ * Wrapper de FullCalendar : on stub FullCalendar et ContentLoader pour éviter
+ * l'init réelle. On vérifie :
+ *  - le loader s'affiche quand loading=true (FullCalendar absent)
+ *  - le calendrier s'affiche quand loading=false
+ *  - getApi() est exposé (parité avec l'ancien calendarRef.getApi())
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+
+// On neutralise FullCalendar (init réelle = plugins requis) et le loader.
+vi.mock('@fullcalendar/vue3', () => ({ default: { name: 'FullCalendar', render: () => null } }))
+
+import CalendarView from '@/components/calendar/CalendarView.vue'
+
+function mountView(props = {}) {
+  return mount(CalendarView, {
+    props: { options: { initialView: 'dayGridMonth' }, loading: false, ...props },
+    global: { stubs: { ContentLoader: true } }
+  })
+}
+
+describe('CalendarView.vue (H8) — montage', () => {
+  it('monte la carte calendrier et le wrapper quand loading=false', () => {
+    const w = mountView({ loading: false })
+    expect(w.find('.calendar-card').exists()).toBe(true)
+    expect(w.find('.calendar-wrapper').exists()).toBe(true)
+  })
+
+  it('affiche le loader et masque le wrapper quand loading=true', () => {
+    const w = mountView({ loading: true })
+    expect(w.find('.calendar-wrapper').exists()).toBe(false)
+  })
+
+  it('expose getApi()', () => {
+    const w = mountView()
+    expect(typeof w.vm.getApi).toBe('function')
+  })
+})

--- a/tests/unit/CalendarViewSelector.test.js
+++ b/tests/unit/CalendarViewSelector.test.js
@@ -1,0 +1,38 @@
+/**
+ * Test de montage de CalendarViewSelector.vue (H8 — décomposition UniversalCalendar).
+ * Composant pur (prop currentView + emit change-view). On vérifie :
+ *  - montage + racine .view-selector
+ *  - la vue active reçoit la classe .active
+ *  - le clic émet `change-view` avec la vue ciblée
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import CalendarViewSelector from '@/components/calendar/CalendarViewSelector.vue'
+
+function mountSelector(props = {}) {
+  return mount(CalendarViewSelector, {
+    props: { currentView: 'dayGridMonth', ...props }
+  })
+}
+
+describe('CalendarViewSelector.vue (H8) — montage', () => {
+  it('monte sans erreur (racine .view-selector présente)', () => {
+    const w = mountSelector()
+    expect(w.find('.view-selector').exists()).toBe(true)
+    expect(w.findAll('button')).toHaveLength(3)
+  })
+
+  it('applique .active au bouton de la vue courante', () => {
+    const w = mountSelector({ currentView: 'timeGridWeek' })
+    const buttons = w.findAll('button')
+    // index 1 = Semaine
+    expect(buttons[1].classes()).toContain('active')
+    expect(buttons[0].classes()).not.toContain('active')
+  })
+
+  it('émet `change-view` avec la vue ciblée au clic', async () => {
+    const w = mountSelector()
+    await w.findAll('button')[2].trigger('click') // Jour
+    expect(w.emitted('change-view')[0]).toEqual(['timeGridDay'])
+  })
+})

--- a/tests/unit/CalendarWidgetLegend.test.js
+++ b/tests/unit/CalendarWidgetLegend.test.js
@@ -1,0 +1,14 @@
+/** Test de CalendarWidgetLegend (H8 ≤300) : 3 pastilles de légende. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import CalendarWidgetLegend from '@/components/widgets/CalendarWidgetLegend.vue'
+
+describe('CalendarWidgetLegend (H8)', () => {
+  it('affiche les 3 types (séances, évaluations, visioconférences)', () => {
+    const w = mount(CalendarWidgetLegend)
+    expect(w.findAll('.legend-item')).toHaveLength(3)
+    expect(w.findAll('.legend-dot.seance')).toHaveLength(1)
+    expect(w.findAll('.legend-dot.evaluation')).toHaveLength(1)
+    expect(w.findAll('.legend-dot.visio')).toHaveLength(1)
+  })
+})

--- a/tests/unit/EventDetailActions.test.js
+++ b/tests/unit/EventDetailActions.test.js
@@ -1,0 +1,50 @@
+/**
+ * Test de EventDetailActions (H8 ≤300) : visibilité des boutons selon le rôle/capacités
+ * et émission de `action` avec le bon type.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import EventDetailActions from '@/components/calendar/EventDetailActions.vue'
+
+function mountActions(props = {}) {
+  return mount(EventDetailActions, {
+    props: { userRole: 'student', isSeance: true, eventData: {}, ...props }
+  })
+}
+
+describe('EventDetailActions (H8)', () => {
+  it('affiche toujours "Voir détails complets" et émet viewDetails', async () => {
+    const w = mountActions()
+    await w.find('.action-btn.outline').trigger('click')
+    expect(w.emitted('action')[0]).toEqual(['viewDetails'])
+  })
+
+  it('étudiant: bouton rejoindre visio si canJoinVisio', async () => {
+    const w = mountActions({ canJoinVisio: true })
+    const join = w.find('.action-btn.primary')
+    expect(join.exists()).toBe(true)
+    await join.trigger('click')
+    expect(w.emitted('action')[0]).toEqual(['joinVisio'])
+  })
+
+  it('étudiant: message d’attente si visio programmée et pas de jointure', () => {
+    const w = mountActions({ canJoinVisio: false, eventData: { visio: { status: 'programmee' } } })
+    expect(w.find('.waiting-message').exists()).toBe(true)
+  })
+
+  it('enseignant: 5 boutons (capacités max) dont outline', () => {
+    const w = mountActions({
+      userRole: 'teacher',
+      canActivateVisio: true, canStartVisio: true, canEndVisio: true
+    })
+    // activer + démarrer + terminer + participants + exporter + outline = 6
+    expect(w.findAll('.action-btn')).toHaveLength(6)
+  })
+
+  it('admin: bascule libellé visio selon enabled + supprimer', async () => {
+    const w = mountActions({ userRole: 'admin', eventData: { visio: { enabled: true } } })
+    expect(w.text()).toContain('Désactiver')
+    await w.find('.action-btn.danger').trigger('click')
+    expect(w.emitted('action')[0]).toEqual(['delete'])
+  })
+})

--- a/tests/unit/EventEvaluationDetails.test.js
+++ b/tests/unit/EventEvaluationDetails.test.js
@@ -1,0 +1,35 @@
+/**
+ * Test de EventEvaluationDetails (H8 ≤300) : champs éval + section résultat.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import EventEvaluationDetails from '@/components/calendar/EventEvaluationDetails.vue'
+
+describe('EventEvaluationDetails (H8)', () => {
+  it('affiche matière, durée, barème, coefficient', () => {
+    const w = mount(EventEvaluationDetails, {
+      props: {
+        eventData: { matiere_nom: 'Histoire', duree_minutes: 45, bareme: 20, coefficient: 2 },
+        formattedDate: 'lundi 20 octobre 2025'
+      }
+    })
+    const values = w.findAll('.detail-value').map(n => n.text())
+    expect(values).toContain('Histoire')
+    expect(values).toContain('45 minutes')
+    expect(values).toContain('20/20')
+    expect(values).toContain('2')
+  })
+
+  it('affiche la section résultat si une note est soumise', () => {
+    const w = mount(EventEvaluationDetails, {
+      props: { eventData: { student_submission: { note_sur_20: 15 } }, formattedDate: 'x' }
+    })
+    expect(w.find('.result-section').exists()).toBe(true)
+    expect(w.find('.score-value').text()).toBe('15')
+  })
+
+  it('masque la section résultat sans note', () => {
+    const w = mount(EventEvaluationDetails, { props: { eventData: {}, formattedDate: 'x' } })
+    expect(w.find('.result-section').exists()).toBe(false)
+  })
+})

--- a/tests/unit/EventSeanceDetails.test.js
+++ b/tests/unit/EventSeanceDetails.test.js
@@ -1,0 +1,40 @@
+/**
+ * Test de EventSeanceDetails (H8 ≤300) : rendu des champs séance + section visio.
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import EventSeanceDetails from '@/components/calendar/EventSeanceDetails.vue'
+
+describe('EventSeanceDetails (H8)', () => {
+  it('affiche matière, classe et les valeurs formatées', () => {
+    const w = mount(EventSeanceDetails, {
+      props: {
+        eventData: { matiere_nom: 'Maths', classe_nom: '6e A' },
+        formattedDate: 'lundi 20 octobre 2025',
+        formattedTimeRange: '09:00 - 10:00',
+        visioStatusText: 'En direct'
+      }
+    })
+    const values = w.findAll('.detail-value').map(n => n.text())
+    expect(values).toContain('Maths')
+    expect(values).toContain('6e A')
+    expect(values).toContain('lundi 20 octobre 2025')
+    expect(values).toContain('09:00 - 10:00')
+  })
+
+  it('affiche la section visio si activée', () => {
+    const w = mount(EventSeanceDetails, {
+      props: {
+        eventData: { visio: { enabled: true, status: 'active' } },
+        visioStatusText: 'En direct'
+      }
+    })
+    expect(w.find('.visio-section').exists()).toBe(true)
+    expect(w.find('.visio-status').text()).toBe('En direct')
+  })
+
+  it('masque la section visio si non activée', () => {
+    const w = mount(EventSeanceDetails, { props: { eventData: {} } })
+    expect(w.find('.visio-section').exists()).toBe(false)
+  })
+})

--- a/tests/unit/NotificationItem.test.js
+++ b/tests/unit/NotificationItem.test.js
@@ -1,0 +1,52 @@
+/**
+ * Test de rendu/émissions de NotificationItem (H8 ≤300) : sous-composant
+ * présentationnel. Vérifie titre/message, classe de type, et émissions
+ * (click / mark-read / delete).
+ */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import NotificationItem from '@/components/widgets/NotificationItem.vue'
+
+function mountItem(overrides = {}) {
+  const notification = {
+    id: 7,
+    is_unread: true,
+    time_ago: 'il y a 5 min',
+    data: { type: 'warning', icon: 'ExclamationCircleIcon', title: 'Titre', message: 'Message', ...(overrides.data || {}) },
+    ...overrides
+  }
+  return mount(NotificationItem, { props: { notification } })
+}
+
+describe('NotificationItem (H8)', () => {
+  it('affiche titre, message et temps', () => {
+    const w = mountItem()
+    expect(w.find('.notification-title').text()).toBe('Titre')
+    expect(w.find('.notification-message').text()).toBe('Message')
+    expect(w.find('.notification-time').text()).toBe('il y a 5 min')
+  })
+
+  it('applique la classe de type (warning)', () => {
+    const w = mountItem()
+    expect(w.find('.notification-icon').classes()).toContain('type-warning')
+  })
+
+  it('émet `click` avec la notification', async () => {
+    const w = mountItem()
+    await w.find('.notification-item').trigger('click')
+    expect(w.emitted('click')[0][0].id).toBe(7)
+  })
+
+  it('émet `mark-read` (id) si non-lue, et `delete` (id)', async () => {
+    const w = mountItem()
+    await w.find('.mark-read-btn').trigger('click')
+    expect(w.emitted('mark-read')[0]).toEqual([7])
+    await w.find('.delete-btn').trigger('click')
+    expect(w.emitted('delete')[0]).toEqual([7])
+  })
+
+  it("n'affiche pas le bouton mark-read si déjà lue", () => {
+    const w = mountItem({ is_unread: false })
+    expect(w.find('.mark-read-btn').exists()).toBe(false)
+  })
+})

--- a/tests/unit/UniversalCalendar.test.js
+++ b/tests/unit/UniversalCalendar.test.js
@@ -1,12 +1,13 @@
 /**
- * Test de montage (smoke) de UniversalCalendar.vue (#28bis / G8 — Agent B).
- * Le composant utilise useRouter(), le composable useCalendarEvents (appels réseau),
- * FullCalendar et les sous-composants CalendarFilters / EventDetailModal.
+ * Test de montage (smoke) de UniversalCalendar.vue (#28bis / G8 / H8).
+ * Depuis H8, l'orchestrateur compose CalendarNavigation, CalendarFilters,
+ * CalendarView (qui rend FullCalendar), CalendarLegend et EventDetailModal, et
+ * délègue l'état de la vue à useCalendarView.
  * On mocke :
  *  - vue-router (useRouter)
  *  - @/composables/useCalendarEvents → refs neutres + loadEvents/refreshData no-op (zéro réseau)
- * et on stub FullCalendar, CalendarFilters, EventDetailModal, ContentLoader.
- * Assertion : montage sans erreur (racine .calendar-container présente).
+ * et on stub les sous-composants présentationnels.
+ * Assertion : montage sans erreur (racine .calendar-container présente) + loadEvents au montage.
  */
 import { mount } from '@vue/test-utils'
 import { ref } from 'vue'
@@ -39,10 +40,11 @@ function mountCalendar(props = {}) {
     props: { userRole: 'teacher', userId: 1, ...props },
     global: {
       stubs: {
-        FullCalendar: true,
+        CalendarNavigation: true,
         CalendarFilters: true,
-        EventDetailModal: true,
-        ContentLoader: true
+        CalendarView: true,
+        CalendarLegend: true,
+        EventDetailModal: true
       }
     }
   })

--- a/tests/unit/useCalendarView.test.js
+++ b/tests/unit/useCalendarView.test.js
@@ -1,0 +1,80 @@
+/**
+ * Test du composable useCalendarView (H8 — décomposition UniversalCalendar).
+ * Logique de la vue FullCalendar : label du mois, options, navigation impérative
+ * et synchronisation des événements. L'API FullCalendar est simulée via un faux
+ * objet exposant getApi() (calque du contrat de <CalendarView>).
+ */
+import { ref, computed, nextTick } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+import { useCalendarView } from '@/composables/useCalendarView'
+
+function makeApi() {
+  return {
+    changeView: vi.fn(),
+    prev: vi.fn(),
+    next: vi.fn(),
+    today: vi.fn(),
+    removeAllEvents: vi.fn(),
+    addEvent: vi.fn()
+  }
+}
+
+function setup(initialEvents = []) {
+  const api = makeApi()
+  const calendarRef = ref({ getApi: () => api })
+  const filteredEvents = ref(initialEvents)
+  const onEventClick = vi.fn()
+  const vm = useCalendarView({
+    calendarRef,
+    filteredEvents: computed(() => filteredEvents.value),
+    onEventClick
+  })
+  return { vm, api, calendarRef, filteredEvents, onEventClick }
+}
+
+describe('useCalendarView (H8)', () => {
+  it('expose un label de mois en français', () => {
+    const { vm } = setup()
+    expect(typeof vm.currentMonthLabel.value).toBe('string')
+    expect(vm.currentMonthLabel.value.length).toBeGreaterThan(0)
+  })
+
+  it('calendarOptions reflète les événements filtrés et la vue courante', () => {
+    const { vm } = setup([{ id: 'seance-1' }])
+    expect(vm.calendarOptions.value.initialView).toBe('dayGridMonth')
+    expect(vm.calendarOptions.value.events).toHaveLength(1)
+    expect(vm.calendarOptions.value.locale).toBeDefined()
+  })
+
+  it('changeView met à jour currentView et pilote l’API', () => {
+    const { vm, api } = setup()
+    vm.changeView('timeGridWeek')
+    expect(vm.currentView.value).toBe('timeGridWeek')
+    expect(api.changeView).toHaveBeenCalledWith('timeGridWeek')
+  })
+
+  it('previousMonth / nextMonth / goToToday pilotent l’API', () => {
+    const { vm, api } = setup()
+    vm.previousMonth(); vm.nextMonth(); vm.goToToday()
+    expect(api.prev).toHaveBeenCalled()
+    expect(api.next).toHaveBeenCalled()
+    expect(api.today).toHaveBeenCalled()
+  })
+
+  it('eventClick relaie l’événement à onEventClick', () => {
+    const { vm, onEventClick } = setup()
+    const fakeEvent = { id: 'eval-1' }
+    vm.calendarOptions.value.eventClick({ event: fakeEvent })
+    expect(onEventClick).toHaveBeenCalledWith(fakeEvent)
+  })
+
+  it('synchronise FullCalendar quand les événements filtrés changent', async () => {
+    const { api, filteredEvents } = setup([])
+    api.removeAllEvents.mockClear()
+    api.addEvent.mockClear()
+    filteredEvents.value = [{ id: 'seance-1' }, { id: 'seance-2' }]
+    await nextTick()
+    expect(api.removeAllEvents).toHaveBeenCalled()
+    expect(api.addEvent).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/useCalendarWidget.test.js
+++ b/tests/unit/useCalendarWidget.test.js
@@ -1,0 +1,68 @@
+/**
+ * Test du composable useCalendarWidget (H8 ≤300) : config FullCalendar, bascule de
+ * vue, sélection d'événement (+ emit) et navigation. Router mocké ; pas de
+ * FullCalendar réel (calendarRef nul → getApi() null-safe).
+ */
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+
+const push = vi.fn()
+vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
+
+import { useCalendarWidget } from '@/composables/useCalendarWidget'
+
+function setup(props = {}) {
+  let api
+  const emitted = []
+  const Comp = defineComponent({
+    emits: ['event-click', 'date-click'],
+    setup(_, { emit }) {
+      api = useCalendarWidget(
+        { events: [{ id: 1 }], height: '500px', ...props },
+        (e, p) => { emitted.push([e, p]); emit(e, p) }
+      )
+      return () => null
+    }
+  })
+  mount(Comp)
+  return { api, emitted }
+}
+
+describe('useCalendarWidget (H8)', () => {
+  it('expose une config FullCalendar avec les événements de la prop', () => {
+    const { api } = setup()
+    expect(api.calendarOptions.value.events).toEqual([{ id: 1 }])
+    expect(api.calendarOptions.value.height).toBe('500px')
+    expect(api.currentView.value).toBe('dayGridMonth')
+  })
+
+  it('change la vue courante', () => {
+    const { api } = setup()
+    api.changeView('timeGridWeek')
+    expect(api.currentView.value).toBe('timeGridWeek')
+  })
+
+  it('sélectionne un événement au clic et émet event-click', () => {
+    const { api, emitted } = setup()
+    const ev = { id: 9, title: 'X' }
+    api.handleEventClick({ event: ev })
+    expect(api.selectedEvent.value).toEqual(ev)
+    expect(emitted).toContainEqual(['event-click', ev])
+  })
+
+  it('ferme la modale (selectedEvent = null)', () => {
+    const { api } = setup()
+    api.handleEventClick({ event: { id: 1 } })
+    api.closeEventModal()
+    expect(api.selectedEvent.value).toBe(null)
+  })
+
+  it('navigue via goToEvent si une url est présente, puis ferme', () => {
+    const { api } = setup()
+    api.handleEventClick({ event: { id: 1, extendedProps: { url: '/seances/1' } } })
+    api.goToEvent()
+    expect(push).toHaveBeenCalledWith('/seances/1')
+    expect(api.selectedEvent.value).toBe(null)
+  })
+})

--- a/tests/unit/useEventDetail.test.js
+++ b/tests/unit/useEventDetail.test.js
@@ -1,0 +1,70 @@
+/**
+ * Test du composable useEventDetail (H8 ≤300) : type d'événement, titre, statut,
+ * capacités selon le rôle, formatage et émission d'action.
+ */
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+import { useEventDetail } from '@/composables/useEventDetail'
+
+function setup(event, userRole) {
+  let api
+  const emitted = []
+  const Comp = defineComponent({
+    setup() {
+      api = useEventDetail({ event, userRole }, (e, p) => emitted.push([e, p]))
+      return () => null
+    }
+  })
+  mount(Comp)
+  return { api, emitted }
+}
+
+const seance = (data = {}) => ({
+  title: 'Cours', start: '2025-10-20T09:00:00', end: '2025-10-20T10:00:00',
+  extendedProps: { eventType: 'seance', data: { titre: 'Maths', ...data } }
+})
+const evaluation = (data = {}) => ({
+  title: 'Éval', start: '2025-10-20T09:00:00',
+  extendedProps: { eventType: 'evaluation', data: { ...data } }
+})
+
+describe('useEventDetail (H8)', () => {
+  it('détermine le type et le titre (data.titre prioritaire)', () => {
+    const { api } = setup(seance(), 'student')
+    expect(api.isSeance.value).toBe(true)
+    expect(api.eventTitle.value).toBe('Maths')
+  })
+
+  it('mappe le statut séance selon la visio (active → En direct)', () => {
+    const { api } = setup(seance({ visio: { status: 'active' } }), 'student')
+    expect(api.statusClass.value).toBe('status-active')
+    expect(api.statusLabel.value).toBe('En direct')
+    expect(api.visioStatusText.value).toBe('En direct')
+  })
+
+  it('canJoinVisio: vrai seulement pour un étudiant si la visio est active', () => {
+    expect(setup(seance({ visio: { status: 'active' } }), 'student').api.canJoinVisio.value).toBe(true)
+    expect(setup(seance({ visio: { status: 'programmee' } }), 'student').api.canJoinVisio.value).toBe(false)
+    expect(setup(seance({ visio: { status: 'active' } }), 'teacher').api.canJoinVisio.value).toBe(false)
+  })
+
+  it('capacités enseignant: activer/démarrer/terminer selon état visio', () => {
+    expect(setup(seance({ visio: { enabled: false } }), 'teacher').api.canActivateVisio.value).toBe(true)
+    expect(setup(seance({ visio: { enabled: true, status: 'programmee' } }), 'teacher').api.canStartVisio.value).toBe(true)
+    expect(setup(seance({ visio: { enabled: true, status: 'active' } }), 'teacher').api.canEndVisio.value).toBe(true)
+  })
+
+  it('canStartEvaluation: étudiant, éval non terminée et non soumise', () => {
+    expect(setup(evaluation({ status: 'programmee' }), 'student').api.canStartEvaluation.value).toBe(true)
+    expect(setup(evaluation({ status: 'terminee' }), 'student').api.canStartEvaluation.value).toBe(false)
+  })
+
+  it('formate la date (fr-FR) et émet une action avec data', () => {
+    const { api, emitted } = setup(seance(), 'student')
+    expect(api.formattedDate.value).toContain('2025')
+    api.emitAction('viewDetails')
+    expect(emitted[0][0]).toBe('action')
+    expect(emitted[0][1]).toEqual({ type: 'viewDetails', data: { titre: 'Maths' } })
+  })
+})

--- a/tests/unit/useNotificationsWidget.test.js
+++ b/tests/unit/useNotificationsWidget.test.js
@@ -1,0 +1,93 @@
+/**
+ * Test du composable useNotificationsWidget (H8 ≤300) : chargement au montage,
+ * marquage lu (local + compteur), suppression. Service + router mockés.
+ */
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { getRecentNotifications, getUnreadCount, markAsRead, markAllAsRead, deleteNotification } = vi.hoisted(() => ({
+  getRecentNotifications: vi.fn(),
+  getUnreadCount: vi.fn(),
+  markAsRead: vi.fn(),
+  markAllAsRead: vi.fn(),
+  deleteNotification: vi.fn()
+}))
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/services/notifications', () => ({
+  notificationsService: { getRecentNotifications, getUnreadCount, markAsRead, markAllAsRead, deleteNotification }
+}))
+
+import { useNotificationsWidget } from '@/composables/useNotificationsWidget'
+
+function sample() {
+  return [
+    { id: 1, is_unread: true, time_ago: 'now', data: { type: 'info', icon: 'BellIcon', title: 'A', message: 'a' } },
+    { id: 2, is_unread: false, time_ago: '1h', data: { type: 'success', icon: 'CheckCircleIcon', title: 'B', message: 'b' } }
+  ]
+}
+
+async function setup(props = {}) {
+  let api
+  const emitted = []
+  const Comp = defineComponent({
+    emits: ['notification-read', 'notification-deleted', 'notification-click'],
+    setup(_, { emit }) {
+      api = useNotificationsWidget(
+        { limit: 5, autoRefresh: false, refreshInterval: 60000, ...props },
+        (e, p) => { emitted.push([e, p]); emit(e, p) }
+      )
+      return () => null
+    }
+  })
+  mount(Comp)
+  await flushPromises()
+  return { api, emitted }
+}
+
+describe('useNotificationsWidget (H8)', () => {
+  beforeEach(() => {
+    getRecentNotifications.mockResolvedValue(sample())
+    getUnreadCount.mockResolvedValue(1)
+    markAsRead.mockResolvedValue(true)
+    markAllAsRead.mockResolvedValue(true)
+    deleteNotification.mockResolvedValue(true)
+  })
+
+  it('charge les notifications au montage avec la limite fournie', async () => {
+    const { api } = await setup({ limit: 5 })
+    expect(getRecentNotifications).toHaveBeenCalledWith(5)
+    expect(getUnreadCount).toHaveBeenCalled()
+    expect(api.notifications.value).toHaveLength(2)
+    expect(api.unreadCount.value).toBe(1)
+    expect(api.loading.value).toBe(false)
+  })
+
+  it('marque une notification comme lue (local + compteur + emit)', async () => {
+    const { api, emitted } = await setup()
+    await api.handleMarkAsRead(1)
+    expect(markAsRead).toHaveBeenCalledWith(1)
+    expect(api.notifications.value.find(n => n.id === 1).is_unread).toBe(false)
+    expect(api.unreadCount.value).toBe(0)
+    expect(emitted).toContainEqual(['notification-read', 1])
+  })
+
+  it('supprime une notification et décrémente le compteur si elle était non-lue', async () => {
+    const { api, emitted } = await setup()
+    await api.handleDelete(1)
+    expect(deleteNotification).toHaveBeenCalledWith(1)
+    expect(api.notifications.value).toHaveLength(1)
+    expect(api.unreadCount.value).toBe(0)
+    expect(emitted).toContainEqual(['notification-deleted', 1])
+  })
+
+  it('marque tout comme lu', async () => {
+    const { api, emitted } = await setup()
+    await api.handleMarkAllAsRead()
+    expect(markAllAsRead).toHaveBeenCalled()
+    expect(api.notifications.value.every(n => !n.is_unread)).toBe(true)
+    expect(api.unreadCount.value).toBe(0)
+    expect(emitted).toContainEqual(['notification-read', 'all'])
+  })
+})


### PR DESCRIPTION
## Lot H8 — Calendrier & Widgets (chantier ≤300 lignes par FICHIER ENTIER)

Éclatement complet (pattern G1) des 4 fichiers du lot : composables `use*` + sous-composants présentationnels + CSS distribué **verbatim** + tests. **Aucun** service/util/partial existant modifié — uniquement consommés. Dettes pré-existantes conservées à l'identique et documentées.

### Bilan par fichier (avant → après)

| Fichier du lot | Avant | Après | Fichiers créés |
|---|---|---|---|
| `widgets/NotificationsWidget.vue` | 552 | **285** | `composables/useNotificationsWidget.js` (128), `widgets/NotificationItem.vue` (219) |
| `widgets/CalendarWidget.vue` | 570 | **258** | `composables/useCalendarWidget.js` (114), `widgets/CalendarWidgetLegend.vue` (72), `widgets/CalendarEventModal.vue` (213) |
| `calendar/EventDetailModal.vue` | 744 | **202** | `composables/useEventDetail.js` (162), `calendar/EventSeanceDetails.vue` (174), `calendar/EventEvaluationDetails.vue` (168), `calendar/EventDetailActions.vue` (237) |
| `calendar/UniversalCalendar.vue` | 1154 | **228** | `composables/useCalendarView.js` (150), `calendar/CalendarNavigation.vue` (265), `calendar/CalendarViewSelector.vue` (137), `calendar/CalendarView.vue` (221), `calendar/CalendarLegend.vue` (131), partials `_calendar-fc-dark.scss` (188) + `_calendar-shell-dark.scss` (91) |

**Tous les fichiers produits sont ≤300 lignes** (max : CalendarNavigation 265).

### Méthode (parité par construction)
- Tout le `<script>` (état, appels services, computed, handlers, watch, onMounted) → composables `use*`.
- Sections de template → sous-composants présentationnels (props pour les données, `emit`/`defineModel` pour les actions), avec **CSS déplacé verbatim** (`@media` inclus).
- UniversalCalendar : le bloc dark mode global (non-scoped) a été relocalisé verbatim — `.fc` + carte + loader dans `_calendar-fc-dark.scss` (`@use` depuis CalendarView), coque + filtres dans `_calendar-shell-dark.scss` (`@use` depuis l'orchestrateur) ; nav / sélecteur / légende portent leur propre dark mode. Mêmes appels API, mêmes classes/couleurs/textes.

### Dettes pré-existantes conservées à l'identique (documentées dans les commits)
- **UniversalCalendar** : `router` (`useRouter`) déclaré sans usage ; règle media scoped `.filters-content`/`.filter-count` qui ne cible plus rien depuis l'extraction de CalendarFilters (#28bis).
- **NotificationsWidget** : styles `.loading-state`/`.spinner` morts (le template emploie `<ContentLoader>`).
- **EventDetailModal** : `console.log` de debug dans `canJoinVisio`.

### Vérifications
- `npx vite build` → ✅ exit 0 (warning chunk-size préexistant ignoré).
- Tests Vitest ciblés H8 → ✅ tous verts (composables + montage des sous-composants + parité comportementale). Nouveaux tests : useNotificationsWidget, NotificationItem, useCalendarWidget, CalendarEventModal, CalendarWidgetLegend, useEventDetail, EventDetailActions, EventSeanceDetails, EventEvaluationDetails (+ tests UniversalCalendar/Nav/ViewSelector/View/Legend/useCalendarView).
- `wc -l` ≤300 sur chaque fichier produit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)