### PR TITLE
fix(matieres): dériver classe_id de classes_concernees (corrige le 403 création de leçon)

### DIFF
--- a/src/composables/useMatiereDetails.js
+++ b/src/composables/useMatiereDetails.js
@@ -126,7 +126,7 @@ export function useMatiereDetails() {
 
       // Préparer les données avec contexte automatique (mapping pur extrait)
       const lessonData = buildLessonPayload(newLesson.value, {
-        matiere: matiere.value,
+        classes: classes.value,
         user,
         matiereId: matiereId.value
       })

--- a/src/utils/matiereDetails.js
+++ b/src/utils/matiereDetails.js
@@ -91,16 +91,18 @@ export function createEmptyLesson() {
 
 /**
  * Construit le payload de création de leçon (contexte matière/classe/enseignant
- * ajouté au brouillon). Mapping PUR — identique au littéral d'origine.
+ * ajouté au brouillon). Mapping PUR.
  * @param {Object} newLesson - brouillon du formulaire
- * @param {{ matiere:Object, user:Object, matiereId:number }} ctx
+ * @param {{ classes:Array, user:Object, matiereId:number }} ctx
+ *   `classes` = classes_concernees de la matière (1ère classe utilisée comme
+ *   classe_id, requis par le backend). `matiere` n'a PAS de propriété `classes`.
  * @returns {Object} payload prêt pour lessonService.createLesson
  */
-export function buildLessonPayload(newLesson, { matiere, user, matiereId }) {
+export function buildLessonPayload(newLesson, { classes, user, matiereId }) {
   return {
     ...newLesson,
     matiere_id: matiereId,
-    classe_id: matiere?.classes?.[0]?.id || null, // Première classe si disponible
+    classe_id: classes?.[0]?.id || null, // 1ère classe concernée (classes_concernees)
     enseignant_id: user?.id,
     type: 'cours',
     status: 'draft'

--- a/tests/unit/matiereDetails.test.js
+++ b/tests/unit/matiereDetails.test.js
@@ -83,9 +83,9 @@ describe('utils/matiereDetails — createEmptyLesson', () => {
 describe('utils/matiereDetails — buildLessonPayload', () => {
   const draft = { title: 'Algèbre', description: 'Intro', niveau_difficulte: 'debutant' }
 
-  it('enrichit le brouillon avec le contexte matière/enseignant', () => {
+  it('enrichit le brouillon avec le contexte classes_concernees/enseignant', () => {
     const payload = buildLessonPayload(draft, {
-      matiere: { classes: [{ id: 7 }, { id: 9 }] },
+      classes: [{ id: 7 }, { id: 9 }], // classes_concernees de la matière
       user: { id: 42 },
       matiereId: 3
     })
@@ -93,15 +93,15 @@ describe('utils/matiereDetails — buildLessonPayload', () => {
       title: 'Algèbre',
       description: 'Intro',
       matiere_id: 3,
-      classe_id: 7,            // première classe
+      classe_id: 7,            // première classe concernée
       enseignant_id: 42,
       type: 'cours',
       status: 'draft'
     })
   })
-  it('classe_id null si la matière n\'a pas de classe', () => {
-    expect(buildLessonPayload(draft, { matiere: {}, user: { id: 1 }, matiereId: 3 }).classe_id).toBeNull()
-    expect(buildLessonPayload(draft, { matiere: null, user: null, matiereId: 3 }).classe_id).toBeNull()
+  it('classe_id null si aucune classe concernée', () => {
+    expect(buildLessonPayload(draft, { classes: [], user: { id: 1 }, matiereId: 3 }).classe_id).toBeNull()
+    expect(buildLessonPayload(draft, { classes: null, user: null, matiereId: 3 }).classe_id).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Problème
Créer une leçon depuis une matière → **403** sur `POST /lessons`.

## Cause
`buildLessonPayload` lisait `matiere?.classes?.[0]?.id`, mais l'objet `matiere` **n'a pas** de propriété `classes` → `classe_id` toujours `null`. Le backend exige une `Classe` locale valide → 403.

Les classes sont en réalité dans **`classes_concernees`** (ref `classes` du composable, alimentée par `/lms/matieres/{id}`).

## Correctif
- `buildLessonPayload(newLesson, { classes, user, matiereId })` lit `classes?.[0]?.id`.
- `useMatiereDetails` passe `classes: classes.value` au lieu de `matiere`.

Complément du fix backend qui **expose** `classes_concernees` (PR lms **#274**) — les deux sont nécessaires.

## Vérifications
- Chemin équivalent vérifié **en live** : `classes_concernees=[{id:1}]` → `POST /lessons` → **201 « Cours créé avec succès »**.
- Logique de `buildLessonPayload` exécutée directement sur les 3 cas du test mis à jour → `classe_id` = 7 / null / null ✓.
- `matiereDetails.test.js` mis à jour (nouvelle signature `classes`).

> Note : pas de CI sur ce repo frontend ; vérification faite manuellement (live + exécution de la logique), le repo n'ayant pas de pipeline vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)