### PR TITLE
fix: pont route via inst.proxy dans les composables H1/H4 (3 tests cassés)

### DIFF
--- a/src/composables/useLessonChapters.js
+++ b/src/composables/useLessonChapters.js
@@ -1,5 +1,4 @@
-import { ref, computed, onMounted } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { ref, computed, onMounted, getCurrentInstance } from 'vue'
 import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
 import lessonService from '@/services/lesson'
@@ -10,17 +9,20 @@ import lessonService from '@/services/lesson'
  * et la navigation. La vue ne fait plus que câbler le composable + ChapterManager.
  */
 export function useLessonChapters() {
-  const route = useRoute()
-  const router = useRouter()
+  // Pont route/router via l'instance (compatible global.mocks.$route des tests de
+  // montage, et réactif en prod) — voir specs decomposition-300.
+  const inst = getCurrentInstance()
+  const route = computed(() => inst.proxy.$route)
+  const router = inst.proxy.$router
 
   const lesson = ref(null)
   const loadingLesson = ref(false)
   const error = ref(null)
   const publishing = ref(false)
 
-  const lessonId = computed(() => parseInt(route.params.id))
+  const lessonId = computed(() => parseInt(route.value.params.id))
   // Mode lecture seule uniquement si explicitement demande avec ?readonly=true
-  const isReadOnly = computed(() => route.query.readonly === 'true')
+  const isReadOnly = computed(() => route.value.query.readonly === 'true')
 
   async function loadLesson() {
     loadingLesson.value = true

--- a/src/composables/useTakeEvaluation.js
+++ b/src/composables/useTakeEvaluation.js
@@ -1,5 +1,4 @@
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
+import { ref, computed, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
 import evaluationService from '@/services/evaluation'
 import { auth } from '@/services/api'
 
@@ -11,8 +10,11 @@ import { auth } from '@/services/api'
  * l'original (conversion Options API → Composition API sans changement de logique).
  */
 export function useTakeEvaluation() {
-  const router = useRouter()
-  const route = useRoute()
+  // Pont route/router via l'instance (compatible global.mocks.$route des tests de
+  // montage, et réactif en prod) — voir specs decomposition-300.
+  const inst = getCurrentInstance()
+  const router = inst.proxy.$router
+  const route = computed(() => inst.proxy.$route)
 
   const evaluation = ref(null)
   const answers = ref({})
@@ -45,7 +47,7 @@ export function useTakeEvaluation() {
   async function loadEvaluation() {
     loading.value = true
     try {
-      const id = route.params.id
+      const id = route.value.params.id
       const result = await evaluationService.getEvaluation(id)
 
       if (result.success) {
@@ -199,8 +201,8 @@ export function useTakeEvaluation() {
       return
     }
 
-    submissionId.value = route.query.submission_id
-    isPractice.value = route.query.practice === '1'
+    submissionId.value = route.value.query.submission_id
+    isPractice.value = route.value.query.practice === '1'
     if (!submissionId.value) {
       error.value = 'ID de soumission manquant'
       loading.value = false


### PR DESCRIPTION
## Problème
La suite complète sur `dev` (après merge des 13 lots H) révélait **3 tests en échec** (sur 1351) — régression réelle introduite par les décompositions **H1** (`TakeEvaluation`) et **H4** (`LessonChapters`), passée en douce car ces fenêtres n'ont lancé que **leurs nouveaux tests**, pas les tests de montage **pré-existants** (G3/G5) des mêmes fichiers.

- `tests/unit/TakeEvaluation.test.js` (1)
- `tests/unit/LessonChapters.test.js` (2)

## Cause racine
`useTakeEvaluation` et `useLessonChapters` lisaient la route via `useRoute()`/`useRouter()`, qui nécessitent le **plugin router installé**. Or les tests existants injectent `global.mocks.$route` (style Options-API `this.$route`) **sans** installer de router → `route` undefined → `Cannot read properties of undefined (reading 'params'/'query')`.

## Correctif
Lecture de la route **paresseuse via l'instance** : `const route = computed(() => inst.proxy.$route)` + `const router = inst.proxy.$router`. Réactif en production **et** compatible avec les `$route` mockés des tests. **Comportement de prod strictement inchangé.**

## Vérif
- Les 2 fichiers de test repassent : **4/4 verts**.
- `vite build` ✅ vert.
- Suite complète relancée pour confirmer l'absence d'autre casse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)