### PR TITLE
fix(evaluations): aligner le select de type sur l'enum backend (corrige le 422)

### DIFF
--- a/src/components/evaluations/TeacherEvalCreateModal.vue
+++ b/src/components/evaluations/TeacherEvalCreateModal.vue
@@ -26,7 +26,8 @@
             <label class="form-label required">Type d'évaluation</label>
             <select v-model="onlineForm.type" required class="form-select">
               <option value="qcm">QCM uniquement</option>
-              <option value="qcm_multiple">QCM à choix multiples</option>
+              <option value="reponse_courte">Réponses courtes</option>
+              <option value="dissertation">Dissertation</option>
               <option value="mixte">Mixte (QCM + réponses courtes)</option>
             </select>
           </div>


### PR DESCRIPTION
## Problème
Créer la **version en ligne** d'une évaluation échouait avec un popup « Erreur lors de la création de la version en ligne ». Console : `POST /api/evaluations 422`.

## Cause (prouvée en live)
Le `<select>` « Type d'évaluation » du modal `TeacherEvalCreateModal.vue` proposait l'option **`qcm_multiple`**, qui n'existe **pas** dans l'enum accepté par le backend `StoreEvaluationRequest` :
```
'type' => 'required|in:qcm,reponse_courte,dissertation,mixte'
```
→ choisir « QCM à choix multiples » renvoie **422 « Le type d'évaluation est invalide »**.

C'était un **désalignement front ↔ back** : le formulaire offrait `qcm_multiple` (refusé) et n'offrait **pas** `reponse_courte` / `dissertation` (acceptés).

## Correctif
Aligner les options du select sur l'enum backend :
- ➖ retire `qcm_multiple` (c'est un type de **question**, conservé dans `QuestionEditor`/`QuestionItemEditor`, accepté par `questions.*.type`) ;
- ➕ ajoute `reponse_courte` et `dissertation`.

## Vérifications
- **Live** : les 4 valeurs du select (`qcm`, `reponse_courte`, `dissertation`, `mixte`) passent désormais la validation backend — plus aucun 422 sur `type`.
- Défaut `onlineForm.type = 'qcm'` : valide.
- Aucun test impacté (`TeacherEvalComponents` teste l'affichage/émissions, pas la liste d'options). CI exécutera la suite complète.

## Portée
1 seul fichier, 1 ligne nette. Pas de jumeau du bug : `CreateEvaluation` envoie un `type` figé à `'qcm'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)