### PR TITLE
feat(endpoints): carte unique des chemins API Klassci/LMS (#105)

### DIFF
--- a/src/services/endpoints.js
+++ b/src/services/endpoints.js
@@ -1,0 +1,151 @@
+/**
+ * Carte UNIQUE des endpoints d'API (#105, E1).
+ *
+ * Registre centralisé de TOUS les chemins d'API consommés par les services
+ * existants (api.js, klassci.js, lms*.js). On centralise les CHEMINS, pas la
+ * logique : aucun `api.get/post/...` ici, aucune dépendance, aucune règle
+ * métier. Les services restent les seuls à porter try/catch, transformation
+ * de réponse et frontières d'usage.
+ *
+ * Frontière BRUT vs ENRICHI (#26 — cf. en-tête de src/services/klassci.js) :
+ *  - `endpoints.klassci.*` → `/proxy/*` : données KLASSCI BRUTES (passe-plat).
+ *  - `endpoints.lms.*`     → `/lms/*`   : données ENRICHIES LMS.
+ * Cette séparation est STRUCTURELLE ici : un chemin `/proxy/*` ne doit jamais
+ * apparaître sous `endpoints.lms`, ni l'inverse (garde-fou testé, #26).
+ *
+ * Convention : chemin statique = chaîne ; chemin paramétré = fonction pure
+ * (ex. `classeDetails: (id) => `/proxy/classes/${id}``). Les query strings
+ * (?with_details, ?page…) restent à la charge des appelants (orthogonaux).
+ */
+
+// Préfixes de frontière (#26) — source unique, évite la dérive proxy/lms.
+const KLASSCI = '/proxy'
+const LMS = '/lms'
+
+export const endpoints = {
+  // ── KLASSCI — BRUT (/proxy/*) ───────────────────────────────────────────
+  klassci: {
+    classes: `${KLASSCI}/classes`,
+    classeDetails: (id) => `${KLASSCI}/classes/${id}`,
+    classeEtudiants: (id) => `${KLASSCI}/classes/${id}/etudiants`,
+    matieres: `${KLASSCI}/matieres`,
+    enseignants: `${KLASSCI}/enseignants`,
+    emploiTemps: `${KLASSCI}/emploi-temps`,
+    structure: `${KLASSCI}/structure`,
+    evaluations: `${KLASSCI}/evaluations`,
+    studentDashboard: `${KLASSCI}/me/dashboard`,
+    teacherDashboard: `${KLASSCI}/me/teacher-dashboard`,
+  },
+
+  // ── LMS — ENRICHI (/lms/*) ──────────────────────────────────────────────
+  lms: {
+    enseignants: `${LMS}/enseignants`,
+
+    classes: {
+      details: (id) => `${LMS}/classes/${id}`,
+      etudiants: (id) => `${LMS}/classes/${id}/etudiants`,
+    },
+
+    matieres: {
+      details: (id) => `${LMS}/matieres/${id}`,
+      myTeacher: `${LMS}/teacher/my-matieres`,
+    },
+
+    seances: {
+      upcoming: `${LMS}/seances/upcoming`,
+      history: `${LMS}/seances/history`,
+      myTeaching: `${LMS}/seances/my-teaching`,
+      myClasses: `${LMS}/seances/my-classes`,
+      details: (id) => `${LMS}/seances/${id}/details`,
+      participants: (id) => `${LMS}/seances/${id}/participants`,
+      attendances: (id) => `${LMS}/seances/${id}/attendances`,
+      validateParticipant: (id) => `${LMS}/seances/${id}/validate-participant`,
+      hide: (id) => `${LMS}/seances/${id}/hide`,
+      unhide: (id) => `${LMS}/seances/${id}/unhide`,
+      delete: (id) => `${LMS}/seances/${id}`,
+    },
+
+    // Cycle de vie visio d'une séance (sous /lms/seances/{id}/*).
+    visio: {
+      toggle: (id) => `${LMS}/seances/${id}/toggle-visio`,
+      activate: (id) => `${LMS}/seances/${id}/activate-visio`,
+      deactivate: (id) => `${LMS}/seances/${id}/deactivate-visio`,
+      start: (id) => `${LMS}/seances/${id}/start-visio`,
+      end: (id) => `${LMS}/seances/${id}/end-visio`,
+      join: (id) => `${LMS}/seances/${id}/join`,
+      leave: (id) => `${LMS}/seances/${id}/leave`,
+      heartbeat: (id) => `${LMS}/seances/${id}/heartbeat`,
+      participants: (id) => `${LMS}/seances/${id}/visio-participants`,
+    },
+
+    attendance: {
+      history: `${LMS}/attendance/history`,
+      fromVideoSession: `${LMS}/attendances/from-video-session`,
+    },
+
+    // Notifications LIÉES aux séances (préférences, rappels). Le client
+    // notifications général (cloche) reste src/services/notifications.js.
+    notifications: {
+      preferences: (userId) => `${LMS}/notifications/preferences/${userId}`,
+      sendSessionReminder: `${LMS}/notifications/send-session-reminder`,
+    },
+  },
+
+  // ── ADMIN (/admin/*) ────────────────────────────────────────────────────
+  admin: {
+    matieres: '/admin/matieres',
+    institutions: {
+      // list (GET) et create (POST) partagent le chemin collection.
+      list: '/admin/institutions',
+      // details (GET) / update (PUT) / delete (DELETE) partagent le chemin item.
+      details: (id) => `/admin/institutions/${id}`,
+      toggle: (id) => `/admin/institutions/${id}/toggle`,
+      testConnection: (id) => `/admin/institutions/${id}/test-connection`,
+    },
+  },
+
+  // ── LESSONS (/lessons/*) ────────────────────────────────────────────────
+  lessons: {
+    list: '/lessons',
+    details: (id) => `/lessons/${id}`,
+    myCourses: '/lessons/my-courses',
+  },
+
+  // ── QUIZZES & tentatives ────────────────────────────────────────────────
+  quizzes: {
+    list: '/quizzes',
+    details: (id) => `/quizzes/${id}`,
+    start: (id) => `/quizzes/${id}/start`,
+    submitAttempt: (attemptId) => `/quiz-attempts/${attemptId}/submit`,
+  },
+
+  // ── DASHBOARD LMS local (/dashboard/*) — distinct des dashboards KLASSCI
+  //    /proxy/me/* ci-dessus, qu'on conserve séparément (#26). ─────────────
+  dashboard: {
+    student: '/dashboard/student',
+    teacher: '/dashboard/teacher',
+    stats: '/dashboard/stats',
+  },
+
+  // ── FORUM (/forum/*) ────────────────────────────────────────────────────
+  forum: {
+    topics: '/forum/topics',
+    topic: (id) => `/forum/topics/${id}`,
+    topicPosts: (id) => `/forum/topics/${id}/posts`,
+    closeTopic: (id) => `/forum/topics/${id}/close`,
+    pinTopic: (id) => `/forum/topics/${id}/pin`,
+    post: (id) => `/forum/posts/${id}`,
+    postSolution: (id) => `/forum/posts/${id}/solution`,
+  },
+
+  // ── DIVERS ──────────────────────────────────────────────────────────────
+  teacher: {
+    stats: '/teacher/stats',
+  },
+  evaluations: {
+    // Évaluations de l'étudiant connecté (≠ /proxy/evaluations brut KLASSCI).
+    student: '/evaluations/student',
+  },
+}
+
+export default endpoints

--- a/tests/unit/Endpoints.test.js
+++ b/tests/unit/Endpoints.test.js
@@ -1,0 +1,186 @@
+/**
+ * Tests de la carte unique des endpoints (#105, E1).
+ *
+ * NB nommage : la config Vitest (`vitest.config.js`) ne collecte que
+ * `tests/**\/*.test.{js,mjs}`. L'issue mentionne `Endpoints.spec.js`, mais un
+ * `.spec.js` ne serait JAMAIS exécuté → fichier nommé `Endpoints.test.js`
+ * pour qu'il tourne réellement sous `npm test` (convention du dépôt).
+ *
+ * Objectifs :
+ *  1. Chaque chemin résout EXACTEMENT à sa valeur attendue (fonctions incluses).
+ *  2. La frontière #26 est préservée STRUCTURELLEMENT :
+ *     - tout `endpoints.klassci.*` est sous `/proxy/*`,
+ *     - tout `endpoints.lms.*`     est sous `/lms/*`,
+ *     - aucun croisement.
+ *  3. Couverture : tous les chemins en dur d'api.js/klassci.js/lms*.js recensés.
+ */
+import { describe, it, expect } from 'vitest'
+import endpoints from '@/services/endpoints'
+
+/**
+ * Aplatit le registre en paires [chemin-pointé, valeur résolue], en appelant
+ * chaque fonction paramétrée avec un id sentinelle pour obtenir le chemin final.
+ */
+const ID = ':id'
+function flatten(node, prefix = '') {
+  const out = []
+  for (const [key, val] of Object.entries(node)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (typeof val === 'function') out.push([path, val(ID)])
+    else if (typeof val === 'string') out.push([path, val])
+    else out.push(...flatten(val, path))
+  }
+  return out
+}
+
+describe('endpoints — carte unique (#105)', () => {
+  describe('frontière BRUT /proxy vs ENRICHI /lms (#26)', () => {
+    it('tout endpoints.klassci.* est sous /proxy/', () => {
+      for (const [path, url] of flatten(endpoints.klassci, 'klassci')) {
+        expect(url.startsWith('/proxy/'), `${path} → ${url}`).toBe(true)
+      }
+    })
+
+    it('tout endpoints.lms.* est sous /lms/', () => {
+      for (const [path, url] of flatten(endpoints.lms, 'lms')) {
+        expect(url.startsWith('/lms/'), `${path} → ${url}`).toBe(true)
+      }
+    })
+
+    it('aucun chemin /proxy/ ne fuit hors de endpoints.klassci', () => {
+      for (const group of ['lms', 'admin', 'lessons', 'quizzes', 'dashboard', 'forum', 'teacher', 'evaluations']) {
+        for (const [path, url] of flatten(endpoints[group], group)) {
+          expect(url.startsWith('/proxy/'), `${path} → ${url}`).toBe(false)
+        }
+      }
+    })
+  })
+
+  describe('valeurs exactes — KLASSCI brut (/proxy/*)', () => {
+    const k = endpoints.klassci
+    it('chemins statiques', () => {
+      expect(k.classes).toBe('/proxy/classes')
+      expect(k.matieres).toBe('/proxy/matieres')
+      expect(k.enseignants).toBe('/proxy/enseignants')
+      expect(k.emploiTemps).toBe('/proxy/emploi-temps')
+      expect(k.structure).toBe('/proxy/structure')
+      expect(k.evaluations).toBe('/proxy/evaluations')
+      expect(k.studentDashboard).toBe('/proxy/me/dashboard')
+      expect(k.teacherDashboard).toBe('/proxy/me/teacher-dashboard')
+    })
+    it('chemins paramétrés', () => {
+      expect(k.classeDetails(7)).toBe('/proxy/classes/7')
+      expect(k.classeEtudiants(7)).toBe('/proxy/classes/7/etudiants')
+    })
+  })
+
+  describe('valeurs exactes — LMS enrichi (/lms/*)', () => {
+    const l = endpoints.lms
+    it('enseignants / classes / matieres', () => {
+      expect(l.enseignants).toBe('/lms/enseignants')
+      expect(l.classes.details(3)).toBe('/lms/classes/3')
+      expect(l.classes.etudiants(3)).toBe('/lms/classes/3/etudiants')
+      expect(l.matieres.details(9)).toBe('/lms/matieres/9')
+      expect(l.matieres.myTeacher).toBe('/lms/teacher/my-matieres')
+    })
+    it('seances', () => {
+      expect(l.seances.upcoming).toBe('/lms/seances/upcoming')
+      expect(l.seances.history).toBe('/lms/seances/history')
+      expect(l.seances.myTeaching).toBe('/lms/seances/my-teaching')
+      expect(l.seances.myClasses).toBe('/lms/seances/my-classes')
+      expect(l.seances.details(5)).toBe('/lms/seances/5/details')
+      expect(l.seances.participants(5)).toBe('/lms/seances/5/participants')
+      expect(l.seances.attendances(5)).toBe('/lms/seances/5/attendances')
+      expect(l.seances.validateParticipant(5)).toBe('/lms/seances/5/validate-participant')
+      expect(l.seances.hide(5)).toBe('/lms/seances/5/hide')
+      expect(l.seances.unhide(5)).toBe('/lms/seances/5/unhide')
+      expect(l.seances.delete(5)).toBe('/lms/seances/5')
+    })
+    it('visio', () => {
+      expect(l.visio.toggle(5)).toBe('/lms/seances/5/toggle-visio')
+      expect(l.visio.activate(5)).toBe('/lms/seances/5/activate-visio')
+      expect(l.visio.deactivate(5)).toBe('/lms/seances/5/deactivate-visio')
+      expect(l.visio.start(5)).toBe('/lms/seances/5/start-visio')
+      expect(l.visio.end(5)).toBe('/lms/seances/5/end-visio')
+      expect(l.visio.join(5)).toBe('/lms/seances/5/join')
+      expect(l.visio.leave(5)).toBe('/lms/seances/5/leave')
+      expect(l.visio.heartbeat(5)).toBe('/lms/seances/5/heartbeat')
+      expect(l.visio.participants(5)).toBe('/lms/seances/5/visio-participants')
+    })
+    it('attendance / notifications', () => {
+      expect(l.attendance.history).toBe('/lms/attendance/history')
+      expect(l.attendance.fromVideoSession).toBe('/lms/attendances/from-video-session')
+      expect(l.notifications.preferences(42)).toBe('/lms/notifications/preferences/42')
+      expect(l.notifications.sendSessionReminder).toBe('/lms/notifications/send-session-reminder')
+    })
+  })
+
+  describe('valeurs exactes — admin / lessons / quizzes / dashboard / forum / divers', () => {
+    it('admin', () => {
+      expect(endpoints.admin.matieres).toBe('/admin/matieres')
+      expect(endpoints.admin.institutions.list).toBe('/admin/institutions')
+      expect(endpoints.admin.institutions.details(2)).toBe('/admin/institutions/2')
+      expect(endpoints.admin.institutions.toggle(2)).toBe('/admin/institutions/2/toggle')
+      expect(endpoints.admin.institutions.testConnection(2)).toBe('/admin/institutions/2/test-connection')
+    })
+    it('lessons / quizzes', () => {
+      expect(endpoints.lessons.list).toBe('/lessons')
+      expect(endpoints.lessons.details(1)).toBe('/lessons/1')
+      expect(endpoints.lessons.myCourses).toBe('/lessons/my-courses')
+      expect(endpoints.quizzes.list).toBe('/quizzes')
+      expect(endpoints.quizzes.details(1)).toBe('/quizzes/1')
+      expect(endpoints.quizzes.start(1)).toBe('/quizzes/1/start')
+      expect(endpoints.quizzes.submitAttempt(8)).toBe('/quiz-attempts/8/submit')
+    })
+    it('dashboard / forum / teacher / evaluations', () => {
+      expect(endpoints.dashboard.student).toBe('/dashboard/student')
+      expect(endpoints.dashboard.teacher).toBe('/dashboard/teacher')
+      expect(endpoints.dashboard.stats).toBe('/dashboard/stats')
+      expect(endpoints.forum.topics).toBe('/forum/topics')
+      expect(endpoints.forum.topic(4)).toBe('/forum/topics/4')
+      expect(endpoints.forum.topicPosts(4)).toBe('/forum/topics/4/posts')
+      expect(endpoints.forum.closeTopic(4)).toBe('/forum/topics/4/close')
+      expect(endpoints.forum.pinTopic(4)).toBe('/forum/topics/4/pin')
+      expect(endpoints.forum.post(6)).toBe('/forum/posts/6')
+      expect(endpoints.forum.postSolution(6)).toBe('/forum/posts/6/solution')
+      expect(endpoints.teacher.stats).toBe('/teacher/stats')
+      expect(endpoints.evaluations.student).toBe('/evaluations/student')
+    })
+  })
+
+  describe('couverture — tous les chemins en dur recensés (api.js/klassci.js/lms*.js)', () => {
+    it('chaque chemin attendu est présent dans la carte (set complet)', () => {
+      const resolved = new Set(flatten(endpoints).map(([, url]) => url))
+      const EXPECTED = [
+        // api.js
+        '/lessons', '/lessons/:id', '/quizzes', '/quizzes/:id', '/quizzes/:id/start',
+        '/quiz-attempts/:id/submit', '/dashboard/student', '/dashboard/teacher',
+        '/dashboard/stats', '/forum/topics', '/forum/topics/:id', '/forum/topics/:id/posts',
+        '/forum/topics/:id/close', '/forum/topics/:id/pin', '/forum/posts/:id',
+        '/forum/posts/:id/solution', '/teacher/stats', '/admin/institutions',
+        '/admin/institutions/:id', '/admin/institutions/:id/toggle',
+        '/admin/institutions/:id/test-connection',
+        // klassci.js (/proxy/* + chemins partagés)
+        '/proxy/classes', '/proxy/classes/:id', '/proxy/classes/:id/etudiants',
+        '/proxy/matieres', '/proxy/enseignants', '/proxy/emploi-temps', '/proxy/structure',
+        '/proxy/evaluations', '/proxy/me/dashboard', '/proxy/me/teacher-dashboard',
+        '/lessons/my-courses', '/admin/matieres', '/evaluations/student',
+        // lms*.js (/lms/*)
+        '/lms/enseignants', '/lms/classes/:id', '/lms/classes/:id/etudiants',
+        '/lms/matieres/:id', '/lms/teacher/my-matieres', '/lms/seances/upcoming',
+        '/lms/seances/history', '/lms/seances/my-teaching', '/lms/seances/my-classes',
+        '/lms/seances/:id/details', '/lms/seances/:id/participants',
+        '/lms/seances/:id/attendances', '/lms/seances/:id/validate-participant',
+        '/lms/seances/:id/hide', '/lms/seances/:id/unhide', '/lms/seances/:id',
+        '/lms/seances/:id/toggle-visio', '/lms/seances/:id/activate-visio',
+        '/lms/seances/:id/deactivate-visio', '/lms/seances/:id/start-visio',
+        '/lms/seances/:id/end-visio', '/lms/seances/:id/join', '/lms/seances/:id/leave',
+        '/lms/seances/:id/heartbeat', '/lms/seances/:id/visio-participants',
+        '/lms/attendance/history', '/lms/attendances/from-video-session',
+        '/lms/notifications/preferences/:id', '/lms/notifications/send-session-reminder',
+      ]
+      const missing = EXPECTED.filter((p) => !resolved.has(p))
+      expect(missing, `chemins manquants : ${missing.join(', ')}`).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
Registre centralise de tous les chemins d'API consommes par les services existants (api.js, klassci.js, lms*.js). On centralise les CHEMINS, pas la logique : aucun appel api.*, aucune dependance, aucun service modifie/fusionne.

- 63 chemins recenses, organises par frontiere d'URL : klassci (/proxy/*), lms (/lms/* : classes/matieres/seances/visio/attendance/notifications), admin, lessons, quizzes, dashboard, forum, teacher, evaluations.
- Frontiere #26 BRUT /proxy vs ENRICHI /lms encodee via constantes KLASSCI/LMS et garde-fou structurel teste (aucun croisement proxy<->lms).
- Chemins parametres via fonctions pures ; query strings laissees aux appelants.
- tests/unit/Endpoints.test.js : 13 tests (valeurs exactes + frontiere + couverture exhaustive). Nomme .test.js (pas .spec.js) car vitest.config.js ne collecte que *.test.{js,mjs} ; un .spec.js ne serait jamais execute.

Fichier neuf uniquement, zero conflit. Debloque #E2 et #E3.