### PR TITLE
refactor(calendar): finir la décomposition d'UniversalCalendar (<300 lignes) (#107)

### DIFF
--- a/src/components/calendar/CalendarFilters.vue
+++ b/src/components/calendar/CalendarFilters.vue
@@ -107,6 +107,7 @@ defineEmits(['reset', 'apply-preset'])
 <style lang="scss" scoped>
 // Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé ;
 // les couleurs « système » passent par les CSS custom properties globales var(--…)).
+// NB : la carte de base `.card` est fournie par le parent via :deep() (#107), pas dupliquée ici.
 $lms-blue: #2563eb;
 $lms-blue-light: #3b82f6;
 $lms-blue-dark: #1e3a8a;
@@ -116,21 +117,9 @@ $text-secondary: #64748B;
 $text-tertiary: #6B7280;
 $gray-light: #F8FAFC;
 $gray-border: #E5E7EB;
-$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
 $transition-fast: all 0.2s ease;
 $border-radius-md: 6px;
-$border-radius-lg: 8px;
 $border-radius-full: 9999px;
-
-.card {
-  background: var(--card-bg, $white);
-  border: 1px solid var(--card-border, transparent);
-  border-radius: $border-radius-lg;
-  box-shadow: var(--card-shadow, $shadow-light);
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
 
 .filters-card {
   .filters-header {
@@ -244,6 +233,86 @@ $border-radius-full: 9999px;
       .material-icons {
         color: $white;
         font-size: 1.25rem;
+      }
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .filters-content {
+    grid-template-columns: 1fr !important;
+
+    .filter-count {
+      justify-self: stretch;
+      justify-content: center;
+    }
+  }
+}
+</style>
+
+<!-- Mode sombre : non-scoped pour cibler html[data-theme="dark"] (rapatrié du parent, #107) -->
+<style lang="scss">
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+html[data-theme="dark"] {
+  .filters-card {
+    .filters-title {
+      .material-icons {
+        color: $lms-blue-light;
+      }
+
+      h3 {
+        color: $white;
+      }
+    }
+
+    .reset-button {
+      color: rgba($white, 0.7);
+
+      &:hover {
+        background: rgba($lms-blue-light, 0.3);
+        color: $lms-blue-light;
+      }
+    }
+
+    .filter-field {
+      label {
+        color: rgba($white, 0.8);
+
+        .icon-label {
+          color: $lms-blue-light;
+        }
+      }
+
+      select {
+        background: var(--input-bg);
+        border-color: var(--input-border);
+        color: var(--input-text);
+
+        &:hover {
+          border-color: $lms-blue-light;
+        }
+
+        &:focus {
+          border-color: $lms-blue-light;
+          box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.2);
+        }
+
+        option {
+          background: var(--bg-primary);
+          color: var(--text-primary);
+        }
+      }
+    }
+
+    .filter-count {
+      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
+      color: $white;
+
+      .material-icons {
+        color: $white;
       }
     }
   }

--- a/src/components/calendar/CalendarGrid.vue
+++ b/src/components/calendar/CalendarGrid.vue
@@ -1,0 +1,475 @@
+<template>
+  <div class="calendar-card card">
+    <ContentLoader v-if="loading" text="Chargement du calendrier..." />
+
+    <div v-else class="calendar-wrapper">
+      <FullCalendar ref="calendarRef" :options="calendarOptions" />
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Grille du calendrier unifié (#107 — décomposition UniversalCalendar).
+ *
+ * Ce sous-composant encapsule entièrement FullCalendar : plugins, locale, options de
+ * rendu (mois/semaine/jour), et la synchronisation impérative des événements via l'API.
+ * Le parent reste maître de l'état (vue courante, date affichée, événement sélectionné)
+ * et pilote la grille par des méthodes exposées (prev/next/today/changeView) ; la grille
+ * remonte ses changements internes via les évènements `event-click`, `dates-set` et
+ * `view-changed` (ex. un clic sur une date en vue mois bascule en vue jour).
+ */
+import { ref, computed, watch } from 'vue'
+import FullCalendar from '@fullcalendar/vue3'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import frLocale from '@fullcalendar/core/locales/fr'
+import ContentLoader from '@/components/common/ContentLoader.vue'
+
+const props = defineProps({
+  events: { type: Array, default: () => [] },
+  loading: { type: Boolean, default: false },
+  initialView: { type: String, default: 'dayGridMonth' }
+})
+
+const emit = defineEmits(['event-click', 'dates-set', 'view-changed'])
+
+const calendarRef = ref(null)
+
+function getApi() {
+  return calendarRef.value?.getApi() ?? null
+}
+
+const calendarOptions = computed(() => ({
+  plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+  initialView: props.initialView,
+  initialDate: new Date(), // Forcer le calendrier à afficher le mois actuel
+  locale: frLocale,
+  headerToolbar: {
+    left: 'prev,next today',
+    center: 'title',
+    right: ''
+  },
+  buttonText: {
+    today: "Aujourd'hui",
+    month: 'Mois',
+    week: 'Semaine',
+    day: 'Jour'
+  },
+  events: props.events,
+  eventClick: (info) => emit('event-click', info.event),
+  dateClick: handleDateClick,
+  datesSet: (dateInfo) => {
+    // Utiliser le milieu de la plage visible pour déterminer le mois affiché
+    // (dateInfo.start peut être un jour du mois précédent en vue mensuelle)
+    const mid = new Date((dateInfo.start.getTime() + dateInfo.end.getTime()) / 2)
+    emit('dates-set', mid)
+  },
+  nowIndicator: true,
+  slotMinTime: '07:00:00',
+  slotMaxTime: '20:00:00',
+  allDaySlot: false,
+  height: 'auto',
+  eventTimeFormat: {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  },
+  slotLabelFormat: {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  },
+  eventClassNames: (arg) => {
+    const classNames = ['event-item']
+    if (arg.event.extendedProps.eventType) {
+      classNames.push(`event-${arg.event.extendedProps.eventType}`)
+    }
+    if (arg.event.extendedProps.isUrgent) {
+      classNames.push('event-urgent')
+    }
+    return classNames
+  }
+}))
+
+function handleDateClick(info) {
+  // Clic sur une date en vue mois → basculer en vue jour
+  const api = getApi()
+  if (api && api.view.type === 'dayGridMonth') {
+    api.changeView('timeGridDay', info.dateStr)
+    emit('view-changed', 'timeGridDay')
+  }
+}
+
+// Synchronisation impérative : FullCalendar ne réagit pas toujours au remplacement
+// du tableau d'événements, on force donc le rafraîchissement via l'API.
+watch(
+  () => props.events,
+  (newEvents) => {
+    const api = getApi()
+    if (api) {
+      api.removeAllEvents()
+      newEvents.forEach((event) => api.addEvent(event))
+    }
+  },
+  { deep: true, immediate: true }
+)
+
+// API impérative pour le parent (la navigation pilote FullCalendar sans y accéder).
+function prev() {
+  getApi()?.prev()
+}
+function next() {
+  getApi()?.next()
+}
+function today() {
+  getApi()?.today()
+}
+function changeView(view) {
+  getApi()?.changeView(view)
+}
+
+defineExpose({ prev, next, today, changeView, getApi })
+</script>
+
+<style lang="scss" scoped>
+// Sous-ensemble local des variables LMS (couleurs « système » via var(--…) globales).
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+$text-primary: #1E293B;
+$text-secondary: #64748B;
+$text-tertiary: #6B7280;
+$gray-border: #E5E7EB;
+$transition-fast: all 0.2s ease;
+$shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+.calendar-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.calendar-wrapper {
+  padding: 1rem;
+}
+
+.loading-container {
+  padding: 4rem;
+  text-align: center;
+  color: var(--text-tertiary, $text-tertiary);
+
+  .material-icons {
+    font-size: 3rem;
+    color: $lms-blue;
+    margin-bottom: 1rem;
+
+    &.spin {
+      animation: spin 1s linear infinite;
+    }
+  }
+
+  p {
+    font-size: 1rem;
+    color: var(--text-secondary, $text-secondary);
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+// ========== FULLCALENDAR (CHROME PROPRE À LA GRILLE) ==========
+:deep(.fc) {
+  font-family: inherit;
+
+  .fc-toolbar-title {
+    display: none;
+  }
+
+  .fc-header-toolbar {
+    margin-bottom: 1rem;
+  }
+
+  .fc-button-primary {
+    background: $lms-blue;
+    border-color: $lms-blue;
+    transition: $transition-fast;
+
+    &:hover:not(:disabled) {
+      background: $lms-blue-light;
+      border-color: $lms-blue-light;
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 3px rgba($lms-blue, 0.2);
+    }
+  }
+
+  // En-tête des jours (lun, mar, mer, etc.) - Couleur sidebar
+  .fc-col-header-cell {
+    background: linear-gradient(180deg, #0052cc 0%, #0747a6 100%);
+    border-color: #0747a6;
+
+    .fc-col-header-cell-cushion {
+      color: $white;
+      font-weight: 600;
+      padding: 0.75rem 0.5rem;
+    }
+  }
+
+  // Cases des jours
+  .fc-daygrid-day,
+  .fc-timegrid-slot {
+    background: var(--bg-secondary, $white);
+    border-color: var(--border-primary, $gray-border);
+  }
+
+  // Numéros des jours
+  .fc-daygrid-day-number,
+  .fc-timegrid-slot-label {
+    color: var(--text-primary, $text-primary);
+    padding: 0.5rem;
+  }
+
+  // Jour actuel (aujourd'hui)
+  .fc-daygrid-day.fc-day-today {
+    background: linear-gradient(135deg, rgba($lms-blue, 0.15) 0%, rgba($lms-blue, 0.08) 100%);
+    border: 2px solid $lms-blue;
+
+    .fc-daygrid-day-number {
+      color: $lms-blue;
+      font-weight: 700;
+    }
+  }
+
+  // Ligne de l'heure actuelle (time grid)
+  .fc-timegrid-now-indicator-line {
+    border-color: $lms-blue;
+    border-width: 2px;
+  }
+
+  .fc-timegrid-now-indicator-arrow {
+    border-color: $lms-blue;
+  }
+
+  .fc-timegrid-slot {
+    height: 3rem;
+  }
+
+  // Couleurs des événements
+  .event-seance {
+    background: #2563eb; /* LMS blue (séances) */;
+    border-color: #2563eb; /* LMS blue */
+  }
+
+  .event-evaluation {
+    background: #06b6d4; /* Cyan (évaluations) */;
+    border-color: #06b6d4; /* Cyan */
+  }
+
+  .event-urgent {
+    background: #ef4444 !important;
+    border-color: #ef4444 !important;
+    animation: pulse 2s infinite;
+  }
+
+  // Événements en mode clair
+  .fc-event {
+    cursor: pointer;
+    transition: $transition-fast;
+
+    &:hover {
+      opacity: 0.9;
+      transform: translateY(-1px);
+      box-shadow: $shadow-hover;
+    }
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+</style>
+
+<!-- Mode sombre : non-scoped pour cibler html[data-theme="dark"] (#107) -->
+<style lang="scss">
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+html[data-theme="dark"] {
+  // Conteneur de chargement de la grille en mode sombre
+  .loading-container {
+    color: rgba($white, 0.7);
+
+    .material-icons {
+      color: $lms-blue-light;
+    }
+
+    p {
+      color: rgba($white, 0.7);
+    }
+  }
+
+  // FullCalendar en mode sombre
+  .fc {
+    color: $white;
+
+    .fc-button-primary {
+      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
+      border-color: $lms-blue-light;
+      color: $white;
+
+      &:hover:not(:disabled) {
+        background: $lms-blue;
+        border-color: $lms-blue;
+      }
+
+      &:focus {
+        box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.3);
+      }
+    }
+
+    .fc-col-header-cell {
+      background: linear-gradient(180deg, #0a1929 0%, #001e3c 100%) !important;
+      border-color: #001e3c !important;
+
+      .fc-col-header-cell-cushion {
+        color: $white !important;
+        font-weight: 600;
+      }
+    }
+
+    .fc-daygrid-day,
+    .fc-timegrid-slot {
+      background: var(--bg-secondary) !important;
+      border-color: var(--border-primary) !important;
+    }
+
+    .fc-daygrid-day-number,
+    .fc-timegrid-slot-label {
+      color: var(--text-primary) !important;
+    }
+
+    .fc-daygrid-day.fc-day-today {
+      background: linear-gradient(135deg, rgba($lms-blue-light, 0.3) 0%, rgba($lms-blue-light, 0.15) 100%) !important;
+      border: 2px solid $lms-blue-light !important;
+
+      .fc-daygrid-day-number {
+        color: $lms-blue-light !important;
+        font-weight: 700;
+      }
+    }
+
+    .fc-daygrid-day.fc-day-other {
+      background: var(--bg-tertiary) !important;
+      opacity: 0.6;
+
+      .fc-daygrid-day-number {
+        color: var(--text-tertiary) !important;
+      }
+    }
+
+    .fc-timegrid-now-indicator-line {
+      border-color: $lms-blue-light;
+    }
+
+    .fc-timegrid-now-indicator-arrow {
+      border-color: $lms-blue-light;
+    }
+
+    // Événements en mode sombre
+    .fc-event {
+      border-width: 2px;
+      font-weight: 500;
+    }
+
+    .event-seance {
+      background: rgba($lms-blue, 0.9);
+      border-color: $lms-blue;
+      color: $white;
+
+      &:hover {
+        background: $lms-blue;
+        box-shadow: 0 2px 8px rgba($lms-blue, 0.5);
+      }
+    }
+
+    .event-evaluation {
+      background: rgba(#06b6d4, 0.9);
+      border-color: #06b6d4;
+      color: $white;
+      font-weight: 600;
+
+      &:hover {
+        background: #06b6d4;
+        box-shadow: 0 2px 8px rgba(#06b6d4, 0.5);
+      }
+    }
+
+    .event-urgent {
+      background: #ef4444 !important;
+      border-color: #ef4444 !important;
+      color: $white !important;
+      animation: pulse-urgent-dark 2s infinite;
+
+      &:hover {
+        box-shadow: 0 2px 8px rgba(#ef4444, 0.5);
+      }
+    }
+
+    // Grille horaire en mode sombre
+    .fc-scrollgrid {
+      border-color: var(--border-primary) !important;
+    }
+
+    .fc-scrollgrid-section > * {
+      border-color: var(--border-primary) !important;
+    }
+
+    // Conteneurs FullCalendar en mode sombre
+    .fc-view-harness,
+    .fc-scrollgrid-sync-table,
+    .fc-timegrid-body,
+    .fc-timegrid-slots,
+    .fc-daygrid-body {
+      background: var(--bg-secondary) !important;
+    }
+
+    // Cellules de la grille temporelle
+    .fc-timegrid-slot-lane {
+      background: var(--bg-secondary) !important;
+      border-color: var(--border-primary) !important;
+    }
+
+    // Zone vide du calendrier
+    .fc-daygrid-day-frame,
+    .fc-daygrid-day-bg {
+      background: transparent !important;
+    }
+
+    // Table et corps du calendrier
+    table, tbody, tr, td, th {
+      border-color: var(--border-primary) !important;
+    }
+  }
+
+  @keyframes pulse-urgent-dark {
+    0%, 100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.85;
+      transform: scale(1.02);
+    }
+  }
+}
+</style>

--- a/src/components/calendar/CalendarLegend.vue
+++ b/src/components/calendar/CalendarLegend.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="legend-card card">
+    <h3>
+      <i class="material-icons">info</i>
+      Légende
+    </h3>
+    <div class="legend-items">
+      <div class="legend-item">
+        <div class="color-dot" style="background: #2563eb; /* LMS blue (séances) */"></div>
+        <span>Séances</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot" style="background: #10b981"></div>
+        <span>Visio active</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot" style="background: #ea580c; /* LMS orange (évaluations) */"></div>
+        <span>Évaluations</span>
+      </div>
+      <div class="legend-item">
+        <div class="color-dot" style="background: #ef4444"></div>
+        <span>Urgent (&lt; 24h)</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Légende des couleurs du calendrier unifié (#107 — décomposition UniversalCalendar).
+ * Sous-composant purement présentationnel : aucune prop, aucun état, aucun émetteur.
+ */
+</script>
+
+<style lang="scss" scoped>
+// Sous-ensemble local des variables LMS (couleurs « système » via var(--…) globales).
+$lms-blue: #2563eb;
+$gray-lightest: #F9FAFB;
+$gray-border: #E5E7EB;
+$gray-dark: #374151;
+$border-radius-lg: 8px;
+
+.legend-card {
+  h3 {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: $lms-blue;
+
+    .material-icons {
+      color: $lms-blue;
+      font-size: 1.5rem;
+    }
+  }
+
+  .legend-items {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    background: var(--bg-tertiary, $gray-lightest);
+    border-radius: $border-radius-lg;
+    border: 1px solid var(--border-primary, $gray-border);
+
+    .color-dot {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+    }
+
+    span {
+      font-size: 0.875rem;
+      color: var(--text-primary, $gray-dark);
+      font-weight: 500;
+    }
+  }
+}
+</style>
+
+<!-- Mode sombre : non-scoped pour cibler html[data-theme="dark"] (#107) -->
+<style lang="scss">
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+html[data-theme="dark"] {
+  .legend-card {
+    h3 {
+      color: $white;
+
+      .material-icons {
+        color: $lms-blue-light;
+      }
+    }
+
+    .legend-item {
+      background: var(--bg-tertiary);
+      border-color: var(--border-primary);
+
+      span {
+        color: var(--text-primary);
+      }
+    }
+  }
+}
+</style>

--- a/src/components/calendar/CalendarNavigation.vue
+++ b/src/components/calendar/CalendarNavigation.vue
@@ -1,0 +1,344 @@
+<template>
+  <div class="navigation-card card">
+    <div class="navigation-controls">
+      <button class="nav-button" @click="$emit('prev')" title="Mois précédent">
+        <i class="material-icons">chevron_left</i>
+      </button>
+
+      <div class="current-month">
+        <i class="material-icons">calendar_today</i>
+        <span>{{ currentMonthLabel }}</span>
+      </div>
+
+      <button class="nav-button" @click="$emit('next')" title="Mois suivant">
+        <i class="material-icons">chevron_right</i>
+      </button>
+
+      <button class="today-button" @click="$emit('today')" title="Revenir à aujourd'hui">
+        <i class="material-icons">today</i>
+        Aujourd'hui
+      </button>
+
+      <button
+        class="refresh-button"
+        :disabled="refreshing"
+        title="Actualiser les donnees depuis KLASSCI"
+        @click="$emit('refresh')"
+      >
+        <i class="material-icons" :class="{ 'spin': refreshing }">sync</i>
+        {{ refreshing ? 'Chargement...' : 'Actualiser' }}
+      </button>
+
+      <div class="view-selector">
+        <button
+          :class="{ active: currentView === 'dayGridMonth' }"
+          title="Vue mensuelle"
+          @click="$emit('change-view', 'dayGridMonth')"
+        >
+          <i class="material-icons">view_module</i>
+          Mois
+        </button>
+        <button
+          :class="{ active: currentView === 'timeGridWeek' }"
+          title="Vue hebdomadaire"
+          @click="$emit('change-view', 'timeGridWeek')"
+        >
+          <i class="material-icons">view_week</i>
+          Semaine
+        </button>
+        <button
+          :class="{ active: currentView === 'timeGridDay' }"
+          title="Vue journalière"
+          @click="$emit('change-view', 'timeGridDay')"
+        >
+          <i class="material-icons">view_day</i>
+          Jour
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+/**
+ * Barre de navigation du calendrier unifié (#107 — décomposition UniversalCalendar).
+ * Sous-composant de présentation : le libellé du mois, la vue active et l'état de
+ * rafraîchissement sont des props ; toutes les actions (précédent/suivant/aujourd'hui/
+ * actualiser/changement de vue) sont émises. Aucun accès direct à FullCalendar ici.
+ */
+defineProps({
+  currentMonthLabel: { type: String, default: '' },
+  currentView: { type: String, default: 'dayGridMonth' },
+  refreshing: { type: Boolean, default: false }
+})
+
+defineEmits(['prev', 'next', 'today', 'refresh', 'change-view'])
+</script>
+
+<style lang="scss" scoped>
+// Variables LMS utilisées par ce sous-composant (sous-ensemble local ; les couleurs
+// « système » passent par les CSS custom properties globales var(--…)).
+$lms-blue: #2563eb;
+$lms-blue-dark: #1e3a8a;
+$white: #ffffff;
+$text-primary: #1E293B;
+$text-tertiary: #6B7280;
+$gray-lightest: #F9FAFB;
+$gray-light: #F8FAFC;
+$gray-medium: #E2E8F0;
+$gray-border: #E5E7EB;
+$gray-dark: #374151;
+$transition-fast: all 0.2s ease;
+$border-radius-md: 6px;
+$border-radius-lg: 8px;
+
+.navigation-card {
+  padding: 1rem 1.5rem;
+
+  .navigation-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    .nav-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border: 1px solid var(--border-primary, $gray-border);
+      border-radius: $border-radius-md;
+      background: transparent;
+      color: var(--text-primary, $text-primary);
+      cursor: pointer;
+      transition: $transition-fast;
+
+      .material-icons {
+        font-size: 1.5rem;
+        color: var(--text-primary, $text-primary);
+      }
+
+      &:hover {
+        background: var(--bg-hover, $gray-light);
+        border-color: $lms-blue;
+        color: $lms-blue;
+
+        .material-icons {
+          color: $lms-blue;
+        }
+      }
+    }
+
+    .current-month {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      font-size: 1.5rem;
+      font-weight: 600;
+      color: $lms-blue;
+      text-transform: capitalize;
+
+      .material-icons {
+        color: $lms-blue;
+      }
+    }
+
+    .today-button {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: 1px solid $lms-blue;
+      color: $lms-blue;
+      padding: 0.5rem 1rem;
+      border-radius: $border-radius-md;
+      background: transparent;
+      transition: $transition-fast;
+      font-weight: 500;
+      cursor: pointer;
+
+      &:hover {
+        background: $lms-blue;
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+    }
+
+    .refresh-button {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: 1px solid #10b981;
+      color: #10b981;
+      padding: 0.5rem 1rem;
+      border-radius: $border-radius-md;
+      background: transparent;
+      transition: $transition-fast;
+      font-weight: 500;
+      cursor: pointer;
+
+      &:hover:not(:disabled) {
+        background: #10b981;
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+
+      .material-icons.spin {
+        animation: spin 1s linear infinite;
+      }
+    }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    .view-selector {
+      display: flex;
+      gap: 0.5rem;
+      border: 1px solid var(--border-primary, $gray-border);
+      border-radius: $border-radius-lg;
+      padding: 0.25rem;
+      background: var(--bg-tertiary, $gray-lightest);
+
+      button {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: $border-radius-md;
+        border: none;
+        transition: $transition-fast;
+        color: var(--text-tertiary, $text-tertiary);
+        font-weight: 500;
+        font-size: 0.875rem;
+        cursor: pointer;
+        background: transparent;
+
+        &:hover {
+          background: var(--bg-hover, $gray-medium);
+          color: var(--text-primary, $gray-dark);
+        }
+
+        &.active {
+          background: $lms-blue-dark;
+          color: $white;
+          font-weight: 600;
+          box-shadow: 0 2px 4px rgba($lms-blue-dark, 0.2);
+
+          .material-icons {
+            color: $white;
+          }
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .navigation-controls {
+    flex-wrap: wrap;
+
+    .current-month {
+      order: -1;
+      flex-basis: 100%;
+      margin-bottom: 1rem;
+    }
+
+    .today-button,
+    .view-selector {
+      flex-basis: 100%;
+    }
+  }
+}
+</style>
+
+<!-- Mode sombre : non-scoped pour cibler html[data-theme="dark"] (#107) -->
+<style lang="scss">
+$lms-blue: #2563eb;
+$lms-blue-light: #3b82f6;
+$white: #ffffff;
+
+html[data-theme="dark"] {
+  .navigation-card {
+    .nav-button {
+      border-color: rgba($lms-blue-light, 0.5);
+      color: $white;
+      background: transparent;
+
+      .material-icons {
+        color: $white !important;
+      }
+
+      &:hover {
+        background: rgba($lms-blue-light, 0.3);
+        border-color: $lms-blue-light;
+        color: $lms-blue-light;
+
+        .material-icons {
+          color: $lms-blue-light !important;
+        }
+      }
+    }
+
+    .current-month {
+      color: $white;
+
+      .material-icons {
+        color: $lms-blue-light;
+      }
+    }
+
+    .today-button {
+      border-color: $lms-blue-light;
+      color: $white;
+      background: rgba($lms-blue-light, 0.2);
+
+      &:hover {
+        background: $lms-blue-light;
+        color: $white;
+
+        .material-icons {
+          color: $white;
+        }
+      }
+    }
+
+    .view-selector {
+      background: var(--bg-tertiary);
+      border-color: var(--border-primary);
+
+      button {
+        color: rgba($white, 0.7);
+
+        &:hover {
+          background: rgba($lms-blue-light, 0.3);
+          color: $white;
+        }
+
+        &.active {
+          background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
+          color: $white;
+
+          .material-icons {
+            color: $white;
+          }
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/calendar/UniversalCalendar.vue
+++ b/src/components/calendar/UniversalCalendar.vue
@@ -1,61 +1,18 @@
 <template>
   <div class="calendar-container">
-    <!-- ========== NAVIGATION CARD ========== -->
-    <div class="navigation-card card">
-      <div class="navigation-controls">
-        <button class="nav-button" @click="previousMonth()" title="Mois précédent">
-          <i class="material-icons">chevron_left</i>
-        </button>
+    <!-- Navigation (mois / vue / actualiser) -->
+    <CalendarNavigation
+      :current-month-label="currentMonthLabel"
+      :current-view="currentView"
+      :refreshing="refreshing"
+      @prev="grid?.prev()"
+      @next="grid?.next()"
+      @today="grid?.today()"
+      @refresh="refreshData"
+      @change-view="onChangeView"
+    />
 
-        <div class="current-month">
-          <i class="material-icons">calendar_today</i>
-          <span>{{ currentMonthLabel }}</span>
-        </div>
-
-        <button class="nav-button" @click="nextMonth()" title="Mois suivant">
-          <i class="material-icons">chevron_right</i>
-        </button>
-
-        <button class="today-button" @click="goToToday()" title="Revenir à aujourd'hui">
-          <i class="material-icons">today</i>
-          Aujourd'hui
-        </button>
-
-        <button class="refresh-button" @click="refreshData()" :disabled="refreshing" title="Actualiser les donnees depuis KLASSCI">
-          <i class="material-icons" :class="{ 'spin': refreshing }">sync</i>
-          {{ refreshing ? 'Chargement...' : 'Actualiser' }}
-        </button>
-
-        <div class="view-selector">
-          <button
-            :class="{ active: currentView === 'dayGridMonth' }"
-            @click="changeView('dayGridMonth')"
-            title="Vue mensuelle"
-          >
-            <i class="material-icons">view_module</i>
-            Mois
-          </button>
-          <button
-            :class="{ active: currentView === 'timeGridWeek' }"
-            @click="changeView('timeGridWeek')"
-            title="Vue hebdomadaire"
-          >
-            <i class="material-icons">view_week</i>
-            Semaine
-          </button>
-          <button
-            :class="{ active: currentView === 'timeGridDay' }"
-            @click="changeView('timeGridDay')"
-            title="Vue journalière"
-          >
-            <i class="material-icons">view_day</i>
-            Jour
-          </button>
-        </div>
-      </div>
-    </div>
-
-    <!-- ========== FILTERS CARD (#28bis : extraite en sous-composant) ========== -->
+    <!-- Filtres (#28bis) -->
     <CalendarFilters
       v-model:event-type-filter="eventTypeFilter"
       v-model:date-range-preset="dateRangePreset"
@@ -73,43 +30,19 @@
       @apply-preset="applyDateRangePreset"
     />
 
-    <!-- ========== CALENDAR CARD ========== -->
-    <div class="calendar-card card">
-      <ContentLoader v-if="loading" text="Chargement du calendrier..." />
+    <!-- Grille FullCalendar (#107) -->
+    <CalendarGrid
+      ref="grid"
+      :events="filteredEvents"
+      :loading="loading"
+      :initial-view="currentView"
+      @event-click="selectedEvent = $event"
+      @dates-set="currentDate = $event"
+      @view-changed="currentView = $event"
+    />
 
-      <div v-else class="calendar-wrapper">
-        <FullCalendar
-          ref="calendarRef"
-          :options="calendarOptions"
-        />
-      </div>
-    </div>
-
-    <!-- ========== LEGEND CARD ========== -->
-    <div class="legend-card card">
-      <h3>
-        <i class="material-icons">info</i>
-        Légende
-      </h3>
-      <div class="legend-items">
-        <div class="legend-item">
-          <div class="color-dot" style="background: #2563eb; /* LMS blue (séances) */"></div>
-          <span>Séances</span>
-        </div>
-        <div class="legend-item">
-          <div class="color-dot" style="background: #10b981"></div>
-          <span>Visio active</span>
-        </div>
-        <div class="legend-item">
-          <div class="color-dot" style="background: #ea580c; /* LMS orange (évaluations) */"></div>
-          <span>Évaluations</span>
-        </div>
-        <div class="legend-item">
-          <div class="color-dot" style="background: #ef4444"></div>
-          <span>Urgent (&lt; 24h)</span>
-        </div>
-      </div>
-    </div>
+    <!-- Légende (#107) -->
+    <CalendarLegend />
 
     <!-- Modal de détails -->
     <EventDetailModal
@@ -123,18 +56,25 @@
 </template>
 
 <script setup>
+/**
+ * Calendrier unifié — orchestrateur (#107 — fin de décomposition, < 300 lignes).
+ *
+ * Ce composant ne fait plus que de la composition et de l'état partagé :
+ *  - navigation (CalendarNavigation), filtres (CalendarFilters), grille (CalendarGrid),
+ *    légende (CalendarLegend) et détails (EventDetailModal) sont des sous-composants ;
+ *  - le chargement/rafraîchissement des données est délégué au composable
+ *    useCalendarEvents (#28bis) ; les fonctions pures (couleurs/urgence/bornes) vivent
+ *    dans @/utils/calendar (testées dans tests/unit/calendar.test.js).
+ *
+ * Le CSS « chrome » partagé (carte de base + conteneur + mode sombre de base) reste ici
+ * et atteint les sous-composants via :deep() / sélecteurs globaux, sans duplication.
+ */
 import { ref, computed, onMounted, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import FullCalendar from '@fullcalendar/vue3'
-import dayGridPlugin from '@fullcalendar/daygrid'
-import timeGridPlugin from '@fullcalendar/timegrid'
-import interactionPlugin from '@fullcalendar/interaction'
-import frLocale from '@fullcalendar/core/locales/fr'
 import EventDetailModal from './EventDetailModal.vue'
 import CalendarFilters from './CalendarFilters.vue'
-import ContentLoader from '@/components/common/ContentLoader.vue'
-// #28bis : données + chargement extraits dans le composable (couleurs/urgence/bornes
-// pures dans @/utils/calendar, testées dans tests/unit/calendar.test.js)
+import CalendarNavigation from './CalendarNavigation.vue'
+import CalendarGrid from './CalendarGrid.vue'
+import CalendarLegend from './CalendarLegend.vue'
 import { useCalendarEvents } from '@/composables/useCalendarEvents'
 
 const props = defineProps({
@@ -151,10 +91,9 @@ const props = defineProps({
 
 const emit = defineEmits(['event-action'])
 
-const router = useRouter()
-const calendarRef = ref(null)
+const grid = ref(null)
 const currentView = ref('dayGridMonth')
-const currentDate = ref(new Date())  // Pour forcer la réactivité du label
+const currentDate = ref(new Date()) // Pour forcer la réactivité du label
 const selectedEvent = ref(null)
 
 // Filtres
@@ -164,7 +103,7 @@ const selectedMatiere = ref('')
 const selectedClasse = ref('')
 const selectedEnseignant = ref('')
 
-// Données + chargement délégués au composable (#28bis : script < 300)
+// Données + chargement délégués au composable (#28bis)
 const { events, matieres, classes, enseignants, loading, refreshing, loadEvents, refreshData } = useCalendarEvents({
   getUserRole: () => props.userRole,
   getUserId: () => props.userId,
@@ -172,44 +111,29 @@ const { events, matieres, classes, enseignants, loading, refreshing, loadEvents,
   dateRangePreset
 })
 
-// Computed - Label mois courant
-const currentMonthLabel = computed(() => {
-  return currentDate.value.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
-})
+// Label du mois courant
+const currentMonthLabel = computed(() =>
+  currentDate.value.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' })
+)
 
 // Filtres conditionnels selon le rôle
-const showMatiereFilter = computed(() => {
-  return ['teacher', 'admin', 'coordinator'].includes(props.userRole)
-})
+const showMatiereFilter = computed(() => ['teacher', 'admin', 'coordinator'].includes(props.userRole))
+const showClasseFilter = computed(() => ['admin', 'coordinator'].includes(props.userRole))
+const showEnseignantFilter = computed(() => ['admin', 'coordinator'].includes(props.userRole))
 
-const showClasseFilter = computed(() => {
-  return ['admin', 'coordinator'].includes(props.userRole)
-})
-
-const showEnseignantFilter = computed(() => {
-  return ['admin', 'coordinator'].includes(props.userRole)
-})
-
-// Événements filtrés
+// Événements filtrés (côté client, en plus du filtrage serveur du composable)
 const filteredEvents = computed(() => {
   let filtered = events.value
 
-  // Filtre par type d'événement
   if (eventTypeFilter.value !== 'all') {
     filtered = filtered.filter(event => event.extendedProps.eventType === eventTypeFilter.value.replace(/s$/, ''))
   }
-
-  // Filtre par matière
   if (selectedMatiere.value) {
     filtered = filtered.filter(event => event.extendedProps.matiereId === parseInt(selectedMatiere.value))
   }
-
-  // Filtre par classe
   if (selectedClasse.value) {
     filtered = filtered.filter(event => event.extendedProps.classeId === parseInt(selectedClasse.value))
   }
-
-  // Filtre par enseignant
   if (selectedEnseignant.value) {
     filtered = filtered.filter(event => event.extendedProps.enseignantId === parseInt(selectedEnseignant.value))
   }
@@ -217,106 +141,13 @@ const filteredEvents = computed(() => {
   return filtered
 })
 
-// Configuration FullCalendar
-const calendarOptions = computed(() => ({
-  plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
-  initialView: currentView.value,
-  initialDate: new Date(), // Forcer le calendrier à afficher le mois actuel
-  locale: frLocale,
-  headerToolbar: {
-    left: 'prev,next today',
-    center: 'title',
-    right: ''
-  },
-  buttonText: {
-    today: "Aujourd'hui",
-    month: 'Mois',
-    week: 'Semaine',
-    day: 'Jour'
-  },
-  events: filteredEvents.value,
-  eventClick: handleEventClick,
-  dateClick: handleDateClick,
-  datesSet: (dateInfo) => {
-    // Utiliser le milieu de la plage visible pour déterminer le mois affiché
-    // (dateInfo.start peut être un jour du mois précédent en vue mensuelle)
-    const mid = new Date((dateInfo.start.getTime() + dateInfo.end.getTime()) / 2)
-    currentDate.value = mid
-  },
-  nowIndicator: true,
-  slotMinTime: '07:00:00',
-  slotMaxTime: '20:00:00',
-  allDaySlot: false,
-  height: 'auto',
-  eventTimeFormat: {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  },
-  slotLabelFormat: {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false
-  },
-  eventClassNames: (arg) => {
-    const classes = ['event-item']
-    if (arg.event.extendedProps.eventType) {
-      classes.push(`event-${arg.event.extendedProps.eventType}`)
-    }
-    if (arg.event.extendedProps.isUrgent) {
-      classes.push('event-urgent')
-    }
-    return classes
-  }
-}))
+function onChangeView(view) {
+  currentView.value = view
+  grid.value?.changeView(view)
+}
 
-// Charger les données
 function applyDateRangePreset() {
   loadEvents()
-}
-
-function changeView(view) {
-  currentView.value = view
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.changeView(view)
-  }
-}
-
-function previousMonth() {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.prev()
-  }
-}
-
-function nextMonth() {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.next()
-  }
-}
-
-function goToToday() {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    calendarApi.today()
-  }
-}
-
-function handleEventClick(info) {
-  selectedEvent.value = info.event
-}
-
-function handleDateClick(info) {
-  // Naviguer vers la vue jour si clic sur une date en vue mois
-  if (currentView.value === 'dayGridMonth') {
-    const calendarApi = calendarRef.value?.getApi()
-    if (calendarApi) {
-      calendarApi.changeView('timeGridDay', info.dateStr)
-      currentView.value = 'timeGridDay'
-    }
-  }
 }
 
 function handleEventAction(action) {
@@ -338,68 +169,24 @@ onMounted(() => {
   loadEvents()
 })
 
-// Recharger quand les filtres changent
+// Recharger quand le type d'événement change
 watch([eventTypeFilter], () => {
   loadEvents()
 })
 
-// IMPORTANT: Forcer FullCalendar a mettre a jour quand les evenements changent
-watch(filteredEvents, (newEvents) => {
-  const calendarApi = calendarRef.value?.getApi()
-  if (calendarApi) {
-    // Supprimer tous les evenements existants
-    calendarApi.removeAllEvents()
-    // Ajouter les nouveaux evenements
-    newEvents.forEach(event => {
-      calendarApi.addEvent(event)
-    })
-  }
-}, { deep: true, immediate: true })
-
-// Exposer les methodes pour le parent (force le bypass cache KLASSCI des 2 sources)
+// Exposer le rafraîchissement au parent (bypass cache KLASSCI des 2 sources)
 async function refreshEvents() {
   await refreshData()
 }
 
-defineExpose({
-  refreshEvents
-})
+defineExpose({ refreshEvents })
 </script>
 
 <style lang="scss" scoped>
-// Couleurs LMS
-$lms-blue: #2563eb;
-$lms-blue-light: #3b82f6;
-$lms-blue-dark: #1e3a8a;
-$lms-orange: #ea580c;
-$lms-green: #10b981;
-$lms-red: #ef4444;
-
-// Couleurs système
+// Sous-ensemble local des variables LMS (couleurs « système » via var(--…) globales).
 $white: #ffffff;
-$text-primary: #1E293B;
-$text-secondary: #64748B;
-$text-tertiary: #6B7280;
-$gray-lightest: #F9FAFB;
-$gray-light: #F8FAFC;
-$gray-medium: #E2E8F0;
-$gray-border: #E5E7EB;
-$gray-dark: #374151;
-
-// Ombres
 $shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
-$shadow-medium: 0 2px 8px rgba(0, 0, 0, 0.1);
-$shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
-
-// Transitions
-$transition-fast: all 0.2s ease;
-
-// Bordures
-$border-radius-sm: 4px;
-$border-radius-md: 6px;
 $border-radius-lg: 8px;
-$border-radius-xl: 12px;
-$border-radius-full: 9999px;
 
 .calendar-container {
   padding: 2rem;
@@ -407,8 +194,9 @@ $border-radius-full: 9999px;
   margin: 0 auto;
 }
 
-// ========== CARD BASE ==========
-.card {
+// ========== CARTE DE BASE (CHROME PARTAGÉ) ==========
+// Centralisée ici et atteinte dans chaque sous-composant via :deep(), sans duplication.
+:deep(.card) {
   background: var(--card-bg, $white);
   border: 1px solid var(--card-border, transparent);
   border-radius: $border-radius-lg;
@@ -418,737 +206,25 @@ $border-radius-full: 9999px;
   transition: background 0.2s ease, border-color 0.2s ease;
 }
 
-// ========== NAVIGATION ==========
-.navigation-card {
-  padding: 1rem 1.5rem;
-
-  .navigation-controls {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-
-    .nav-button {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 40px;
-      height: 40px;
-      border: 1px solid var(--border-primary, $gray-border);
-      border-radius: $border-radius-md;
-      background: transparent;
-      color: var(--text-primary, $text-primary);
-      cursor: pointer;
-      transition: $transition-fast;
-
-      .material-icons {
-        font-size: 1.5rem;
-        color: var(--text-primary, $text-primary);
-      }
-
-      &:hover {
-        background: var(--bg-hover, $gray-light);
-        border-color: $lms-blue;
-        color: $lms-blue;
-
-        .material-icons {
-          color: $lms-blue;
-        }
-      }
-    }
-
-    .current-month {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.75rem;
-      font-size: 1.5rem;
-      font-weight: 600;
-      color: $lms-blue;
-      text-transform: capitalize;
-
-      .material-icons {
-        color: $lms-blue;
-      }
-    }
-
-    .today-button {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 1px solid $lms-blue;
-      color: $lms-blue;
-      padding: 0.5rem 1rem;
-      border-radius: $border-radius-md;
-      background: transparent;
-      transition: $transition-fast;
-      font-weight: 500;
-      cursor: pointer;
-
-      &:hover {
-        background: $lms-blue;
-        color: $white;
-
-        .material-icons {
-          color: $white;
-        }
-      }
-    }
-
-    .refresh-button {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      border: 1px solid #10b981;
-      color: #10b981;
-      padding: 0.5rem 1rem;
-      border-radius: $border-radius-md;
-      background: transparent;
-      transition: $transition-fast;
-      font-weight: 500;
-      cursor: pointer;
-
-      &:hover:not(:disabled) {
-        background: #10b981;
-        color: $white;
-
-        .material-icons {
-          color: $white;
-        }
-      }
-
-      &:disabled {
-        opacity: 0.7;
-        cursor: not-allowed;
-      }
-
-      .material-icons.spin {
-        animation: spin 1s linear infinite;
-      }
-    }
-
-    @keyframes spin {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
-    }
-
-    .view-selector {
-      display: flex;
-      gap: 0.5rem;
-      border: 1px solid var(--border-primary, $gray-border);
-      border-radius: $border-radius-lg;
-      padding: 0.25rem;
-      background: var(--bg-tertiary, $gray-lightest);
-
-      button {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.5rem 1rem;
-        border-radius: $border-radius-md;
-        border: none;
-        transition: $transition-fast;
-        color: var(--text-tertiary, $text-tertiary);
-        font-weight: 500;
-        font-size: 0.875rem;
-        cursor: pointer;
-        background: transparent;
-
-        &:hover {
-          background: var(--bg-hover, $gray-medium);
-          color: var(--text-primary, $gray-dark);
-        }
-
-        &.active {
-          background: $lms-blue-dark;
-          color: $white;
-          font-weight: 600;
-          box-shadow: 0 2px 4px rgba($lms-blue-dark, 0.2);
-
-          .material-icons {
-            color: $white;
-          }
-        }
-      }
-    }
-  }
-}
-
-// ========== CALENDAR CARD ==========
-.calendar-card {
-  padding: 0;
-  overflow: hidden;
-}
-
-.calendar-wrapper {
-  padding: 1rem;
-}
-
-.loading-container {
-  padding: 4rem;
-  text-align: center;
-  color: var(--text-tertiary, $text-tertiary);
-
-  .material-icons {
-    font-size: 3rem;
-    color: $lms-blue;
-    margin-bottom: 1rem;
-
-    &.spin {
-      animation: spin 1s linear infinite;
-    }
-  }
-
-  p {
-    font-size: 1rem;
-    color: var(--text-secondary, $text-secondary);
-  }
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-// ========== LEGEND ==========
-.legend-card {
-  h3 {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin: 0 0 1rem 0;
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: $lms-blue;
-
-    .material-icons {
-      color: $lms-blue;
-      font-size: 1.5rem;
-    }
-  }
-
-  .legend-items {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
-  }
-
-  .legend-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    background: var(--bg-tertiary, $gray-lightest);
-    border-radius: $border-radius-lg;
-    border: 1px solid var(--border-primary, $gray-border);
-
-    .color-dot {
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-    }
-
-    span {
-      font-size: 0.875rem;
-      color: var(--text-primary, $gray-dark);
-      font-weight: 500;
-    }
-  }
-}
-
-// ========== FULLCALENDAR CUSTOM STYLES ==========
-:deep(.fc) {
-  font-family: inherit;
-
-  .fc-toolbar-title {
-    display: none;
-  }
-
-  .fc-header-toolbar {
-    margin-bottom: 1rem;
-  }
-
-  .fc-button-primary {
-    background: $lms-blue;
-    border-color: $lms-blue;
-    transition: $transition-fast;
-
-    &:hover:not(:disabled) {
-      background: $lms-blue-light;
-      border-color: $lms-blue-light;
-    }
-
-    &:focus {
-      box-shadow: 0 0 0 3px rgba($lms-blue, 0.2);
-    }
-  }
-
-  // En-tête des jours (lun, mar, mer, etc.) - Couleur sidebar
-  .fc-col-header-cell {
-    background: linear-gradient(180deg, #0052cc 0%, #0747a6 100%);
-    border-color: #0747a6;
-
-    .fc-col-header-cell-cushion {
-      color: $white;
-      font-weight: 600;
-      padding: 0.75rem 0.5rem;
-    }
-  }
-
-  // Cases des jours
-  .fc-daygrid-day,
-  .fc-timegrid-slot {
-    background: var(--bg-secondary, $white);
-    border-color: var(--border-primary, $gray-border);
-  }
-
-  // Numéros des jours
-  .fc-daygrid-day-number,
-  .fc-timegrid-slot-label {
-    color: var(--text-primary, $text-primary);
-    padding: 0.5rem;
-  }
-
-  // Jour actuel (aujourd'hui)
-  .fc-daygrid-day.fc-day-today {
-    background: linear-gradient(135deg, rgba($lms-blue, 0.15) 0%, rgba($lms-blue, 0.08) 100%);
-    border: 2px solid $lms-blue;
-
-    .fc-daygrid-day-number {
-      color: $lms-blue;
-      font-weight: 700;
-    }
-  }
-
-  // Ligne de l'heure actuelle (time grid)
-  .fc-timegrid-now-indicator-line {
-    border-color: $lms-blue;
-    border-width: 2px;
-  }
-
-  .fc-timegrid-now-indicator-arrow {
-    border-color: $lms-blue;
-  }
-
-  .fc-timegrid-slot {
-    height: 3rem;
-  }
-
-  // Couleurs des événements
-  .event-seance {
-    background: #2563eb; /* LMS blue (séances) */;
-    border-color: #2563eb; /* LMS blue */
-  }
-
-  .event-evaluation {
-    background: #06b6d4; /* Cyan (évaluations) */;
-    border-color: #06b6d4; /* Cyan */
-  }
-
-  .event-urgent {
-    background: #ef4444 !important;
-    border-color: #ef4444 !important;
-    animation: pulse 2s infinite;
-  }
-
-  // Événements en mode clair
-  .fc-event {
-    cursor: pointer;
-    transition: $transition-fast;
-
-    &:hover {
-      opacity: 0.9;
-      transform: translateY(-1px);
-      box-shadow: $shadow-hover;
-    }
-  }
-}
-
-@keyframes pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.8;
-  }
-}
-
-// ========== RESPONSIVE ==========
 @media (max-width: 768px) {
   .calendar-container {
     padding: 1rem;
   }
-
-  .navigation-controls {
-    flex-wrap: wrap;
-
-    .current-month {
-      order: -1;
-      flex-basis: 100%;
-      margin-bottom: 1rem;
-    }
-
-    .today-button,
-    .view-selector {
-      flex-basis: 100%;
-    }
-  }
-
-  .filters-content {
-    grid-template-columns: 1fr !important;
-
-    .filter-count {
-      justify-self: stretch;
-      justify-content: center;
-    }
-  }
 }
 </style>
 
-<!-- Styles mode sombre non-scoped pour fonctionner avec data-theme -->
+<!-- Mode sombre de base (chrome partagé) : non-scoped pour cibler html[data-theme="dark"] -->
 <style lang="scss">
-// Couleurs LMS pour le mode sombre
-$lms-blue: #2563eb;
-$lms-blue-light: #3b82f6;
-$lms-blue-dark: #1e3a8a;
-$lms-orange: #ea580c;
-$lms-green: #10b981;
-$lms-red: #ef4444;
-$white: #ffffff;
-
-// ========== DARK MODE ==========
 html[data-theme="dark"] {
   .calendar-container {
     background: transparent;
   }
 
-  // Cards en mode sombre
+  // Cartes en mode sombre (base partagée par tous les sous-composants)
   .card {
     background: var(--card-bg) !important;
     border: 1px solid var(--card-border) !important;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
-
-  // Navigation en mode sombre
-  .navigation-card {
-    .nav-button {
-      border-color: rgba($lms-blue-light, 0.5);
-      color: $white;
-      background: transparent;
-
-      .material-icons {
-        color: $white !important;
-      }
-
-      &:hover {
-        background: rgba($lms-blue-light, 0.3);
-        border-color: $lms-blue-light;
-        color: $lms-blue-light;
-
-        .material-icons {
-          color: $lms-blue-light !important;
-        }
-      }
-    }
-
-    .current-month {
-      color: $white;
-
-      .material-icons {
-        color: $lms-blue-light;
-      }
-    }
-
-    .today-button {
-      border-color: $lms-blue-light;
-      color: $white;
-      background: rgba($lms-blue-light, 0.2);
-
-      &:hover {
-        background: $lms-blue-light;
-        color: $white;
-
-        .material-icons {
-          color: $white;
-        }
-      }
-    }
-
-    .view-selector {
-      background: var(--bg-tertiary);
-      border-color: var(--border-primary);
-
-      button {
-        color: rgba($white, 0.7);
-
-        &:hover {
-          background: rgba($lms-blue-light, 0.3);
-          color: $white;
-        }
-
-        &.active {
-          background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
-          color: $white;
-
-          .material-icons {
-            color: $white;
-          }
-        }
-      }
-    }
-  }
-
-  // Filtres en mode sombre
-  .filters-card {
-    .filters-title {
-      .material-icons {
-        color: $lms-blue-light;
-      }
-
-      h3 {
-        color: $white;
-      }
-    }
-
-    .reset-button {
-      color: rgba($white, 0.7);
-
-      &:hover {
-        background: rgba($lms-blue-light, 0.3);
-        color: $lms-blue-light;
-      }
-    }
-
-    .filter-field {
-      label {
-        color: rgba($white, 0.8);
-
-        .icon-label {
-          color: $lms-blue-light;
-        }
-      }
-
-      select {
-        background: var(--input-bg);
-        border-color: var(--input-border);
-        color: var(--input-text);
-
-        &:hover {
-          border-color: $lms-blue-light;
-        }
-
-        &:focus {
-          border-color: $lms-blue-light;
-          box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.2);
-        }
-
-        option {
-          background: var(--bg-primary);
-          color: var(--text-primary);
-        }
-      }
-    }
-
-    .filter-count {
-      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
-      color: $white;
-
-      .material-icons {
-        color: $white;
-      }
-    }
-  }
-
-  // Calendrier en mode sombre
-  .calendar-card {
-    background: var(--card-bg) !important;
-  }
-
-  .loading-container {
-    color: rgba($white, 0.7);
-
-    .material-icons {
-      color: $lms-blue-light;
-    }
-
-    p {
-      color: rgba($white, 0.7);
-    }
-  }
-
-  // Légende en mode sombre
-  .legend-card {
-    h3 {
-      color: $white;
-
-      .material-icons {
-        color: $lms-blue-light;
-      }
-    }
-
-    .legend-item {
-      background: var(--bg-tertiary);
-      border-color: var(--border-primary);
-
-      span {
-        color: var(--text-primary);
-      }
-    }
-  }
-
-  // FullCalendar en mode sombre
-  .fc {
-    color: $white;
-
-    .fc-button-primary {
-      background: linear-gradient(135deg, $lms-blue-light 0%, $lms-blue 100%);
-      border-color: $lms-blue-light;
-      color: $white;
-
-      &:hover:not(:disabled) {
-        background: $lms-blue;
-        border-color: $lms-blue;
-      }
-
-      &:focus {
-        box-shadow: 0 0 0 3px rgba($lms-blue-light, 0.3);
-      }
-    }
-
-    .fc-col-header-cell {
-      background: linear-gradient(180deg, #0a1929 0%, #001e3c 100%) !important;
-      border-color: #001e3c !important;
-
-      .fc-col-header-cell-cushion {
-        color: $white !important;
-        font-weight: 600;
-      }
-    }
-
-    .fc-daygrid-day,
-    .fc-timegrid-slot {
-      background: var(--bg-secondary) !important;
-      border-color: var(--border-primary) !important;
-    }
-
-    .fc-daygrid-day-number,
-    .fc-timegrid-slot-label {
-      color: var(--text-primary) !important;
-    }
-
-    .fc-daygrid-day.fc-day-today {
-      background: linear-gradient(135deg, rgba($lms-blue-light, 0.3) 0%, rgba($lms-blue-light, 0.15) 100%) !important;
-      border: 2px solid $lms-blue-light !important;
-
-      .fc-daygrid-day-number {
-        color: $lms-blue-light !important;
-        font-weight: 700;
-      }
-    }
-
-    .fc-daygrid-day.fc-day-other {
-      background: var(--bg-tertiary) !important;
-      opacity: 0.6;
-
-      .fc-daygrid-day-number {
-        color: var(--text-tertiary) !important;
-      }
-    }
-
-    .fc-timegrid-now-indicator-line {
-      border-color: $lms-blue-light;
-    }
-
-    .fc-timegrid-now-indicator-arrow {
-      border-color: $lms-blue-light;
-    }
-
-    // Événements en mode sombre
-    .fc-event {
-      border-width: 2px;
-      font-weight: 500;
-    }
-
-    .event-seance {
-      background: rgba($lms-blue, 0.9);
-      border-color: $lms-blue;
-      color: $white;
-
-      &:hover {
-        background: $lms-blue;
-        box-shadow: 0 2px 8px rgba($lms-blue, 0.5);
-      }
-    }
-
-    .event-evaluation {
-      background: rgba(#06b6d4, 0.9);
-      border-color: #06b6d4;
-      color: $white;
-      font-weight: 600;
-
-      &:hover {
-        background: #06b6d4;
-        box-shadow: 0 2px 8px rgba(#06b6d4, 0.5);
-      }
-    }
-
-    .event-urgent {
-      background: #ef4444 !important;
-      border-color: #ef4444 !important;
-      color: $white !important;
-      animation: pulse-urgent-dark 2s infinite;
-
-      &:hover {
-        box-shadow: 0 2px 8px rgba(#ef4444, 0.5);
-      }
-    }
-
-    // Grille horaire en mode sombre
-    .fc-scrollgrid {
-      border-color: var(--border-primary) !important;
-    }
-
-    .fc-scrollgrid-section > * {
-      border-color: var(--border-primary) !important;
-    }
-
-    // Conteneurs FullCalendar en mode sombre
-    .fc-view-harness,
-    .fc-scrollgrid-sync-table,
-    .fc-timegrid-body,
-    .fc-timegrid-slots,
-    .fc-daygrid-body {
-      background: var(--bg-secondary) !important;
-    }
-
-    // Cellules de la grille temporelle
-    .fc-timegrid-slot-lane {
-      background: var(--bg-secondary) !important;
-      border-color: var(--border-primary) !important;
-    }
-
-    // Zone vide du calendrier
-    .fc-daygrid-day-frame,
-    .fc-daygrid-day-bg {
-      background: transparent !important;
-    }
-
-    // Table et corps du calendrier
-    table, tbody, tr, td, th {
-      border-color: var(--border-primary) !important;
-    }
-  }
-
-  @keyframes pulse-urgent-dark {
-    0%, 100% {
-      opacity: 1;
-      transform: scale(1);
-    }
-    50% {
-      opacity: 0.85;
-      transform: scale(1.02);
-    }
   }
 }
 </style>


### PR DESCRIPTION
## Objectif (issue #107)
Poursuivre la décomposition entamée en #28bis jusqu'à faire passer **`UniversalCalendar.vue` sous 300 lignes**.

**Résultat : 1154 → 230 lignes** (DoD atteint).

## Ce qui change
L'orchestrateur ne fait plus que de la **composition + état partagé** (vue courante, date affichée, événement sélectionné, filtres). Le rendu est éclaté en sous-composants dans `src/components/calendar/` :

| Composant | Rôle |
|---|---|
| `CalendarNavigation.vue` | Barre de navigation (mois / vues / actualiser). Props + émetteurs, **aucun accès direct à FullCalendar**. |
| `CalendarGrid.vue` | Encapsule FullCalendar (plugins, options, sync impérative des événements). Expose `prev/next/today/changeView`, émet `event-click`/`dates-set`/`view-changed`. Porte les styles `.fc` (light + dark). |
| `CalendarLegend.vue` | Légende, purement présentationnel. |
| `CalendarFilters.vue` | Rapatrie ses styles dark restés **orphelins dans le parent** (#28bis) et retire le `.card` dupliqué. |

### Détails
- **CSS « chrome » partagé** (carte de base + conteneur + dark de base) centralisé dans le parent via `:deep()` / sélecteurs globaux, **sans duplication**.
- Délégation impérative propre : `nav → parent (currentView) → grid.changeView()`. Le clic-date en vue mois bascule en vue jour via `view-changed`.
- Suppression d'un `import useRouter` mort.
- **Contrat public inchangé** : props `userRole`/`userId`, emit `event-action`, expose `refreshEvents`. Les 3 vues consommatrices (`SeanceManagement`, `StudentSchedule`, `TeacherSchedule`) ne bougent pas.

## Vérifications
- ✅ Suite unit complète : **277/277** (dont `calendar.test.js`, `CalendarFilters.test.js`)
- ✅ `vite build` vert (warning chunk-size `LessonChapters` préexistant, hors périmètre)
- ✅ **Vérification visuelle navigateur** : mode clair + mode sombre fidèles, changement de vue (Mois/Semaine) fonctionnel, zéro erreur Vue/rendu en console

## Réserve honnête (dette tracée)
`CalendarGrid.vue` (475) et `CalendarNavigation.vue` (344) dépassent 300 lignes à cause du CSS light+dark inhérent (cohérent avec le précédent `EventDetailModal.vue` = 744). Réductible via un partiel SCSS dark partagé — non fait car la convention actuelle privilégie `:deep()` parent plutôt que les partiels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)