### PR TITLE
refactor(lessons): LessonEditor sous 300 lignes — éclatement complet (H4)

### DIFF
--- a/src/components/lessons/LessonBasicInfoFields.vue
+++ b/src/components/lessons/LessonBasicInfoFields.vue
@@ -1,0 +1,208 @@
+<template>
+  <div class="form-section">
+    <h2 class="section-title"><i class="fa fa-info-circle"></i> Informations de base</h2>
+
+    <div class="form-row">
+      <div class="form-group full-width">
+        <label class="form-label required">Titre</label>
+        <input
+          v-model="title"
+          type="text"
+          required
+          class="form-input"
+          placeholder="Ex: Introduction à Laravel"
+        />
+      </div>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group full-width">
+        <label class="form-label">Description courte</label>
+        <textarea
+          v-model="description"
+          rows="3"
+          class="form-textarea"
+          placeholder="Résumé de la leçon (2-3 phrases)"
+        ></textarea>
+      </div>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group">
+        <label class="form-label required">Type de leçon</label>
+        <select v-model="type" required class="form-select">
+          <option value="cours">Cours magistral</option>
+          <option value="tp">Travaux Pratiques (TP)</option>
+          <option value="td">Travaux Dirigés (TD)</option>
+          <option value="projet">Projet</option>
+          <option value="autre">Autre</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Durée estimée (minutes)</label>
+        <input
+          v-model.number="durationMinutes"
+          type="number"
+          min="1"
+          class="form-input"
+          placeholder="Ex: 120"
+        />
+      </div>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group">
+        <label class="form-label">Matière</label>
+        <select v-model.number="matiereId" class="form-select" @change="$emit('load-chapters')">
+          <option :value="null">Sélectionnez une matière</option>
+          <option v-for="matiere in matieres" :key="matiere.id" :value="matiere.id">
+            {{ matiere.nom || matiere.name }}
+          </option>
+        </select>
+        <p class="form-hint">Optionnel - Matière associée à cette leçon</p>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Classe</label>
+        <select v-model.number="classeId" class="form-select">
+          <option :value="null">Sélectionnez une classe</option>
+          <option v-for="classe in classes" :key="classe.id" :value="classe.id">
+            {{ classe.name || classe.nom }}
+          </option>
+        </select>
+        <p class="form-hint">Optionnel - Classe associée à cette leçon</p>
+      </div>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group full-width">
+        <label class="form-label">Chapitre / Module (optionnel)</label>
+        <select v-model="chapterId" class="form-select" :disabled="loadingChapters">
+          <option :value="null">Aucun chapitre (leçon indépendante)</option>
+          <option v-for="chapter in chapters" :key="chapter.id" :value="chapter.id">
+            {{ chapter.title }}
+          </option>
+        </select>
+        <p class="form-hint">Associer cette leçon à un chapitre pour mieux organiser votre cours</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Section « Informations de base » de LessonEditor (#H4 ≤300) : titre, description,
+ * type, durée, matière, classe, chapitre. Champs en v-model (defineModel) ; matières/
+ * classes/chapitres via props ; `load-chapters` émis au changement de matière.
+ * Chrome de formulaire dupliqué VERBATIM (pas de partial, choix utilisateur).
+ */
+const title = defineModel('title', { type: String, default: '' })
+const description = defineModel('description', { type: String, default: '' })
+const type = defineModel('type', { type: String, default: 'cours' })
+const durationMinutes = defineModel('durationMinutes', { default: null })
+const matiereId = defineModel('matiereId', { default: null })
+const classeId = defineModel('classeId', { default: null })
+const chapterId = defineModel('chapterId', { default: null })
+
+defineProps({
+  matieres: { type: Array, default: () => [] },
+  classes: { type: Array, default: () => [] },
+  chapters: { type: Array, default: () => [] },
+  loadingChapters: { type: Boolean, default: false }
+})
+
+defineEmits(['load-chapters'])
+</script>
+
+<style scoped>
+.form-section {
+  background: var(--card-bg);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  box-shadow: var(--card-shadow);
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 1.5rem 0;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-row:last-child {
+  margin-bottom: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.form-label.required::after {
+  content: ' *';
+  color: #ef4444;
+}
+
+.form-input,
+.form-select,
+.form-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  transition: all 0.2s;
+}
+
+.form-input:focus,
+.form-select:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-input::placeholder,
+.form-textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.form-textarea {
+  resize: vertical;
+  font-family: inherit;
+}
+
+.form-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/lessons/LessonContentFields.vue
+++ b/src/components/lessons/LessonContentFields.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="form-section">
+    <h2 class="section-title"><i class="fa fa-file-text"></i> Contenu principal</h2>
+
+    <!-- Contenu VIDÉO -->
+    <div v-if="contentType === 'video'" class="content-fields">
+      <div class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label required">URL de la vidéo</label>
+          <input
+            v-model="videoUrl"
+            type="url"
+            class="form-input"
+            placeholder="https://www.youtube.com/watch?v=..."
+          />
+          <p class="form-hint">URL complète de la vidéo (YouTube, Vimeo, etc.)</p>
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label">Plateforme vidéo</label>
+          <div class="radio-group">
+            <label
+              v-for="provider in videoProviders"
+              :key="provider.value"
+              :class="['radio-card', { 'active': videoProvider === provider.value }]"
+            >
+              <input
+                v-model="videoProvider"
+                type="radio"
+                :value="provider.value"
+              />
+              <span>{{ provider.icon }} {{ provider.label }}</span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Contenu PDF -->
+    <div v-else-if="contentType === 'pdf'" class="content-fields">
+      <div class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label required">URL du fichier PDF</label>
+          <input
+            v-model="pdfUrl"
+            type="url"
+            class="form-input"
+            placeholder="https://exemple.com/document.pdf"
+          />
+          <p class="form-hint">URL publique du document PDF à afficher</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Contenu AUDIO -->
+    <div v-else-if="contentType === 'audio'" class="content-fields">
+      <div class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label required">URL du fichier audio</label>
+          <input
+            v-model="audioUrl"
+            type="url"
+            class="form-input"
+            placeholder="https://exemple.com/audio.mp3"
+          />
+          <p class="form-hint">URL du fichier audio (MP3, WAV, OGG, etc.)</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Contenu PRÉSENTATION -->
+    <div v-else-if="contentType === 'presentation'" class="content-fields">
+      <div class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label required">URL de la présentation</label>
+          <input
+            v-model="presentationUrl"
+            type="url"
+            class="form-input"
+            placeholder="https://docs.google.com/presentation/d/..."
+          />
+          <p class="form-hint">URL de Google Slides, PowerPoint Online, ou autre plateforme</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Contenu LIEN EXTERNE -->
+    <div v-else-if="contentType === 'link'" class="content-fields">
+      <div class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label required">Lien externe</label>
+          <input
+            v-model="externalLink"
+            type="url"
+            class="form-input"
+            placeholder="https://exemple.com/ressource-externe"
+          />
+          <p class="form-hint">Lien vers une page web, un article, ou une ressource externe</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Contenu TEXTE ou MIXTE -->
+    <LessonRichTextEditor
+      v-else-if="contentType === 'text' || contentType === 'mixed'"
+      v-model="content"
+    />
+  </div>
+</template>
+
+<script setup>
+/**
+ * Section « Contenu principal » de LessonEditor (#H4 ≤300) : affiche les champs selon
+ * le type (vidéo+plateforme, PDF, audio, présentation, lien) et délègue texte/mixte à
+ * LessonRichTextEditor. Champs en v-model (defineModel). Chrome dupliqué VERBATIM.
+ */
+import LessonRichTextEditor from '@/components/lessons/LessonRichTextEditor.vue'
+
+const videoUrl = defineModel('videoUrl', { type: String, default: '' })
+const videoProvider = defineModel('videoProvider', { type: String, default: 'youtube' })
+const pdfUrl = defineModel('pdfUrl', { type: String, default: '' })
+const audioUrl = defineModel('audioUrl', { type: String, default: '' })
+const presentationUrl = defineModel('presentationUrl', { type: String, default: '' })
+const externalLink = defineModel('externalLink', { type: String, default: '' })
+const content = defineModel('content', { type: String, default: '' })
+
+defineProps({
+  contentType: { type: String, default: 'text' },
+  videoProviders: { type: Array, default: () => [] }
+})
+</script>
+
+<style scoped>
+.form-section {
+  background: var(--card-bg);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  box-shadow: var(--card-shadow);
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 1.5rem 0;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-row:last-child {
+  margin-bottom: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.form-label.required::after {
+  content: ' *';
+  color: #ef4444;
+}
+
+.form-input,
+.form-select,
+.form-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  transition: all 0.2s;
+}
+
+.form-input:focus,
+.form-select:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-input::placeholder,
+.form-textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.form-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+/* Radio Group */
+.radio-group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.radio-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-primary);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.radio-card:hover {
+  background: var(--bg-tertiary);
+}
+
+.radio-card.active {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: #3b82f6;
+}
+
+.radio-card input[type="radio"] {
+  margin: 0;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .radio-group {
+    flex-direction: column;
+  }
+}
+</style>

--- a/src/components/lessons/LessonContentTypePicker.vue
+++ b/src/components/lessons/LessonContentTypePicker.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="form-section">
+    <h2 class="section-title"><i class="fa fa-th-large"></i> Type de contenu principal</h2>
+
+    <div class="content-type-grid">
+      <label
+        v-for="type in contentTypes"
+        :key="type.value"
+        :class="['content-type-card', { 'active': contentType === type.value }]"
+      >
+        <input
+          v-model="contentType"
+          type="radio"
+          :value="type.value"
+          class="content-type-radio"
+        />
+        <div class="content-type-icon">{{ type.icon }}</div>
+        <div class="content-type-label">{{ type.label }}</div>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Sélecteur du type de contenu principal de LessonEditor (#H4 ≤300) : grille de cartes
+ * radio. Type sélectionné en v-model (defineModel), liste via la prop `contentTypes`.
+ * Chrome de formulaire dupliqué VERBATIM.
+ */
+const contentType = defineModel({ type: String, default: 'text' })
+
+defineProps({
+  contentTypes: { type: Array, default: () => [] }
+})
+</script>
+
+<style scoped>
+.form-section {
+  background: var(--card-bg);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  box-shadow: var(--card-shadow);
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 1.5rem 0;
+}
+
+/* Content Type Grid */
+.content-type-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.content-type-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-primary);
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.content-type-card:hover {
+  background: var(--bg-tertiary);
+  transform: translateY(-2px);
+}
+
+.content-type-card.active {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: #3b82f6;
+}
+
+.content-type-radio {
+  position: absolute;
+  opacity: 0;
+}
+
+.content-type-icon {
+  font-size: 2rem;
+}
+
+.content-type-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-align: center;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .content-type-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+</style>

--- a/src/components/lessons/LessonEditorActions.vue
+++ b/src/components/lessons/LessonEditorActions.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="form-actions">
+    <button type="button" @click="$emit('cancel')" class="btn-cancel">
+      Annuler
+    </button>
+    <button type="submit" :disabled="saving" class="btn-save">
+      {{ saving ? 'Enregistrement...' : (isEditMode ? 'Mettre à jour' : 'Créer la leçon') }}
+    </button>
+    <button
+      v-if="isEditMode"
+      type="button"
+      @click="$emit('delete')"
+      :disabled="saving"
+      class="btn-delete"
+    >
+      Supprimer
+    </button>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Barre d'actions de LessonEditor (#H4 ≤300) : Annuler / Enregistrer (submit) /
+ * Supprimer (mode édition). Le bouton submit déclenche le @submit du formulaire parent ;
+ * cancel/delete relayés via emit. Chrome de boutons dupliqué VERBATIM.
+ */
+defineProps({
+  saving: { type: Boolean, default: false },
+  isEditMode: { type: Boolean, default: false }
+})
+
+defineEmits(['cancel', 'delete'])
+</script>
+
+<style scoped>
+/* Actions */
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  padding: 1.5rem;
+  background: var(--card-bg);
+  border-radius: 0.75rem;
+  box-shadow: var(--card-shadow);
+}
+
+.btn-cancel,
+.btn-save,
+.btn-delete {
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: none;
+}
+
+.btn-cancel {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+}
+
+.btn-cancel:hover {
+  background: var(--bg-tertiary);
+}
+
+.btn-save {
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: white;
+}
+
+.btn-save:hover:not(:disabled) {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  transform: translateY(-1px);
+}
+
+.btn-save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-delete {
+  background: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fca5a5;
+}
+
+.btn-delete:hover:not(:disabled) {
+  background: #fecaca;
+}
+
+.btn-delete:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .form-actions {
+    flex-direction: column;
+  }
+
+  .btn-cancel,
+  .btn-save,
+  .btn-delete {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/lessons/LessonResourcesFields.vue
+++ b/src/components/lessons/LessonResourcesFields.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="form-section">
+    <div class="section-header">
+      <h2 class="section-title"><i class="fa fa-paperclip"></i> Ressources supplémentaires</h2>
+      <button type="button" @click="$emit('add')" class="btn-add">
+        + Ajouter une ressource
+      </button>
+    </div>
+
+    <p class="section-description">
+      Ajoutez des documents PDF, liens, vidéos complémentaires ou autres ressources pour enrichir votre leçon
+    </p>
+
+    <div v-if="resources && resources.length > 0" class="resources-list">
+      <div
+        v-for="(resource, index) in resources"
+        :key="index"
+        class="resource-card"
+      >
+        <div class="resource-header">
+          <span class="resource-number">#{{ index + 1 }}</span>
+          <button
+            type="button"
+            @click="$emit('remove', index)"
+            class="btn-remove"
+          >
+            Supprimer
+          </button>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Titre</label>
+            <input
+              v-model="resource.title"
+              type="text"
+              class="form-input"
+              placeholder="Nom de la ressource"
+            />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Type</label>
+            <select v-model="resource.type" class="form-select">
+              <option value="pdf">PDF</option>
+              <option value="document">Document</option>
+              <option value="link">Lien</option>
+              <option value="video">Vidéo</option>
+              <option value="image">Image</option>
+              <option value="archive">Archive</option>
+              <option value="other">Autre</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group full-width">
+            <label class="form-label">URL</label>
+            <input
+              v-model="resource.url"
+              type="url"
+              class="form-input"
+              placeholder="https://exemple.com/ressource.pdf"
+            />
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group full-width">
+            <label class="form-label">Description (optionnelle)</label>
+            <textarea
+              v-model="resource.description"
+              rows="2"
+              class="form-textarea"
+              placeholder="Description de la ressource..."
+            ></textarea>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else class="resources-empty">
+      <p>Aucune ressource supplémentaire</p>
+      <p class="text-hint">Cliquez sur "Ajouter une ressource" pour en ajouter</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Section « Ressources supplémentaires » de LessonEditor (#H4 ≤300) : liste éditable
+ * de ressources. `add`/`remove` relayés au parent (la mutation de la liste reste dans
+ * le composable) ; les champs éditent en place les objets ressources passés par
+ * référence via la prop `resources`. Chrome dupliqué VERBATIM.
+ */
+defineProps({
+  resources: { type: Array, default: () => [] }
+})
+
+defineEmits(['add', 'remove'])
+</script>
+
+<style scoped>
+.form-section {
+  background: var(--card-bg);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  box-shadow: var(--card-shadow);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 1.5rem 0;
+}
+
+.section-description {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-row:last-child {
+  margin-bottom: 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.form-input,
+.form-select,
+.form-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  transition: all 0.2s;
+}
+
+.form-input:focus,
+.form-select:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-input::placeholder,
+.form-textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.form-textarea {
+  resize: vertical;
+  font-family: inherit;
+}
+
+/* Resources */
+.resources-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.resource-card {
+  padding: 1.5rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+}
+
+.resource-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.resource-number {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.btn-remove {
+  padding: 0.5rem 1rem;
+  background: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fca5a5;
+  border-radius: 0.375rem;
+  font-size: 0.813rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-remove:hover {
+  background: #fecaca;
+}
+
+.resources-empty {
+  text-align: center;
+  padding: 3rem;
+  color: var(--text-tertiary);
+}
+
+.resources-empty p {
+  margin: 0.5rem 0;
+}
+
+.text-hint {
+  font-size: 0.875rem;
+}
+
+.btn-add {
+  padding: 0.75rem 1.5rem;
+  background: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #93c5fd;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-add:hover {
+  background: #bfdbfe;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/lessons/LessonRichTextEditor.vue
+++ b/src/components/lessons/LessonRichTextEditor.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="content-fields">
+    <div class="editor-tabs">
+      <button
+        type="button"
+        @click="showPreview = false"
+        :class="['tab-btn', { 'active': !showPreview }]"
+      >
+        Éditer
+      </button>
+      <button
+        type="button"
+        @click="showPreview = true"
+        :class="['tab-btn', { 'active': showPreview }]"
+      >
+        Prévisualiser
+      </button>
+    </div>
+
+    <div v-show="!showPreview" class="editor-panel">
+      <textarea
+        v-model="content"
+        rows="20"
+        class="form-textarea code-editor"
+        placeholder="Contenu HTML de la leçon...
+
+Exemples:
+<h1>Titre principal</h1>
+<h2>Sous-titre</h2>
+<p>Paragraphe de texte...</p>
+<ul>
+  <li>Élément de liste</li>
+</ul>"
+      ></textarea>
+      <p class="form-hint">Vous pouvez utiliser du HTML pour formater le contenu</p>
+    </div>
+
+    <div v-show="showPreview" class="preview-panel">
+      <div v-if="content" v-html="content" class="preview-content"></div>
+      <div v-else class="preview-empty">Aucun contenu à prévisualiser</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Éditeur de contenu HTML (texte/mixte) de LessonEditor (#H4 ≤300) : onglets
+ * Éditer/Prévisualiser, textarea code + rendu v-html. Contenu en v-model (defineModel) ;
+ * l'état d'onglet (showPreview) est local. Chrome textarea dupliqué VERBATIM.
+ */
+import { ref } from 'vue'
+
+const content = defineModel({ type: String, default: '' })
+const showPreview = ref(false)
+</script>
+
+<style scoped>
+.form-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  transition: all 0.2s;
+  resize: vertical;
+  font-family: inherit;
+}
+
+.form-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-textarea::placeholder {
+  color: var(--text-tertiary);
+}
+
+.form-textarea.code-editor {
+  font-family: 'Courier New', monospace;
+  font-size: 0.813rem;
+}
+
+.form-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+}
+
+/* Editor Tabs */
+.editor-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.tab-btn {
+  padding: 0.75rem 1.5rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.tab-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.tab-btn.active {
+  color: #3b82f6;
+  border-bottom-color: #3b82f6;
+}
+
+/* Preview Panel */
+.preview-panel {
+  min-height: 300px;
+  padding: 1.5rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 0.5rem;
+}
+
+.preview-content {
+  color: var(--text-primary);
+  line-height: 1.75;
+}
+
+.preview-empty {
+  text-align: center;
+  padding: 4rem;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+</style>

--- a/src/components/lessons/LessonStatusPicker.vue
+++ b/src/components/lessons/LessonStatusPicker.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="form-section">
+    <h2 class="section-title"><i class="fa fa-toggle-on"></i> Statut de publication</h2>
+
+    <div class="status-grid">
+      <label :class="['status-card', { 'active': status === 'draft' }]">
+        <input
+          v-model="status"
+          type="radio"
+          value="draft"
+        />
+        <div class="status-icon">[D]</div>
+        <div class="status-name">Brouillon</div>
+        <div class="status-desc">La leçon ne sera pas visible par les étudiants</div>
+      </label>
+
+      <label :class="['status-card', { 'active': status === 'published' }]">
+        <input
+          v-model="status"
+          type="radio"
+          value="published"
+        />
+        <div class="status-icon">[√]</div>
+        <div class="status-name">Publié</div>
+        <div class="status-desc">La leçon sera visible et accessible aux étudiants</div>
+      </label>
+
+      <label :class="['status-card', { 'active': status === 'archived' }]">
+        <input
+          v-model="status"
+          type="radio"
+          value="archived"
+        />
+        <div class="status-icon">[A]</div>
+        <div class="status-name">Archivé</div>
+        <div class="status-desc">La leçon est conservée mais n'est plus accessible</div>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Section « Statut de publication » de LessonEditor (#H4 ≤300) : cartes radio
+ * brouillon/publié/archivé. Statut en v-model (defineModel). Chrome dupliqué VERBATIM.
+ */
+const status = defineModel({ type: String, default: 'draft' })
+</script>
+
+<style scoped>
+.form-section {
+  background: var(--card-bg);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  box-shadow: var(--card-shadow);
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 1.5rem 0;
+}
+
+/* Status Grid */
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.status-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border-primary);
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: center;
+}
+
+.status-card:hover {
+  background: var(--bg-tertiary);
+  transform: translateY(-2px);
+}
+
+.status-card.active {
+  background: rgba(59, 130, 246, 0.1);
+  border-color: #3b82f6;
+}
+
+.status-card input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+}
+
+.status-icon {
+  font-size: 2rem;
+}
+
+.status-name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.status-desc {
+  font-size: 0.813rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/composables/useLessonEditor.js
+++ b/src/composables/useLessonEditor.js
@@ -19,7 +19,6 @@ export function useLessonEditor() {
 
   const loading = ref(false)
   const saving = ref(false)
-  const showPreview = ref(false)
 
   const form = ref({
     title: '',
@@ -238,7 +237,6 @@ export function useLessonEditor() {
   return {
     loading,
     saving,
-    showPreview,
     form,
     chapters,
     loadingChapters,

--- a/src/views/lessons/LessonEditor.vue
+++ b/src/views/lessons/LessonEditor.vue
@@ -22,411 +22,54 @@
       <!-- Formulaire -->
       <form v-else @submit.prevent="saveLesson" class="editor-form">
         <!-- Informations de base -->
-        <div class="form-section">
-          <h2 class="section-title"><i class="fa fa-info-circle"></i> Informations de base</h2>
-
-          <div class="form-row">
-            <div class="form-group full-width">
-              <label class="form-label required">Titre</label>
-              <input
-                v-model="form.title"
-                type="text"
-                required
-                class="form-input"
-                placeholder="Ex: Introduction à Laravel"
-              />
-            </div>
-          </div>
-
-          <div class="form-row">
-            <div class="form-group full-width">
-              <label class="form-label">Description courte</label>
-              <textarea
-                v-model="form.description"
-                rows="3"
-                class="form-textarea"
-                placeholder="Résumé de la leçon (2-3 phrases)"
-              ></textarea>
-            </div>
-          </div>
-
-          <div class="form-row">
-            <div class="form-group">
-              <label class="form-label required">Type de leçon</label>
-              <select v-model="form.type" required class="form-select">
-                <option value="cours">Cours magistral</option>
-                <option value="tp">Travaux Pratiques (TP)</option>
-                <option value="td">Travaux Dirigés (TD)</option>
-                <option value="projet">Projet</option>
-                <option value="autre">Autre</option>
-              </select>
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Durée estimée (minutes)</label>
-              <input
-                v-model.number="form.duration_minutes"
-                type="number"
-                min="1"
-                class="form-input"
-                placeholder="Ex: 120"
-              />
-            </div>
-          </div>
-
-          <div class="form-row">
-            <div class="form-group">
-              <label class="form-label">Matière</label>
-              <select v-model.number="form.matiere_id" class="form-select" @change="loadChapters">
-                <option :value="null">Sélectionnez une matière</option>
-                <option v-for="matiere in matieres" :key="matiere.id" :value="matiere.id">
-                  {{ matiere.nom || matiere.name }}
-                </option>
-              </select>
-              <p class="form-hint">Optionnel - Matière associée à cette leçon</p>
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Classe</label>
-              <select v-model.number="form.classe_id" class="form-select">
-                <option :value="null">Sélectionnez une classe</option>
-                <option v-for="classe in classes" :key="classe.id" :value="classe.id">
-                  {{ classe.name || classe.nom }}
-                </option>
-              </select>
-              <p class="form-hint">Optionnel - Classe associée à cette leçon</p>
-            </div>
-          </div>
-
-          <div class="form-row">
-            <div class="form-group full-width">
-              <label class="form-label">Chapitre / Module (optionnel)</label>
-              <select v-model="form.chapter_id" class="form-select" :disabled="loadingChapters">
-                <option :value="null">Aucun chapitre (leçon indépendante)</option>
-                <option v-for="chapter in chapters" :key="chapter.id" :value="chapter.id">
-                  {{ chapter.title }}
-                </option>
-              </select>
-              <p class="form-hint">Associer cette leçon à un chapitre pour mieux organiser votre cours</p>
-            </div>
-          </div>
-        </div>
+        <LessonBasicInfoFields
+          v-model:title="form.title"
+          v-model:description="form.description"
+          v-model:type="form.type"
+          v-model:duration-minutes="form.duration_minutes"
+          v-model:matiere-id="form.matiere_id"
+          v-model:classe-id="form.classe_id"
+          v-model:chapter-id="form.chapter_id"
+          :matieres="matieres"
+          :classes="classes"
+          :chapters="chapters"
+          :loading-chapters="loadingChapters"
+          @load-chapters="loadChapters"
+        />
 
         <!-- Type de contenu principal -->
-        <div class="form-section">
-          <h2 class="section-title"><i class="fa fa-th-large"></i> Type de contenu principal</h2>
-
-          <div class="content-type-grid">
-            <label
-              v-for="type in contentTypes"
-              :key="type.value"
-              :class="['content-type-card', { 'active': form.content_type === type.value }]"
-            >
-              <input
-                v-model="form.content_type"
-                type="radio"
-                :value="type.value"
-                class="content-type-radio"
-              />
-              <div class="content-type-icon">{{ type.icon }}</div>
-              <div class="content-type-label">{{ type.label }}</div>
-            </label>
-          </div>
-        </div>
+        <LessonContentTypePicker v-model="form.content_type" :content-types="contentTypes" />
 
         <!-- Contenu principal selon le type -->
-        <div class="form-section">
-          <h2 class="section-title"><i class="fa fa-file-text"></i> Contenu principal</h2>
-
-          <!-- Contenu VIDÉO -->
-          <div v-if="form.content_type === 'video'" class="content-fields">
-            <div class="form-row">
-              <div class="form-group full-width">
-                <label class="form-label required">URL de la vidéo</label>
-                <input
-                  v-model="form.video_url"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://www.youtube.com/watch?v=..."
-                />
-                <p class="form-hint">URL complète de la vidéo (YouTube, Vimeo, etc.)</p>
-              </div>
-            </div>
-
-            <div class="form-row">
-              <div class="form-group full-width">
-                <label class="form-label">Plateforme vidéo</label>
-                <div class="radio-group">
-                  <label
-                    v-for="provider in videoProviders"
-                    :key="provider.value"
-                    :class="['radio-card', { 'active': form.video_provider === provider.value }]"
-                  >
-                    <input
-                      v-model="form.video_provider"
-                      type="radio"
-                      :value="provider.value"
-                    />
-                    <span>{{ provider.icon }} {{ provider.label }}</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Contenu PDF -->
-          <div v-else-if="form.content_type === 'pdf'" class="content-fields">
-            <div class="form-row">
-              <div class="form-group full-width">
-                <label class="form-label required">URL du fichier PDF</label>
-                <input
-                  v-model="form.pdf_url"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://exemple.com/document.pdf"
-                />
-                <p class="form-hint">URL publique du document PDF à afficher</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Contenu AUDIO -->
-          <div v-else-if="form.content_type === 'audio'" class="content-fields">
-            <div class="form-row">
-              <div class="form-group full-width">
-                <label class="form-label required">URL du fichier audio</label>
-                <input
-                  v-model="form.audio_url"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://exemple.com/audio.mp3"
-                />
-                <p class="form-hint">URL du fichier audio (MP3, WAV, OGG, etc.)</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Contenu PRÉSENTATION -->
-          <div v-else-if="form.content_type === 'presentation'" class="content-fields">
-            <div class="form-row">
-              <div class="form-group full-width">
-                <label class="form-label required">URL de la présentation</label>
-                <input
-                  v-model="form.presentation_url"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://docs.google.com/presentation/d/..."
-                />
-                <p class="form-hint">URL de Google Slides, PowerPoint Online, ou autre plateforme</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Contenu LIEN EXTERNE -->
-          <div v-else-if="form.content_type === 'link'" class="content-fields">
-            <div class="form-row">
-              <div class="form-group full-width">
-                <label class="form-label required">Lien externe</label>
-                <input
-                  v-model="form.external_link"
-                  type="url"
-                  class="form-input"
-                  placeholder="https://exemple.com/ressource-externe"
-                />
-                <p class="form-hint">Lien vers une page web, un article, ou une ressource externe</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Contenu TEXTE ou MIXTE -->
-          <div v-else-if="form.content_type === 'text' || form.content_type === 'mixed'" class="content-fields">
-            <div class="editor-tabs">
-              <button
-                type="button"
-                @click="showPreview = false"
-                :class="['tab-btn', { 'active': !showPreview }]"
-              >
-                Éditer
-              </button>
-              <button
-                type="button"
-                @click="showPreview = true"
-                :class="['tab-btn', { 'active': showPreview }]"
-              >
-                Prévisualiser
-              </button>
-            </div>
-
-            <div v-show="!showPreview" class="editor-panel">
-              <textarea
-                v-model="form.content"
-                rows="20"
-                class="form-textarea code-editor"
-                placeholder="Contenu HTML de la leçon...
-
-Exemples:
-<h1>Titre principal</h1>
-<h2>Sous-titre</h2>
-<p>Paragraphe de texte...</p>
-<ul>
-  <li>Élément de liste</li>
-</ul>"
-              ></textarea>
-              <p class="form-hint">Vous pouvez utiliser du HTML pour formater le contenu</p>
-            </div>
-
-            <div v-show="showPreview" class="preview-panel">
-              <div v-if="form.content" v-html="form.content" class="preview-content"></div>
-              <div v-else class="preview-empty">Aucun contenu à prévisualiser</div>
-            </div>
-          </div>
-        </div>
+        <LessonContentFields
+          :content-type="form.content_type"
+          :video-providers="videoProviders"
+          v-model:video-url="form.video_url"
+          v-model:video-provider="form.video_provider"
+          v-model:pdf-url="form.pdf_url"
+          v-model:audio-url="form.audio_url"
+          v-model:presentation-url="form.presentation_url"
+          v-model:external-link="form.external_link"
+          v-model:content="form.content"
+        />
 
         <!-- Ressources supplémentaires -->
-        <div class="form-section">
-          <div class="section-header">
-            <h2 class="section-title"><i class="fa fa-paperclip"></i> Ressources supplémentaires</h2>
-            <button type="button" @click="addResource" class="btn-add">
-              + Ajouter une ressource
-            </button>
-          </div>
-
-          <p class="section-description">
-            Ajoutez des documents PDF, liens, vidéos complémentaires ou autres ressources pour enrichir votre leçon
-          </p>
-
-          <div v-if="form.resources && form.resources.length > 0" class="resources-list">
-            <div
-              v-for="(resource, index) in form.resources"
-              :key="index"
-              class="resource-card"
-            >
-              <div class="resource-header">
-                <span class="resource-number">#{{ index + 1 }}</span>
-                <button
-                  type="button"
-                  @click="removeResource(index)"
-                  class="btn-remove"
-                >
-                  Supprimer
-                </button>
-              </div>
-
-              <div class="form-row">
-                <div class="form-group">
-                  <label class="form-label">Titre</label>
-                  <input
-                    v-model="resource.title"
-                    type="text"
-                    class="form-input"
-                    placeholder="Nom de la ressource"
-                  />
-                </div>
-
-                <div class="form-group">
-                  <label class="form-label">Type</label>
-                  <select v-model="resource.type" class="form-select">
-                    <option value="pdf">PDF</option>
-                    <option value="document">Document</option>
-                    <option value="link">Lien</option>
-                    <option value="video">Vidéo</option>
-                    <option value="image">Image</option>
-                    <option value="archive">Archive</option>
-                    <option value="other">Autre</option>
-                  </select>
-                </div>
-              </div>
-
-              <div class="form-row">
-                <div class="form-group full-width">
-                  <label class="form-label">URL</label>
-                  <input
-                    v-model="resource.url"
-                    type="url"
-                    class="form-input"
-                    placeholder="https://exemple.com/ressource.pdf"
-                  />
-                </div>
-              </div>
-
-              <div class="form-row">
-                <div class="form-group full-width">
-                  <label class="form-label">Description (optionnelle)</label>
-                  <textarea
-                    v-model="resource.description"
-                    rows="2"
-                    class="form-textarea"
-                    placeholder="Description de la ressource..."
-                  ></textarea>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div v-else class="resources-empty">
-            <p>Aucune ressource supplémentaire</p>
-            <p class="text-hint">Cliquez sur "Ajouter une ressource" pour en ajouter</p>
-          </div>
-        </div>
+        <LessonResourcesFields
+          :resources="form.resources"
+          @add="addResource"
+          @remove="removeResource"
+        />
 
         <!-- Statut de publication -->
-        <div class="form-section">
-          <h2 class="section-title"><i class="fa fa-toggle-on"></i> Statut de publication</h2>
-
-          <div class="status-grid">
-            <label :class="['status-card', { 'active': form.status === 'draft' }]">
-              <input
-                v-model="form.status"
-                type="radio"
-                value="draft"
-              />
-              <div class="status-icon">[D]</div>
-              <div class="status-name">Brouillon</div>
-              <div class="status-desc">La leçon ne sera pas visible par les étudiants</div>
-            </label>
-
-            <label :class="['status-card', { 'active': form.status === 'published' }]">
-              <input
-                v-model="form.status"
-                type="radio"
-                value="published"
-              />
-              <div class="status-icon">[√]</div>
-              <div class="status-name">Publié</div>
-              <div class="status-desc">La leçon sera visible et accessible aux étudiants</div>
-            </label>
-
-            <label :class="['status-card', { 'active': form.status === 'archived' }]">
-              <input
-                v-model="form.status"
-                type="radio"
-                value="archived"
-              />
-              <div class="status-icon">[A]</div>
-              <div class="status-name">Archivé</div>
-              <div class="status-desc">La leçon est conservée mais n'est plus accessible</div>
-            </label>
-          </div>
-        </div>
+        <LessonStatusPicker v-model="form.status" />
 
         <!-- Actions -->
-        <div class="form-actions">
-          <button type="button" @click="$router.go(-1)" class="btn-cancel">
-            Annuler
-          </button>
-          <button type="submit" :disabled="saving" class="btn-save">
-            {{ saving ? 'Enregistrement...' : (isEditMode ? 'Mettre à jour' : 'Créer la leçon') }}
-          </button>
-          <button
-            v-if="isEditMode"
-            type="button"
-            @click="deleteLesson"
-            :disabled="saving"
-            class="btn-delete"
-          >
-            Supprimer
-          </button>
-        </div>
+        <LessonEditorActions
+          :saving="saving"
+          :is-edit-mode="isEditMode"
+          @cancel="$router.go(-1)"
+          @delete="deleteLesson"
+        />
       </form>
     </div>
   </DashboardLayout>
@@ -434,19 +77,24 @@ Exemples:
 
 <script setup>
 /**
- * Éditeur de leçon (#H4) — la donnée et la logique vivent dans useLessonEditor ;
- * cette vue conserve son template + CSS (choix utilisateur : pas d'éclatement des
- * sections) et se contente de câbler le composable. `$router.go(-1)` reste utilisé
- * tel quel dans le template via la propriété globale du routeur.
+ * Éditeur de leçon (#H4 ≤300) — orchestrateur. Donnée/logique dans useLessonEditor ;
+ * UI composée des sections LessonBasicInfoFields, LessonContentTypePicker,
+ * LessonContentFields, LessonResourcesFields, LessonStatusPicker et
+ * LessonEditorActions. `$router.go(-1)` via la propriété globale du routeur.
  */
 import DashboardLayout from '@/components/layout/DashboardLayout.vue'
 import ContentLoader from '@/components/common/ContentLoader.vue'
+import LessonBasicInfoFields from '@/components/lessons/LessonBasicInfoFields.vue'
+import LessonContentTypePicker from '@/components/lessons/LessonContentTypePicker.vue'
+import LessonContentFields from '@/components/lessons/LessonContentFields.vue'
+import LessonResourcesFields from '@/components/lessons/LessonResourcesFields.vue'
+import LessonStatusPicker from '@/components/lessons/LessonStatusPicker.vue'
+import LessonEditorActions from '@/components/lessons/LessonEditorActions.vue'
 import { useLessonEditor } from '@/composables/useLessonEditor'
 
 const {
   loading,
   saving,
-  showPreview,
   form,
   chapters,
   loadingChapters,
@@ -537,418 +185,6 @@ const {
   gap: 2rem;
 }
 
-.form-section {
-  background: var(--card-bg);
-  border-radius: 0.75rem;
-  padding: 2rem;
-  box-shadow: var(--card-shadow);
-}
-
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.section-title {
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin: 0 0 1.5rem 0;
-}
-
-.section-description {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  margin-bottom: 1.5rem;
-}
-
-.form-row {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin-bottom: 1.5rem;
-}
-
-.form-row:last-child {
-  margin-bottom: 0;
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-}
-
-.form-group.full-width {
-  grid-column: 1 / -1;
-}
-
-.form-label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 0.5rem;
-}
-
-.form-label.required::after {
-  content: ' *';
-  color: #ef4444;
-}
-
-.form-input,
-.form-select,
-.form-textarea {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-primary);
-  border-radius: 0.5rem;
-  color: var(--text-primary);
-  font-size: 0.875rem;
-  transition: all 0.2s;
-}
-
-.form-input:focus,
-.form-select:focus,
-.form-textarea:focus {
-  outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-}
-
-.form-input::placeholder,
-.form-textarea::placeholder {
-  color: var(--text-tertiary);
-}
-
-.form-textarea {
-  resize: vertical;
-  font-family: inherit;
-}
-
-.form-textarea.code-editor {
-  font-family: 'Courier New', monospace;
-  font-size: 0.813rem;
-}
-
-.form-hint {
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  margin-top: 0.25rem;
-}
-
-/* Content Type Grid */
-.content-type-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-}
-
-.content-type-card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 1.5rem 1rem;
-  background: var(--bg-secondary);
-  border: 2px solid var(--border-primary);
-  border-radius: 0.75rem;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.content-type-card:hover {
-  background: var(--bg-tertiary);
-  transform: translateY(-2px);
-}
-
-.content-type-card.active {
-  background: rgba(59, 130, 246, 0.1);
-  border-color: #3b82f6;
-}
-
-.content-type-radio {
-  position: absolute;
-  opacity: 0;
-}
-
-.content-type-icon {
-  font-size: 2rem;
-}
-
-.content-type-label {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  text-align: center;
-}
-
-/* Radio Group */
-.radio-group {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.radio-card {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: var(--bg-secondary);
-  border: 2px solid var(--border-primary);
-  border-radius: 0.5rem;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.radio-card:hover {
-  background: var(--bg-tertiary);
-}
-
-.radio-card.active {
-  background: rgba(59, 130, 246, 0.1);
-  border-color: #3b82f6;
-}
-
-.radio-card input[type="radio"] {
-  margin: 0;
-}
-
-/* Editor Tabs */
-.editor-tabs {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-  border-bottom: 1px solid var(--border-primary);
-}
-
-.tab-btn {
-  padding: 0.75rem 1.5rem;
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-secondary);
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.tab-btn:hover {
-  color: var(--text-primary);
-  background: var(--bg-secondary);
-}
-
-.tab-btn.active {
-  color: #3b82f6;
-  border-bottom-color: #3b82f6;
-}
-
-/* Preview Panel */
-.preview-panel {
-  min-height: 300px;
-  padding: 1.5rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: 0.5rem;
-}
-
-.preview-content {
-  color: var(--text-primary);
-  line-height: 1.75;
-}
-
-.preview-empty {
-  text-align: center;
-  padding: 4rem;
-  color: var(--text-tertiary);
-  font-style: italic;
-}
-
-/* Resources */
-.resources-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.resource-card {
-  padding: 1.5rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: 0.5rem;
-}
-
-.resource-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.resource-number {
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.btn-remove {
-  padding: 0.5rem 1rem;
-  background: #fee2e2;
-  color: #dc2626;
-  border: 1px solid #fca5a5;
-  border-radius: 0.375rem;
-  font-size: 0.813rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.btn-remove:hover {
-  background: #fecaca;
-}
-
-.resources-empty {
-  text-align: center;
-  padding: 3rem;
-  color: var(--text-tertiary);
-}
-
-.resources-empty p {
-  margin: 0.5rem 0;
-}
-
-.text-hint {
-  font-size: 0.875rem;
-}
-
-/* Status Grid */
-.status-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.status-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 1.5rem;
-  background: var(--bg-secondary);
-  border: 2px solid var(--border-primary);
-  border-radius: 0.75rem;
-  cursor: pointer;
-  transition: all 0.2s;
-  text-align: center;
-}
-
-.status-card:hover {
-  background: var(--bg-tertiary);
-  transform: translateY(-2px);
-}
-
-.status-card.active {
-  background: rgba(59, 130, 246, 0.1);
-  border-color: #3b82f6;
-}
-
-.status-card input[type="radio"] {
-  position: absolute;
-  opacity: 0;
-}
-
-.status-icon {
-  font-size: 2rem;
-}
-
-.status-name {
-  font-size: 1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.status-desc {
-  font-size: 0.813rem;
-  color: var(--text-secondary);
-  line-height: 1.4;
-}
-
-/* Actions */
-.form-actions {
-  display: flex;
-  gap: 1rem;
-  justify-content: flex-end;
-  padding: 1.5rem;
-  background: var(--card-bg);
-  border-radius: 0.75rem;
-  box-shadow: var(--card-shadow);
-}
-
-.btn-cancel,
-.btn-save,
-.btn-delete,
-.btn-add {
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.5rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  border: none;
-}
-
-.btn-cancel {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  border: 1px solid var(--border-primary);
-}
-
-.btn-cancel:hover {
-  background: var(--bg-tertiary);
-}
-
-.btn-save {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  color: white;
-}
-
-.btn-save:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: translateY(-1px);
-}
-
-.btn-save:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.btn-delete {
-  background: #fee2e2;
-  color: #dc2626;
-  border: 1px solid #fca5a5;
-}
-
-.btn-delete:hover:not(:disabled) {
-  background: #fecaca;
-}
-
-.btn-delete:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.btn-add {
-  padding: 0.75rem 1.5rem;
-  background: #dbeafe;
-  color: #1d4ed8;
-  border: 1px solid #93c5fd;
-}
-
-.btn-add:hover {
-  background: #bfdbfe;
-}
-
 /* Responsive */
 @media (max-width: 768px) {
   .lesson-editor-container {
@@ -958,32 +194,6 @@ const {
   .editor-header {
     flex-direction: column;
     gap: 1rem;
-  }
-
-  .form-row {
-    grid-template-columns: 1fr;
-  }
-
-  .content-type-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .radio-group {
-    flex-direction: column;
-  }
-
-  .status-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .form-actions {
-    flex-direction: column;
-  }
-
-  .btn-cancel,
-  .btn-save,
-  .btn-delete {
-    width: 100%;
   }
 }
 </style>

--- a/tests/unit/LessonBasicInfoFields.test.js
+++ b/tests/unit/LessonBasicInfoFields.test.js
@@ -1,0 +1,32 @@
+/** Test LessonBasicInfoFields (#H4 ≤300) : options matières/classes, v-model, load-chapters. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonBasicInfoFields from '@/components/lessons/LessonBasicInfoFields.vue'
+
+const base = {
+  title: '', description: '', type: 'cours', durationMinutes: null,
+  matiereId: null, classeId: null, chapterId: null,
+  matieres: [{ id: 1, nom: 'Maths' }], classes: [{ id: 2, name: '6e A' }], chapters: []
+}
+
+describe('LessonBasicInfoFields (#H4)', () => {
+  it('rend les options matières et classes', () => {
+    const w = mount(LessonBasicInfoFields, { props: base })
+    expect(w.html()).toContain('Maths')
+    expect(w.html()).toContain('6e A')
+  })
+
+  it('émet update:title à la saisie', async () => {
+    const w = mount(LessonBasicInfoFields, { props: base })
+    await w.find('input[type="text"]').setValue('Intro')
+    expect(w.emitted('update:title')[0]).toEqual(['Intro'])
+  })
+
+  it('émet load-chapters au changement de matière', async () => {
+    const w = mount(LessonBasicInfoFields, { props: base })
+    const matiereSelect = w.findAll('select')[1]
+    await matiereSelect.setValue(1)
+    expect(w.emitted('load-chapters')).toBeTruthy()
+    expect(w.emitted('update:matiereId')).toBeTruthy()
+  })
+})

--- a/tests/unit/LessonContentFields.test.js
+++ b/tests/unit/LessonContentFields.test.js
@@ -1,0 +1,34 @@
+/** Test LessonContentFields (#H4 ≤300) : branche par type + délégation texte/mixte. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonContentFields from '@/components/lessons/LessonContentFields.vue'
+
+const stubs = { LessonRichTextEditor: true }
+
+describe('LessonContentFields (#H4)', () => {
+  it('affiche le champ URL vidéo + plateformes pour le type video', () => {
+    const w = mount(LessonContentFields, {
+      props: { contentType: 'video', videoProviders: [{ value: 'youtube', label: 'YouTube', icon: '►' }] },
+      global: { stubs }
+    })
+    expect(w.find('.form-input').exists()).toBe(true)
+    expect(w.find('.radio-group').exists()).toBe(true)
+  })
+
+  it('affiche un seul champ URL (sans plateformes) pour le type pdf', () => {
+    const w = mount(LessonContentFields, { props: { contentType: 'pdf' }, global: { stubs } })
+    expect(w.find('.form-input').exists()).toBe(true)
+    expect(w.find('.radio-group').exists()).toBe(false)
+  })
+
+  it('délègue à LessonRichTextEditor pour le type text', () => {
+    const w = mount(LessonContentFields, { props: { contentType: 'text' }, global: { stubs } })
+    expect(w.findComponent({ name: 'LessonRichTextEditor' }).exists()).toBe(true)
+  })
+
+  it('émet update:videoUrl à la saisie', async () => {
+    const w = mount(LessonContentFields, { props: { contentType: 'video' }, global: { stubs } })
+    await w.find('.form-input').setValue('https://x.test')
+    expect(w.emitted('update:videoUrl')[0]).toEqual(['https://x.test'])
+  })
+})

--- a/tests/unit/LessonContentTypePicker.test.js
+++ b/tests/unit/LessonContentTypePicker.test.js
@@ -1,0 +1,23 @@
+/** Test LessonContentTypePicker (#H4 ≤300) : rendu des cartes, état actif, v-model. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonContentTypePicker from '@/components/lessons/LessonContentTypePicker.vue'
+
+const contentTypes = [
+  { value: 'text', label: 'Texte', icon: '[T]' },
+  { value: 'video', label: 'Vidéo', icon: '[V]' }
+]
+
+describe('LessonContentTypePicker (#H4)', () => {
+  it('rend une carte par type et marque l\'actif', () => {
+    const w = mount(LessonContentTypePicker, { props: { modelValue: 'video', contentTypes } })
+    expect(w.findAll('.content-type-card')).toHaveLength(2)
+    expect(w.findAll('.content-type-card')[1].classes()).toContain('active')
+  })
+
+  it('émet update:modelValue à la sélection', async () => {
+    const w = mount(LessonContentTypePicker, { props: { modelValue: 'text', contentTypes } })
+    await w.findAll('input[type="radio"]')[1].setValue()
+    expect(w.emitted('update:modelValue')[0]).toEqual(['video'])
+  })
+})

--- a/tests/unit/LessonEditorActions.test.js
+++ b/tests/unit/LessonEditorActions.test.js
@@ -1,0 +1,32 @@
+/** Test LessonEditorActions (#H4 ≤300) : libellés selon mode, emits, bouton supprimer. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonEditorActions from '@/components/lessons/LessonEditorActions.vue'
+
+describe('LessonEditorActions (#H4)', () => {
+  it('mode création : pas de bouton supprimer, libellé « Créer la leçon »', () => {
+    const w = mount(LessonEditorActions, { props: { isEditMode: false } })
+    expect(w.find('.btn-delete').exists()).toBe(false)
+    expect(w.find('.btn-save').text()).toBe('Créer la leçon')
+  })
+
+  it('mode édition : bouton supprimer + libellé « Mettre à jour »', () => {
+    const w = mount(LessonEditorActions, { props: { isEditMode: true } })
+    expect(w.find('.btn-delete').exists()).toBe(true)
+    expect(w.find('.btn-save').text()).toBe('Mettre à jour')
+  })
+
+  it('désactive et change le libellé pendant l\'enregistrement', () => {
+    const w = mount(LessonEditorActions, { props: { saving: true } })
+    expect(w.find('.btn-save').attributes('disabled')).toBeDefined()
+    expect(w.find('.btn-save').text()).toBe('Enregistrement...')
+  })
+
+  it('émet cancel et delete', async () => {
+    const w = mount(LessonEditorActions, { props: { isEditMode: true } })
+    await w.find('.btn-cancel').trigger('click')
+    expect(w.emitted('cancel')).toHaveLength(1)
+    await w.find('.btn-delete').trigger('click')
+    expect(w.emitted('delete')).toHaveLength(1)
+  })
+})

--- a/tests/unit/LessonResourcesFields.test.js
+++ b/tests/unit/LessonResourcesFields.test.js
@@ -1,0 +1,29 @@
+/** Test LessonResourcesFields (#H4 ≤300) : état vide, liste, emits add/remove. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonResourcesFields from '@/components/lessons/LessonResourcesFields.vue'
+
+describe('LessonResourcesFields (#H4)', () => {
+  it('affiche l\'état vide sans ressource', () => {
+    const w = mount(LessonResourcesFields, { props: { resources: [] } })
+    expect(w.find('.resources-empty').exists()).toBe(true)
+    expect(w.find('.resource-card').exists()).toBe(false)
+  })
+
+  it('rend une carte par ressource', () => {
+    const w = mount(LessonResourcesFields, {
+      props: { resources: [{ title: 'A', type: 'pdf', url: '', description: '' }] }
+    })
+    expect(w.findAll('.resource-card')).toHaveLength(1)
+  })
+
+  it('émet add et remove', async () => {
+    const w = mount(LessonResourcesFields, {
+      props: { resources: [{ title: 'A', type: 'pdf', url: '', description: '' }] }
+    })
+    await w.find('.btn-add').trigger('click')
+    expect(w.emitted('add')).toHaveLength(1)
+    await w.find('.btn-remove').trigger('click')
+    expect(w.emitted('remove')[0]).toEqual([0])
+  })
+})

--- a/tests/unit/LessonRichTextEditor.test.js
+++ b/tests/unit/LessonRichTextEditor.test.js
@@ -1,0 +1,27 @@
+/** Test LessonRichTextEditor (#H4 ≤300) : bascule éditer/prévisualiser + v-model. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonRichTextEditor from '@/components/lessons/LessonRichTextEditor.vue'
+
+describe('LessonRichTextEditor (#H4)', () => {
+  it('édite par défaut puis bascule en prévisualisation', async () => {
+    const w = mount(LessonRichTextEditor, { props: { modelValue: '<p>Bonjour</p>' } })
+    const tabs = w.findAll('.tab-btn')
+    expect(tabs[0].classes()).toContain('active')
+    await tabs[1].trigger('click')
+    expect(tabs[1].classes()).toContain('active')
+    expect(w.find('.preview-content').html()).toContain('Bonjour')
+  })
+
+  it('affiche un état vide en prévisualisation sans contenu', async () => {
+    const w = mount(LessonRichTextEditor, { props: { modelValue: '' } })
+    await w.findAll('.tab-btn')[1].trigger('click')
+    expect(w.find('.preview-empty').exists()).toBe(true)
+  })
+
+  it('émet update:modelValue à la saisie', async () => {
+    const w = mount(LessonRichTextEditor, { props: { modelValue: '' } })
+    await w.find('textarea').setValue('<h1>X</h1>')
+    expect(w.emitted('update:modelValue')[0]).toEqual(['<h1>X</h1>'])
+  })
+})

--- a/tests/unit/LessonStatusPicker.test.js
+++ b/tests/unit/LessonStatusPicker.test.js
@@ -1,0 +1,19 @@
+/** Test LessonStatusPicker (#H4 ≤300) : 3 cartes statut, actif, v-model. */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import LessonStatusPicker from '@/components/lessons/LessonStatusPicker.vue'
+
+describe('LessonStatusPicker (#H4)', () => {
+  it('marque la carte correspondant au statut courant', () => {
+    const w = mount(LessonStatusPicker, { props: { modelValue: 'published' } })
+    const cards = w.findAll('.status-card')
+    expect(cards).toHaveLength(3)
+    expect(cards[1].classes()).toContain('active')
+  })
+
+  it('émet update:modelValue à la sélection', async () => {
+    const w = mount(LessonStatusPicker, { props: { modelValue: 'draft' } })
+    await w.findAll('input[type="radio"]')[2].setValue()
+    expect(w.emitted('update:modelValue')[0]).toEqual(['archived'])
+  })
+})


### PR DESCRIPTION
## LessonEditor.vue sous 300 lignes — lève la déviation de la PR #86

Suite du lot H4. La PR #86 avait laissé **LessonEditor.vue à 989 lignes** (déviation assumée : seul le script avait été extrait). Cette PR termine l'éclatement complet.

### Résultat
| Fichier | Avant | Après | ≤300 |
|---|---|---|---|
| `views/lessons/LessonEditor.vue` | 989 | **199** | ✅ |

### Sous-composants créés (tous ≤300)
`LessonBasicInfoFields` (208), `LessonContentTypePicker` (105), `LessonContentFields` (256), `LessonRichTextEditor` (141), `LessonResourcesFields` (266), `LessonStatusPicker` (123), `LessonEditorActions` (110). Composable `useLessonEditor` conservé (254, `showPreview` déplacé dans le rich editor).

### CSS partagé — sans partial (choix produit)
Conformément à ta décision (pas de partial SCSS), le **chrome de formulaire** (`form-section`, `form-row`, `form-group`, `form-input`…) est **dupliqué verbatim** dans chaque section, en ne gardant que les règles réellement utilisées. Option « duplique » prévue par la consigne.

### Parité (non négociable)
- Champs recâblés 1:1 en `v-model` (`defineModel`) ; modificateur `.number` conservé sur les inputs concernés.
- Mêmes appels services/routes/textes ; **CSS déplacé verbatim** (`@media` distribués par section).
- `$router.go(-1)` conservé via la propriété globale du routeur.
- Dette pré-existante conservée : CSS mort `.loading-state`/`.spinner`/`@keyframes spin` dans l'orchestrateur (le template utilise `<ContentLoader>`).

### Vérifications
- `npx vite build` → **exit 0**.
- Tests vitest : **27/27 verts** (7 sous-composants + composable + montage vue G5 existant inchangé).
- `wc -l` : tous les fichiers produits ≤300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
