### PR TITLE
fix(editor): migration TipTap v3 — bubble menu + doublons link/underline

### DIFF
--- a/src/components/common/EditorBubbleMenu.vue
+++ b/src/components/common/EditorBubbleMenu.vue
@@ -4,14 +4,13 @@
        (gras/italique/souligné/barré), lien (via addLink émis vers le parent) et
        sélecteurs de couleur (texte / surlignage). Markup et CSS conservés à
        l'identique pour parité stricte.
-       DETTE PRÉ-EXISTANTE conservée telle quelle : le composant `BubbleMenu` de
-       @tiptap/vue-3 n'est pas importé/enregistré (cf. TipTapEditor.vue d'origine,
-       aucune registration globale ni isCustomElement). Le tag reste `<bubble-menu>`
-       à l'identique pour ne rien changer au rendu actuel. -->
+       TipTap v3 : `BubbleMenu` est importé depuis `@tiptap/vue-3/menus` (déplacé
+       hors de @tiptap/vue-3 en v3) et `:tippy-options` (tippy, supprimé) est
+       remplacé par `:options` (floating-ui). Le composant s'auto-enregistre. -->
   <bubble-menu
     v-if="editor"
     :editor="editor"
-    :tippy-options="{ duration: 100, placement: 'top' }"
+    :options="{ placement: 'top' }"
     class="bubble-menu-custom"
   >
     <button
@@ -71,6 +70,8 @@
 </template>
 
 <script setup>
+import { BubbleMenu } from '@tiptap/vue-3/menus' // v3 : BubbleMenu déplacé hors de @tiptap/vue-3
+
 /**
  * Bubble menu (toolbar flottante) de l'éditeur riche (#G1 ≤300).
  * Extrait de TipTapEditor.vue. Reçoit l'instance `editor` ; les commandes inline

--- a/src/config/tiptapExtensions.js
+++ b/src/config/tiptapExtensions.js
@@ -33,7 +33,12 @@ export function buildEditorExtensions(placeholder) {
     StarterKit.configure({
       heading: {
         levels: [1, 2, 3]
-      }
+      },
+      // StarterKit v3 inclut désormais Link + Underline : on les désactive ici
+      // pour garder nos versions configurées plus bas (sinon « Duplicate
+      // extension names: ['link','underline'] »).
+      link: false,
+      underline: false
     }),
     Placeholder.configure({ placeholder }),
     Link.configure({

--- a/tests/unit/tiptapExtensions.test.js
+++ b/tests/unit/tiptapExtensions.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { Editor } from '@tiptap/vue-3'
+import { buildEditorExtensions } from '@/config/tiptapExtensions'
+
+/**
+ * Régression : StarterKit v3 inclut désormais Link + Underline. Le config les
+ * rajoutait → « Duplicate extension names: ['link','underline'] » (TipTap warn).
+ * On vérifie qu'un éditeur construit avec buildEditorExtensions n'a AUCUN nom
+ * d'extension en double (link/underline désactivés dans StarterKit).
+ */
+describe('config/tiptapExtensions — buildEditorExtensions', () => {
+  it('construit un éditeur sans extension en double (link/underline)', () => {
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: buildEditorExtensions('Placeholder de test'),
+      content: ''
+    })
+
+    const names = editor.extensionManager.extensions.map((e) => e.name)
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i)
+
+    expect(dupes).toEqual([])
+    // link + underline présents UNE seule fois (nos versions configurées)
+    expect(names.filter((n) => n === 'link')).toHaveLength(1)
+    expect(names.filter((n) => n === 'underline')).toHaveLength(1)
+
+    editor.destroy()
+  })
+})


### PR DESCRIPTION
## Problème
Dans l'éditeur de chapitres, deux warnings TipTap v3 :
1. `Failed to resolve component: bubble-menu` → la barre flottante de sélection ne s'affiche pas.
2. `Duplicate extension names found: ['link','underline']`.

## Cause
Migration TipTap **v2 → v3** incomplète :
1. En v3, le composant `BubbleMenu` est **déplacé hors** de `@tiptap/vue-3` (sous-chemin `@tiptap/vue-3/menus`) et n'était pas importé → le tag `<bubble-menu>` ne se résolvait pas. La prop `:tippy-options` (tippy.js) a aussi été **remplacée** par `:options` (floating-ui).
2. `StarterKit` v3 **inclut désormais** Link + Underline ; le config les rajoutait → doublons.

## Correctif
- `EditorBubbleMenu.vue` : `import { BubbleMenu } from '@tiptap/vue-3/menus'` + `:options="{ placement: 'top' }"`. Le composant **s'auto-enregistre** (vérifié : `registerPlugin`/`BubbleMenuPlugin` internes), donc pas besoin d'ajouter l'extension à la liste.
- `tiptapExtensions.js` : `link: false`, `underline: false` dans `StarterKit.configure` (on garde nos versions configurées).

## Vérifications
- **Live** : route `/teacher/lessons/:id/chapters` → éditeur monté (1 ProseMirror), **console propre** (plus aucun des deux warnings).
- Test `tiptapExtensions.test.js` : construit un éditeur réel et asserte 0 extension en double (link/underline présents une seule fois). **Passé en local** (le repo n'a pas de CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)