### PR TITLE
feat(nav): config de navigation déclarative + composable useNavigatio…

### DIFF
--- a/src/composables/useNavigation.js
+++ b/src/composables/useNavigation.js
@@ -1,0 +1,68 @@
+/**
+ * Composable de navigation (#104 / N1).
+ *
+ * Expose le menu déclaratif (`@/constants/navigation`) déjà filtré selon le rôle de
+ * l'utilisateur courant. Réutilise `hasRole` de `@/constants/roles` — la logique de
+ * rôle (normalisation des alias backend, fail-secure) n'est jamais réimplémentée ici.
+ *
+ * Séparation des responsabilités :
+ *   - `filterSectionsByRole` : fonction PURE (données → données), sans Vue ni auth,
+ *     unité-testable en isolation avec un faux `user`. Gère le filtrage récursif des
+ *     `children` (un groupe dont tous les enfants sont masqués disparaît).
+ *   - `useNavigation`        : enveloppe réactive fine qui lit l'utilisateur via le
+ *     store/auth (`auth.getUser()`), ou via un `user` injecté (tests / SSR).
+ */
+
+import { computed } from 'vue'
+import { auth } from '@/services/api'
+import { hasRole } from '@/constants/roles'
+import { NAV_SECTIONS } from '@/constants/navigation'
+
+/**
+ * Filtre récursivement une liste d'items de navigation selon le rôle de l'utilisateur.
+ * Un item est conservé ssi l'utilisateur possède l'un de ses `roles` (via `hasRole`,
+ * donc fail-secure : rôle inconnu/null → rien). Un item avec `children` est conservé
+ * si l'utilisateur y a droit ET qu'il reste au moins un enfant visible (ou aucun
+ * enfant défini). Les `children` sont remplacés par leur version filtrée.
+ *
+ * @param {ReadonlyArray<import('@/constants/navigation').NavItem>} sections
+ * @param {object|string|null} userOrRole - Objet user, chaîne de rôle, ou null.
+ * @returns {Array<import('@/constants/navigation').NavItem>} Nouveaux items filtrés.
+ */
+export function filterSectionsByRole(sections, userOrRole) {
+  if (!Array.isArray(sections)) return []
+
+  return sections.reduce((acc, item) => {
+    if (!hasRole(userOrRole, item.roles)) return acc
+
+    if (Array.isArray(item.children)) {
+      const children = filterSectionsByRole(item.children, userOrRole)
+      // Un groupe sans aucun enfant visible n'est pas affiché.
+      if (children.length === 0) return acc
+      acc.push({ ...item, children })
+    } else {
+      acc.push({ ...item })
+    }
+    return acc
+  }, [])
+}
+
+/**
+ * Retourne les sections de navigation filtrées par rôle, sous forme réactive.
+ *
+ * @param {Object} [options]
+ * @param {object|string|null} [options.user] - Utilisateur injecté (sinon `auth.getUser()`).
+ * @param {ReadonlyArray<import('@/constants/navigation').NavItem>} [options.sections]
+ *        Config injectée (sinon `NAV_SECTIONS`) — utile pour les tests.
+ * @returns {{ sections: import('vue').ComputedRef<Array<import('@/constants/navigation').NavItem>> }}
+ */
+export function useNavigation(options = {}) {
+  const source = options.sections ?? NAV_SECTIONS
+
+  const sections = computed(() => {
+    const user = 'user' in options ? options.user : auth.getUser()
+    return filterSectionsByRole(source, user)
+  })
+
+  return { sections }
+}

--- a/src/constants/navigation.js
+++ b/src/constants/navigation.js
@@ -1,0 +1,92 @@
+/**
+ * Configuration déclarative UNIQUE de la navigation (#104 / N1).
+ *
+ * Source de vérité du menu, extraite à l'identique du `menuSections` codé en dur dans
+ * `src/components/layout/Sidebar.vue` (lignes 138-344, commit de référence). Objectif :
+ * une seule définition réutilisée par la Sidebar (#N2) et la BottomNavigation (#N3),
+ * supprimant la duplication (#25) et préparant le passage de Sidebar sous 300 lignes (#28).
+ *
+ * Ce module ne contient QUE des données pures (aucun Vue, aucun accès auth). Le filtrage
+ * par rôle vit dans `@/composables/useNavigation` et réutilise `@/constants/roles` —
+ * la logique de rôle n'est jamais réimplémentée ici.
+ *
+ * --- Fidélité au code source (aucune invention) ---
+ * Le `menuSections` original calcule des drapeaux puis empile les items dans un ordre
+ * précis avec des conditions (dont des négations `!isCoordinateur` et des `to` variables
+ * selon le rôle). On reproduit EXACTEMENT ce comportement en pré-résolvant, pour chaque
+ * item, l'ensemble des rôles CANONIQUES auxquels il apparaît :
+ *   - isStudentRole  → [etudiant]
+ *   - isTeacherRole  → [enseignant, coordinateur]   (isTeacher OU coordinateur)
+ *   - isAdminRole    → [admin, coordinateur]         (isAdminScope ; supradmin sort en amont)
+ *   - isCoordinateur → [coordinateur]
+ *   - isSupradmin    → [supradmin]                   (menu minimal, retour anticipé)
+ * Les `to` conditionnels du source (Dashboard, Paramètres) sont fidèlement éclatés en
+ * deux entrées disjointes par rôle. L'ordre du tableau ci-dessous est tel que, pour
+ * CHAQUE rôle, la sous-séquence filtrée reproduit l'ordre d'empilement d'origine.
+ *
+ * Le menu source est plat : aucun sous-menu (`children`) n'est défini. Le champ
+ * `children` reste documenté et géré par le filtre (récursif) pour les évolutions #N2/#N3,
+ * sans en inventer le contenu.
+ */
+
+import { ROLES } from '@/constants/roles'
+
+/**
+ * @typedef {Object} NavItem
+ * @property {string} label    Libellé affiché.
+ * @property {string} icon     Classe d'icône Font Awesome (ex. 'fa-home'), reprise telle quelle.
+ * @property {string} [to]     Route cible (absente pour un simple groupe de `children`).
+ * @property {string[]} roles  Rôles CANONIQUES (cf. `ROLES`) auxquels l'item est visible.
+ * @property {NavItem[]} [children] Sous-items optionnels (filtrés récursivement par rôle).
+ */
+
+const { ETUDIANT, ENSEIGNANT, COORDINATEUR, ADMIN, SUPRADMIN } = ROLES
+
+/**
+ * Menu déclaratif complet, dans l'ordre d'empilement du Sidebar source.
+ * @type {ReadonlyArray<NavItem>}
+ */
+export const NAV_SECTIONS = Object.freeze([
+  // --- Bloc Étudiant (isStudentRole) ---
+  { icon: 'fa-home', label: 'Dashboard', to: '/student/dashboard', roles: [ETUDIANT] },
+  { icon: 'fa-book', label: 'Mes Cours', to: '/student/courses', roles: [ETUDIANT] },
+  { icon: 'fa-clock-o', label: 'Emploi du Temps', to: '/student/schedule', roles: [ETUDIANT] },
+  { icon: 'fa-edit', label: 'Évaluations', to: '/student/evaluations-list', roles: [ETUDIANT] },
+  { icon: 'fa-star', label: 'Mes Notes', to: '/student/grades', roles: [ETUDIANT] },
+  { icon: 'fa-comments', label: 'Forum', to: '/forum', roles: [ETUDIANT] },
+  { icon: 'fa-cog', label: 'Paramètres', to: '/student/settings', roles: [ETUDIANT] },
+
+  // --- Dashboard enseignant/admin (to conditionnel éclaté) ---
+  { icon: 'fa-home', label: 'Dashboard', to: '/teacher/dashboard', roles: [ENSEIGNANT] },
+  { icon: 'fa-home', label: 'Dashboard', to: '/admin/dashboard', roles: [COORDINATEUR, ADMIN] },
+
+  // --- Bloc Enseignant (isTeacherRole) ---
+  { icon: 'fa-calendar', label: 'Emploi du Temps', to: '/teacher/schedule', roles: [ENSEIGNANT] },
+  { icon: 'fa-th-large', label: 'Mon Espace', to: '/teacher/hub', roles: [ENSEIGNANT] },
+  { icon: 'fa-edit', label: 'Évaluations', to: '/teacher/evaluations', roles: [ENSEIGNANT] },
+  { icon: 'fa-edit', label: 'Évaluations', to: '/coordinateur/evaluations', roles: [COORDINATEUR] },
+
+  // --- Bloc Admin (isAdminRole) ---
+  { icon: 'fa-users', label: 'Utilisateurs', to: '/admin/users', roles: [ADMIN] },
+  // Coordinateur : hub admin restreint
+  { icon: 'fa-building', label: 'Espace Admin', to: '/admin/hub', roles: [COORDINATEUR] },
+  { icon: 'fa-trophy', label: 'Résultats', to: '/admin/evaluations/results', roles: [COORDINATEUR] },
+  { icon: 'fa-calendar', label: 'Séances & Visio', to: '/coordinateur/seances', roles: [COORDINATEUR] },
+  // Admin/superAdmin complet (pas coordinateur)
+  { icon: 'fa-building', label: 'Classes', to: '/admin/classes', roles: [ADMIN] },
+  { icon: 'fa-book', label: 'Matières', to: '/admin/matieres', roles: [ADMIN] },
+  { icon: 'fa-user', label: 'Enseignants', to: '/admin/enseignants', roles: [ADMIN] },
+  { icon: 'fa-calendar', label: 'Séances', to: '/admin/seances', roles: [ADMIN] },
+  { icon: 'fa-video-camera', label: 'Visioconférences', to: '/admin/visioconferences', roles: [ADMIN] },
+  { icon: 'fa-trophy', label: 'Résultats Évaluations', to: '/admin/evaluations/results', roles: [ADMIN] },
+  { icon: 'fa-line-chart', label: 'Statistiques', to: '/admin/stats', roles: [ADMIN] },
+
+  // --- Queue partagée enseignant/admin ---
+  { icon: 'fa-comments', label: 'Forum', to: '/forum', roles: [ENSEIGNANT, COORDINATEUR, ADMIN] },
+  { icon: 'fa-history', label: 'Historique', to: '/attendance/seances', roles: [ENSEIGNANT, COORDINATEUR, ADMIN] },
+  { icon: 'fa-cog', label: 'Paramètres', to: '/teacher/settings', roles: [ENSEIGNANT] },
+  { icon: 'fa-cog', label: 'Paramètres', to: '/admin/settings', roles: [COORDINATEUR, ADMIN] },
+
+  // --- Supradmin (menu minimal, retour anticipé d'origine) ---
+  { icon: 'fa-university', label: 'Institutions', to: '/admin/institutions', roles: [SUPRADMIN] },
+])

--- a/tests/unit/NavConfig.test.js
+++ b/tests/unit/NavConfig.test.js
@@ -1,0 +1,168 @@
+/**
+ * Tests de la configuration de navigation déclarative (#104 / N1).
+ *
+ * Contrat de FIDÉLITÉ : la sortie de `filterSectionsByRole(NAV_SECTIONS, role)` doit
+ * reproduire EXACTEMENT (libellés, routes, ordre) le `menuSections` codé en dur dans
+ * `src/components/layout/Sidebar.vue` (138-344) pour chaque rôle. Les attendus ci-dessous
+ * sont recopiés à la main depuis ce source — toute divergence est un bug de la config.
+ *
+ * Couvre : admin, teacher, student, coordinateur (DoD), plus supradmin, alias backend,
+ * fail-secure, immuabilité de la source, et filtrage récursif des `children`.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+// useNavigation importe `auth` depuis @/services/api (axios + store) ; on le remplace
+// par un faux léger — le composable est testé via `user` injecté, jamais via getUser.
+vi.mock('@/services/api', () => ({ auth: { getUser: () => null } }))
+
+import { NAV_SECTIONS } from '@/constants/navigation'
+import { filterSectionsByRole, useNavigation } from '@/composables/useNavigation'
+
+/** Réduit une liste d'items à ses couples [label, to] dans l'ordre — pour comparaison. */
+const shape = (sections) => sections.map((s) => [s.label, s.to])
+
+// Attendus recopiés du Sidebar source, dans l'ordre d'empilement, par rôle.
+const EXPECTED = {
+  etudiant: [
+    ['Dashboard', '/student/dashboard'],
+    ['Mes Cours', '/student/courses'],
+    ['Emploi du Temps', '/student/schedule'],
+    ['Évaluations', '/student/evaluations-list'],
+    ['Mes Notes', '/student/grades'],
+    ['Forum', '/forum'],
+    ['Paramètres', '/student/settings'],
+  ],
+  enseignant: [
+    ['Dashboard', '/teacher/dashboard'],
+    ['Emploi du Temps', '/teacher/schedule'],
+    ['Mon Espace', '/teacher/hub'],
+    ['Évaluations', '/teacher/evaluations'],
+    ['Forum', '/forum'],
+    ['Historique', '/attendance/seances'],
+    ['Paramètres', '/teacher/settings'],
+  ],
+  coordinateur: [
+    ['Dashboard', '/admin/dashboard'],
+    ['Évaluations', '/coordinateur/evaluations'],
+    ['Espace Admin', '/admin/hub'],
+    ['Résultats', '/admin/evaluations/results'],
+    ['Séances & Visio', '/coordinateur/seances'],
+    ['Forum', '/forum'],
+    ['Historique', '/attendance/seances'],
+    ['Paramètres', '/admin/settings'],
+  ],
+  admin: [
+    ['Dashboard', '/admin/dashboard'],
+    ['Utilisateurs', '/admin/users'],
+    ['Classes', '/admin/classes'],
+    ['Matières', '/admin/matieres'],
+    ['Enseignants', '/admin/enseignants'],
+    ['Séances', '/admin/seances'],
+    ['Visioconférences', '/admin/visioconferences'],
+    ['Résultats Évaluations', '/admin/evaluations/results'],
+    ['Statistiques', '/admin/stats'],
+    ['Forum', '/forum'],
+    ['Historique', '/attendance/seances'],
+    ['Paramètres', '/admin/settings'],
+  ],
+  supradmin: [
+    ['Institutions', '/admin/institutions'],
+  ],
+}
+
+describe('NAV_SECTIONS — filtrage par rôle reproduit le Sidebar source', () => {
+  for (const [role, expected] of Object.entries(EXPECTED)) {
+    it(`rôle ${role} : libellés, routes et ordre identiques`, () => {
+      const got = filterSectionsByRole(NAV_SECTIONS, { role })
+      expect(shape(got)).toEqual(expected)
+    })
+  }
+
+  it('chaque item conservé porte une icône non vide (parité Sidebar)', () => {
+    const got = filterSectionsByRole(NAV_SECTIONS, { role: 'admin' })
+    expect(got.every((s) => typeof s.icon === 'string' && s.icon.length > 0)).toBe(true)
+  })
+})
+
+describe('Réutilisation de la couche rôles (alias backend, fail-secure)', () => {
+  it('accepte les alias backend (teacher → enseignant, superAdmin → supradmin)', () => {
+    expect(shape(filterSectionsByRole(NAV_SECTIONS, 'teacher'))).toEqual(EXPECTED.enseignant)
+    expect(shape(filterSectionsByRole(NAV_SECTIONS, 'superAdmin'))).toEqual(EXPECTED.supradmin)
+  })
+
+  it('mappe secretaire → coordinateur (divergence tracée #18-FE-1)', () => {
+    expect(shape(filterSectionsByRole(NAV_SECTIONS, 'secretaire'))).toEqual(EXPECTED.coordinateur)
+  })
+
+  it('rôle inconnu / null / absent → aucune section (fail-secure)', () => {
+    expect(filterSectionsByRole(NAV_SECTIONS, 'pirate')).toEqual([])
+    expect(filterSectionsByRole(NAV_SECTIONS, null)).toEqual([])
+    expect(filterSectionsByRole(NAV_SECTIONS, {})).toEqual([])
+  })
+})
+
+describe('Immuabilité et isolation', () => {
+  it('NAV_SECTIONS est gelé', () => {
+    expect(Object.isFrozen(NAV_SECTIONS)).toBe(true)
+  })
+
+  it('retourne de nouveaux objets (pas de fuite de référence sur la source)', () => {
+    const got = filterSectionsByRole(NAV_SECTIONS, { role: 'etudiant' })
+    expect(got[0]).not.toBe(NAV_SECTIONS[0])
+    got[0].label = 'MUTÉ'
+    expect(NAV_SECTIONS[0].label).toBe('Dashboard')
+  })
+
+  it('entrée non-tableau → []', () => {
+    expect(filterSectionsByRole(undefined, 'admin')).toEqual([])
+    expect(filterSectionsByRole(null, 'admin')).toEqual([])
+  })
+})
+
+describe('Filtrage récursif des children (évolutions #N2/#N3)', () => {
+  const FIXTURE = [
+    {
+      label: 'Groupe', icon: 'fa-folder', roles: ['admin', 'enseignant'],
+      children: [
+        { label: 'Réservé admin', to: '/x', icon: 'fa-a', roles: ['admin'] },
+        { label: 'Réservé prof', to: '/y', icon: 'fa-b', roles: ['enseignant'] },
+      ],
+    },
+    {
+      label: 'Groupe vide pour étudiant', icon: 'fa-folder', roles: ['admin', 'etudiant'],
+      children: [{ label: 'admin only', to: '/z', icon: 'fa-c', roles: ['admin'] }],
+    },
+  ]
+
+  it('ne conserve que les enfants autorisés', () => {
+    const got = filterSectionsByRole(FIXTURE, 'enseignant')
+    expect(got).toHaveLength(1)
+    expect(shape(got[0].children)).toEqual([['Réservé prof', '/y']])
+  })
+
+  it('masque un groupe dont tous les enfants sont filtrés', () => {
+    const got = filterSectionsByRole(FIXTURE, { role: 'etudiant' })
+    // 'Groupe vide pour étudiant' visible par rôle mais sans enfant autorisé → retiré.
+    expect(got).toEqual([])
+  })
+})
+
+describe('useNavigation — enveloppe réactive', () => {
+  it('expose un computed de sections filtrées pour un user injecté', () => {
+    const { sections } = useNavigation({ user: { role: 'admin' } })
+    expect(shape(sections.value)).toEqual(EXPECTED.admin)
+  })
+
+  it('accepte une config injectée (substituabilité / DIP)', () => {
+    const { sections } = useNavigation({
+      user: 'enseignant',
+      sections: [{ label: 'X', to: '/x', icon: 'fa-x', roles: ['enseignant'] }],
+    })
+    expect(shape(sections.value)).toEqual([['X', '/x']])
+  })
+
+  it('user null injecté → aucune section', () => {
+    const { sections } = useNavigation({ user: null })
+    expect(sections.value).toEqual([])
+  })
+})


### PR DESCRIPTION
…n (#104)

Source UNIQUE du menu, extraite à l'identique du menuSections codé en dur dans Sidebar.vue (138-344), pour supprimer la duplication Sidebar/BottomNav (#25) et préparer Sidebar < 300 lignes (#28). Fondation débloquant #N2/#N3.

- src/constants/navigation.js : NAV_SECTIONS gelé, données pures. Chaque item porte ses rôles CANONIQUES pré-résolus depuis les drapeaux du source (isStudentRole/isTeacherRole/isAdminScope/isCoordinateur + négations) ; les `to` conditionnels (Dashboard, Paramètres) sont éclatés en entrées disjointes. L'ordre reproduit, par rôle, l'ordre d'empilement d'origine.
- src/composables/useNavigation.js : filterSectionsByRole() pure (réutilise hasRole de @/constants/roles — aucune logique de rôle réimplémentée, filtrage récursif des children) + useNavigation() réactif (user/sections injectables).
- tests/unit/NavConfig.test.js : parité exacte admin/teacher/student/coordinateur
  + supradmin, alias backend, fail-secure, immuabilité, children. 17 tests verts.