### PR TITLE
fix(login,visio) + feat: 401 KLASSCI non éjectant, salle visio déterministe, afficher le mot de passe

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -3,7 +3,7 @@ import notificationsService from './notifications'
 // Imports relatifs (pas l'alias @) : le runner natif des tests de contrat (#17) ne
 // résout que les chemins relatifs.
 import { hasRole as roleHasRole } from '../constants/roles'
-import { normalizeError, logError } from './errorHandler'
+import { normalizeError, logError, shouldForceLogout } from './errorHandler'
 // useAuthStore : on importe la DÉFINITION au top-level (sûr) ; on n'APPELLE
 // useAuthStore() qu'à la volée dans les méthodes (Pinia actif à l'exécution).
 // Cycle api.js <-> auth.js sans danger : aucune des deux références n'est utilisée
@@ -54,8 +54,9 @@ api.interceptors.response.use(
     error.userMessage = normalized.userMessage
     error.fieldErrors = normalized.fieldErrors
 
-    // Si erreur 401, déconnecter l'utilisateur via le store (purge state + storage + cache)
-    if (error.response?.status === 401) {
+    // Déconnexion seulement si le 401 invalide vraiment la session locale (décision
+    // pure et testée). Un 401 de proxy KLASSCI ne doit PAS éjecter l'utilisateur.
+    if (shouldForceLogout(error)) {
       useAuthStore().logout()
 
       // Ne rediriger que si on n'est pas déjà sur la page de login

--- a/src/services/errorHandler.js
+++ b/src/services/errorHandler.js
@@ -75,6 +75,28 @@ export function normalizeError(error) {
 }
 
 /**
+ * Décide si une erreur HTTP doit invalider la SESSION locale (déconnexion).
+ *
+ * Un 401 n'implique PAS toujours que le token de session (Sanctum) est invalide :
+ * les endpoints proxy KLASSCI répondent 401 « Token KLASSCI non trouvé » quand le
+ * token KLASSCI (géré côté serveur) est absent/expiré, alors que la session locale
+ * reste valide. Déconnecter dans ce cas éjecterait l'utilisateur à tort.
+ *
+ * Règle (fail-safe) : on ne force la déconnexion que pour un 401 qui n'est PAS un
+ * échec de proxy KLASSCI. Fonction PURE, ne lève jamais.
+ *
+ * @param {unknown} error
+ * @returns {boolean} true s'il faut déconnecter l'utilisateur.
+ */
+export function shouldForceLogout(error) {
+  if (error?.response?.status !== 401) return false
+  const url = error.config?.url ?? ''
+  const message = error.response?.data?.message ?? ''
+  const isKlassciProxyFailure = url.includes('/proxy/') || /klassci/i.test(message)
+  return !isKlassciProxyFailure
+}
+
+/**
  * Journalise une erreur de façon SÛRE (catégorie, status, url) — jamais de token,
  * email ni corps de requête. Désactivée en production (#15).
  * @param {unknown} error

--- a/src/utils/jitsiRoom.js
+++ b/src/utils/jitsiRoom.js
@@ -24,14 +24,18 @@ export function sanitizeForUrl(str) {
 }
 
 /**
- * Générer un Room ID unique pour la séance
- * Format: lms_seance_{id}_{timestamp}
+ * Room ID DÉTERMINISTE par séance.
+ * Format: lms_seance_{id}
+ *
+ * Prof ET élèves d'une séance doivent rejoindre la MÊME salle. Un timestamp
+ * (Date.now()) donnait une salle différente à chaque ouverture → les élèves
+ * atterrissaient dans une autre salle que le prof (ne pouvaient pas suivre).
+ * L'unicité par séance suffit (le nom de salle inclut déjà la séance).
  * @param {Object} seance
  * @returns {string}
  */
 export function generateRoomId(seance) {
-  const timestamp = Date.now()
-  return `lms_seance_${seance.id}_${timestamp}`
+  return `lms_seance_${seance.id}`
 }
 
 /**

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -35,14 +35,25 @@
           <label class="block text-gray-700 mb-2" for="password">
             Mot de passe
           </label>
-          <input
-            id="password"
-            v-model="password"
-            type="password"
-            required
-            class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-gray-900 bg-white"
-            placeholder="••••••••"
-          />
+          <div class="relative">
+            <input
+              id="password"
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              required
+              class="w-full px-4 py-2 pr-11 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 text-gray-900 bg-white"
+              placeholder="••••••••"
+            />
+            <button
+              type="button"
+              @click="showPassword = !showPassword"
+              :aria-label="showPassword ? 'Masquer le mot de passe' : 'Afficher le mot de passe'"
+              :aria-pressed="showPassword"
+              class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 hover:text-gray-700 focus:outline-none"
+            >
+              <i :class="showPassword ? 'fa fa-eye-slash' : 'fa fa-eye'"></i>
+            </button>
+          </div>
         </div>
 
         <!-- Bouton de connexion -->
@@ -69,6 +80,7 @@ export default {
     return {
       username: '',
       password: '',
+      showPassword: false,
       loading: false,
       error: null,
     }

--- a/tests/unit/errorHandler.test.js
+++ b/tests/unit/errorHandler.test.js
@@ -1,0 +1,39 @@
+/**
+ * Tests de shouldForceLogout (#fix connexion) : un 401 ne doit déconnecter que
+ * s'il invalide la session locale — PAS un 401 de proxy KLASSCI (« Token KLASSCI
+ * non trouvé »), qui laisse la session Sanctum valide.
+ */
+import { describe, it, expect } from 'vitest'
+import { shouldForceLogout } from '@/services/errorHandler'
+
+const err = (status, { url = '', message = '' } = {}) => ({
+  response: { status, data: { message } },
+  config: { url },
+})
+
+describe('errorHandler — shouldForceLogout', () => {
+  it('déconnecte sur un 401 de session classique', () => {
+    expect(shouldForceLogout(err(401, { url: '/api/auth/me' }))).toBe(true)
+  })
+
+  it('NE déconnecte PAS sur un 401 de proxy KLASSCI (par URL)', () => {
+    expect(shouldForceLogout(err(401, { url: '/api/proxy/me/teacher-dashboard' }))).toBe(false)
+  })
+
+  it('NE déconnecte PAS sur un 401 dont le message mentionne KLASSCI', () => {
+    expect(shouldForceLogout(err(401, { url: '/api/x', message: 'Token KLASSCI non trouvé. Veuillez vous reconnecter.' }))).toBe(false)
+  })
+
+  it('ne déconnecte pas sur les statuts non-401', () => {
+    expect(shouldForceLogout(err(500))).toBe(false)
+    expect(shouldForceLogout(err(403))).toBe(false)
+    expect(shouldForceLogout(err(422))).toBe(false)
+  })
+
+  it('ne lève jamais et renvoie false sur entrée invalide', () => {
+    expect(shouldForceLogout(null)).toBe(false)
+    expect(shouldForceLogout(undefined)).toBe(false)
+    expect(shouldForceLogout({})).toBe(false)
+    expect(shouldForceLogout(new Error('boom'))).toBe(false)
+  })
+})

--- a/tests/unit/jitsiRoom.test.js
+++ b/tests/unit/jitsiRoom.test.js
@@ -24,8 +24,10 @@ describe('utils/jitsiRoom — sanitizeForUrl', () => {
 })
 
 describe('utils/jitsiRoom — generateRoomId', () => {
-  it('format lms_seance_{id}_{timestamp}', () => {
-    expect(generateRoomId({ id: 7 })).toMatch(/^lms_seance_7_\d+$/)
+  it('déterministe par séance : lms_seance_{id} (même salle prof + élèves)', () => {
+    expect(generateRoomId({ id: 7 })).toBe('lms_seance_7')
+    // Stable d'une ouverture à l'autre (sinon prof et élèves dans 2 salles).
+    expect(generateRoomId({ id: 7 })).toBe(generateRoomId({ id: 7 }))
   })
 })
 


### PR DESCRIPTION
Trois changements frontend (corrigés/vérifiés en direct sur l'app locale, contre l'API prod) :

## 1. fix(auth) — ne plus être éjecté à la connexion
Un 401 d'un endpoint **proxy KLASSCI** (« Token KLASSCI non trouvé ») n'invalide pas la session Sanctum locale, mais l'intercepteur déconnectait sur **tout** 401 → l'utilisateur était renvoyé sur `/login` dès le chargement du dashboard.
→ `errorHandler.shouldForceLogout(error)` (pure, testée) ne force le logout que pour un 401 qui **n'est pas** un échec proxy KLASSCI. `api.js` l'utilise. **5 tests** (`errorHandler.test.js`).

## 2. fix(visio) — élèves rejoignent la même salle que le prof
`utils/jitsiRoom.generateRoomId` utilisait `Date.now()` → salle différente à chaque ouverture → prof et élèves dans **2 salles**. Rendu **déterministe** (`lms_seance_{id}`). Test `jitsiRoom.test.js` mis à jour (déterminisme).

## 3. feat(login) — afficher/masquer le mot de passe
Bouton œil sur le champ mot de passe (`type` password↔text, `type="button"`, aria-*).

## Vérification
- Tests ciblés : **13/13** (`errorHandler` + `jitsiRoom`). `vite build` ✅ vert.
- ⚠️ **Note honnête** : la suite complète remonte **1 échec préexistant non lié** — `tests/unit/useCalendarWidget.test.js` **passe en isolation (5/5)** mais échoue en run complet (problème de pollution/isolation de tests sur `dev`, **introduit par une autre fenêtre**, pas par cette PR — aucun des fichiers de cette PR ne touche CalendarWidget). À traiter séparément.

> NB : ce correctif a son **pendant backend** (token KLASSCI persisté) dans `lms_backend#255` — les deux ensemble rendent les dashboards fonctionnels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)