### PR TITLE
chore: useSeanceAttendanceHistory repasse à 300 lignes (≤300)

### DIFF
--- a/src/composables/useSeanceAttendanceHistory.js
+++ b/src/composables/useSeanceAttendanceHistory.js
@@ -22,14 +22,12 @@ import { getPeriodDates as computePeriodDates } from '@/utils/attendance'
  *   PRÉEXISTANT conservé à l'identique. Les exports gardent l'appel optionnel.
  * - formatDate/formatTime/formatDuration restent LOCAUX (non convergés vers
  *   @/utils/formatters) pour un rendu strictement inchangé.
- * - getInitials et formatDateInput étaient des méthodes MORTES (jamais appelées)
- *   dans le composant d'origine : conservées telles quelles (dette documentée).
+ * - getInitials et formatDateInput : méthodes MORTES d'origine conservées (dette documentée).
  */
 export function useSeanceAttendanceHistory() {
   // Instance pour le pont route + $toast (non enregistré → undefined, cf. parité supra).
   const instance = getCurrentInstance()
-  // Pont route double source : proxy.$route (tests de vue + prod) ; useRoute() (tests de
-  // composable mockant vue-router) ; repli sûr pour ne jamais crasher. Voir specs decomposition-300.
+  // Pont route double source (proxy.$route + repli useRoute()/sûr) — voir specs decomposition-300.
   const route = instance?.proxy?.$route ?? useRoute() ?? { params: {}, query: {} }
   const $toast = instance?.appContext.config.globalProperties.$toast
 


### PR DESCRIPTION
Le correctif route #97 avait ajouté 2 lignes de commentaire à `useSeanceAttendanceHistory.js`, le portant à **302 lignes** (>300). Condensation de commentaires (zéro changement de code) → **300 lignes**.

`vite build` ✅ vert, tests ciblés 9/9 verts. Rétablit 0 fichier >300 sur `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)