### PR TITLE
fix: compléter le pont route (dev cassé par #96 mergée incomplète)

### DIFF
--- a/src/composables/useCreateEvaluation.js
+++ b/src/composables/useCreateEvaluation.js
@@ -1,4 +1,4 @@
-import { reactive, ref, computed, onMounted } from 'vue'
+import { reactive, ref, computed, onMounted, getCurrentInstance } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import evaluationService from '@/services/evaluation'
 import klassciService from '@/services/klassci'
@@ -10,8 +10,11 @@ import klassciService from '@/services/klassci'
  * Comportement, services, routes et alertes strictement identiques à l'original.
  */
 export function useCreateEvaluation() {
-  const route = useRoute()
-  const router = useRouter()
+  // Pont route/router double source : proxy.$route (tests de vue + prod) ; useRoute()
+  // (tests de composable mockant vue-router) ; repli sûr. Voir specs decomposition-300.
+  const inst = getCurrentInstance()
+  const route = inst?.proxy?.$route ?? useRoute() ?? { params: {}, query: {} }
+  const router = inst?.proxy?.$router ?? useRouter()
 
   const evaluation = reactive({
     klassci_evaluation_id: null,

--- a/src/composables/useLessonChapters.js
+++ b/src/composables/useLessonChapters.js
@@ -1,4 +1,5 @@
 import { ref, computed, onMounted, getCurrentInstance } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { toast } from '@/services/toast'
 import { normalizeError } from '@/services/errorHandler'
 import lessonService from '@/services/lesson'
@@ -9,20 +10,23 @@ import lessonService from '@/services/lesson'
  * et la navigation. La vue ne fait plus que câbler le composable + ChapterManager.
  */
 export function useLessonChapters() {
-  // Pont route/router via l'instance (compatible global.mocks.$route des tests de
-  // montage, et réactif en prod) — voir specs decomposition-300.
+  // Pont route/router double source : inst.proxy.$route (tests de vue via
+  // global.mocks.$route + prod) avec repli sur useRoute() (tests de composable qui
+  // mockent vue-router). Réactif en prod ; comportement identique. Voir specs decomposition-300.
   const inst = getCurrentInstance()
-  const route = computed(() => inst.proxy.$route)
-  const router = inst.proxy.$router
+  const injectedRoute = useRoute()
+  const injectedRouter = useRouter()
+  const route = computed(() => inst?.proxy?.$route ?? injectedRoute)
+  const router = inst?.proxy?.$router ?? injectedRouter
 
   const lesson = ref(null)
   const loadingLesson = ref(false)
   const error = ref(null)
   const publishing = ref(false)
 
-  const lessonId = computed(() => parseInt(route.value.params.id))
+  const lessonId = computed(() => parseInt(route.value?.params?.id))
   // Mode lecture seule uniquement si explicitement demande avec ?readonly=true
-  const isReadOnly = computed(() => route.value.query.readonly === 'true')
+  const isReadOnly = computed(() => route.value?.query?.readonly === 'true')
 
   async function loadLesson() {
     loadingLesson.value = true

--- a/src/composables/useSeanceAttendanceHistory.js
+++ b/src/composables/useSeanceAttendanceHistory.js
@@ -26,9 +26,11 @@ import { getPeriodDates as computePeriodDates } from '@/utils/attendance'
  *   dans le composant d'origine : conservées telles quelles (dette documentée).
  */
 export function useSeanceAttendanceHistory() {
-  const route = useRoute()
-  // Instance pour accéder à $toast (non enregistré → undefined, cf. parité supra).
+  // Instance pour le pont route + $toast (non enregistré → undefined, cf. parité supra).
   const instance = getCurrentInstance()
+  // Pont route double source : proxy.$route (tests de vue + prod) ; useRoute() (tests de
+  // composable mockant vue-router) ; repli sûr pour ne jamais crasher. Voir specs decomposition-300.
+  const route = instance?.proxy?.$route ?? useRoute() ?? { params: {}, query: {} }
   const $toast = instance?.appContext.config.globalProperties.$toast
 
   const loading = ref(false)

--- a/src/composables/useTakeEvaluation.js
+++ b/src/composables/useTakeEvaluation.js
@@ -1,4 +1,5 @@
 import { ref, computed, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import evaluationService from '@/services/evaluation'
 import { auth } from '@/services/api'
 
@@ -10,11 +11,14 @@ import { auth } from '@/services/api'
  * l'original (conversion Options API → Composition API sans changement de logique).
  */
 export function useTakeEvaluation() {
-  // Pont route/router via l'instance (compatible global.mocks.$route des tests de
-  // montage, et réactif en prod) — voir specs decomposition-300.
+  // Pont route/router double source : inst.proxy.$route (tests de vue via
+  // global.mocks.$route + prod) avec repli sur useRoute() (tests de composable qui
+  // mockent vue-router). Réactif en prod ; comportement identique. Voir specs decomposition-300.
   const inst = getCurrentInstance()
-  const router = inst.proxy.$router
-  const route = computed(() => inst.proxy.$route)
+  const injectedRoute = useRoute()
+  const injectedRouter = useRouter()
+  const router = inst?.proxy?.$router ?? injectedRouter
+  const route = computed(() => inst?.proxy?.$route ?? injectedRoute)
 
   const evaluation = ref(null)
   const answers = ref({})
@@ -47,7 +51,7 @@ export function useTakeEvaluation() {
   async function loadEvaluation() {
     loading.value = true
     try {
-      const id = route.value.params.id
+      const id = route.value?.params?.id
       const result = await evaluationService.getEvaluation(id)
 
       if (result.success) {
@@ -201,8 +205,8 @@ export function useTakeEvaluation() {
       return
     }
 
-    submissionId.value = route.value.query.submission_id
-    isPractice.value = route.value.query.practice === '1'
+    submissionId.value = route.value?.query?.submission_id
+    isPractice.value = route.value?.query?.practice === '1'
     if (!submissionId.value) {
       error.value = 'ID de soumission manquant'
       loading.value = false


### PR DESCRIPTION
## Contexte
La PR #96 a été **mergée à son 1er commit** (`7ae43462`, version proxy-only) **avant** que le correctif complet soit poussé. `dev` est donc actuellement **rouge** :
- la version proxy-only (`inst.proxy.$route` sans repli) casse les **tests de composable** (`useTakeEvaluation.test.js`, `useLessonChapters.test.js` — qui mockent `vue-router`) ;
- `useCreateEvaluation` (H1) et `useSeanceAttendanceHistory` (H7) restent non corrigés → **rejections non gérées** (route undefined) → `vitest` exit 1.

## Correctif (cherry-pick de `d2fe42e7`)
Pont route **double-source** uniforme dans les 4 composables : `inst.proxy.$route` (tests de vue via `global.mocks.$route` + prod) avec repli `useRoute()` (tests de composable) et repli sûr `{params:{},query:{}}` + optional chaining. Ne crashe jamais au montage ; **comportement de prod strictement inchangé**.

## Vérif
- Suite complète : **1351/1351 verte, exit 0** (0 unhandled).
- `vite build` ✅ vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)