### PR TITLE
refactor(services): migrer les services lms*.js vers endpoints.* (#111)

### DIFF
--- a/src/services/lmsClasses.js
+++ b/src/services/lmsClasses.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { endpoints } from './endpoints'
 
 /**
  * Service LMS — domaine CLASSES (données enrichies `/lms/classes/*`).
@@ -15,7 +16,7 @@ export const lmsClassesService = {
    */
   async getClasseDetails(classeId) {
     try {
-      return await api.get(`/lms/classes/${classeId}`)
+      return await api.get(endpoints.lms.classes.details(classeId))
     } catch (error) {
       console.error('Erreur récupération classe enrichie:', error)
       throw error
@@ -29,7 +30,7 @@ export const lmsClassesService = {
    */
   async getClasseEtudiants(classeId) {
     try {
-      return await api.get(`/lms/classes/${classeId}/etudiants`)
+      return await api.get(endpoints.lms.classes.etudiants(classeId))
     } catch (error) {
       console.error('Erreur récupération étudiants classe:', error)
       throw error

--- a/src/services/lmsMatieres.js
+++ b/src/services/lmsMatieres.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { endpoints } from './endpoints'
 
 /**
  * Service LMS — domaine MATIÈRES (données enrichies `/lms/matieres/*`, `/lms/teacher/*`).
@@ -15,7 +16,7 @@ export const lmsMatieresService = {
    */
   async getMatiereDetails(matiereId) {
     try {
-      return await api.get(`/lms/matieres/${matiereId}`)
+      return await api.get(endpoints.lms.matieres.details(matiereId))
     } catch (error) {
       console.error('Erreur récupération matière enrichie:', error)
       throw error
@@ -28,7 +29,7 @@ export const lmsMatieresService = {
    */
   async getMyMatieres() {
     try {
-      return await api.get('/lms/teacher/my-matieres')
+      return await api.get(endpoints.lms.matieres.myTeacher)
     } catch (error) {
       console.error('Erreur récupération mes matières:', error)
       throw error

--- a/src/services/lmsNotifications.js
+++ b/src/services/lmsNotifications.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { endpoints } from './endpoints'
 
 /**
  * Service LMS — domaine NOTIFICATIONS de séance (`/lms/notifications/*`).
@@ -15,7 +16,7 @@ export const lmsNotificationsService = {
    */
   async getNotificationPreferences(userId) {
     try {
-      return await api.get(`/lms/notifications/preferences/${userId}`)
+      return await api.get(endpoints.lms.notifications.preferences(userId))
     } catch (error) {
       console.error('Erreur récupération préférences notifications:', error)
       throw error
@@ -29,7 +30,7 @@ export const lmsNotificationsService = {
    */
   async sendSessionReminder(data) {
     try {
-      return await api.post('/lms/notifications/send-session-reminder', data)
+      return await api.post(endpoints.lms.notifications.sendSessionReminder, data)
     } catch (error) {
       console.error('Erreur envoi rappel séance:', error)
       throw error

--- a/src/services/lmsSeances.js
+++ b/src/services/lmsSeances.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { endpoints } from './endpoints'
 
 /**
  * Service LMS — domaine SÉANCES & PRÉSENCES (`/lms/seances/*`, `/lms/attendance*`).
@@ -15,7 +16,7 @@ export const lmsSeancesService = {
    */
   async getUpcomingSeances(params = {}) {
     try {
-      return await api.get('/lms/seances/upcoming', { params })
+      return await api.get(endpoints.lms.seances.upcoming, { params })
     } catch (error) {
       console.error('Erreur récupération séances à venir:', error)
       throw error
@@ -29,7 +30,7 @@ export const lmsSeancesService = {
    */
   async getSeanceDetails(seanceId) {
     try {
-      return await api.get(`/lms/seances/${seanceId}/details`)
+      return await api.get(endpoints.lms.seances.details(seanceId))
     } catch (error) {
       console.error('Erreur récupération détails séance:', error)
       throw error
@@ -44,7 +45,7 @@ export const lmsSeancesService = {
    */
   async getSeanceParticipants(seanceId) {
     try {
-      return await api.get(`/lms/seances/${seanceId}/participants`)
+      return await api.get(endpoints.lms.seances.participants(seanceId))
     } catch (error) {
       console.error('Erreur récupération participants séance:', error)
       throw error
@@ -59,7 +60,7 @@ export const lmsSeancesService = {
    */
   async validateParticipant(seanceId, userId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/validate-participant`, {
+      return await api.post(endpoints.lms.seances.validateParticipant(seanceId), {
         user_id: userId
       })
     } catch (error) {
@@ -77,7 +78,7 @@ export const lmsSeancesService = {
    */
   async syncVideoAttendances(seanceId, date, participants) {
     try {
-      return await api.post('/lms/attendances/from-video-session', {
+      return await api.post(endpoints.lms.attendance.fromVideoSession, {
         seance_cours_id: seanceId,
         date,
         participants
@@ -96,7 +97,7 @@ export const lmsSeancesService = {
   async getMyTeachingSeances(forceRefresh = false) {
     try {
       const params = forceRefresh ? { refresh: true } : {}
-      return await api.get('/lms/seances/my-teaching', { params })
+      return await api.get(endpoints.lms.seances.myTeaching, { params })
     } catch (error) {
       console.error('Erreur récupération mes séances enseignant:', error)
       throw error
@@ -111,7 +112,7 @@ export const lmsSeancesService = {
   async getMyClassesSeances(forceRefresh = false) {
     try {
       const params = forceRefresh ? { refresh: true } : {}
-      return await api.get('/lms/seances/my-classes', { params })
+      return await api.get(endpoints.lms.seances.myClasses, { params })
     } catch (error) {
       console.error('Erreur récupération mes cours étudiant:', error)
       throw error
@@ -125,7 +126,7 @@ export const lmsSeancesService = {
    */
   async hideSeance(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/hide`)
+      return await api.post(endpoints.lms.seances.hide(seanceId))
     } catch (error) {
       console.error('Erreur masquage séance:', error)
       throw error
@@ -139,7 +140,7 @@ export const lmsSeancesService = {
    */
   async unhideSeance(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/unhide`)
+      return await api.post(endpoints.lms.seances.unhide(seanceId))
     } catch (error) {
       console.error('Erreur réaffichage séance:', error)
       throw error
@@ -153,7 +154,7 @@ export const lmsSeancesService = {
    */
   async getAttendanceHistory(params = {}) {
     try {
-      return await api.get('/lms/attendance/history', { params })
+      return await api.get(endpoints.lms.attendance.history, { params })
     } catch (error) {
       console.error('Erreur récupération historique présences:', error)
       throw error
@@ -167,7 +168,7 @@ export const lmsSeancesService = {
    */
   async getSeancesHistory(params = {}) {
     try {
-      return await api.get('/lms/seances/history', { params })
+      return await api.get(endpoints.lms.seances.history, { params })
     } catch (error) {
       console.error('Erreur récupération historique séances:', error)
       throw error
@@ -181,7 +182,7 @@ export const lmsSeancesService = {
    */
   async getSeanceAttendances(seanceId) {
     try {
-      return await api.get(`/lms/seances/${seanceId}/attendances`)
+      return await api.get(endpoints.lms.seances.attendances(seanceId))
     } catch (error) {
       console.error('Erreur récupération présences séance:', error)
       throw error
@@ -195,7 +196,7 @@ export const lmsSeancesService = {
    */
   async deleteSeance(seanceId) {
     try {
-      return await api.delete(`/lms/seances/${seanceId}`)
+      return await api.delete(endpoints.lms.seances.delete(seanceId))
     } catch (error) {
       console.error('Erreur suppression séance:', error)
       throw error

--- a/src/services/lmsTeachers.js
+++ b/src/services/lmsTeachers.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { endpoints } from './endpoints'
 
 /**
  * Service LMS — domaine ENSEIGNANTS (`/lms/enseignants`, dashboard enseignant).
@@ -13,7 +14,8 @@ export const lmsTeachersService = {
    */
   async getEnseignants(withDetails = false) {
     try {
-      const url = withDetails ? '/lms/enseignants?with_details=true' : '/lms/enseignants'
+      // Query string ?with_details (orthogonale) laissée au client — cf. endpoints.js.
+      const url = withDetails ? `${endpoints.lms.enseignants}?with_details=true` : endpoints.lms.enseignants
       return await api.get(url)
     } catch (error) {
       console.error('Erreur récupération enseignants:', error)
@@ -27,7 +29,7 @@ export const lmsTeachersService = {
    */
   async getTeacherDashboard() {
     try {
-      return await api.get('/proxy/me/teacher-dashboard')
+      return await api.get(endpoints.klassci.teacherDashboard)
     } catch (error) {
       console.error('Erreur récupération dashboard enseignant:', error)
       throw error

--- a/src/services/lmsVisio.js
+++ b/src/services/lmsVisio.js
@@ -1,4 +1,5 @@
 import api from './api'
+import { endpoints } from './endpoints'
 
 /**
  * Service LMS — domaine VISIO (`/lms/seances/{id}/{toggle,activate,...}-visio`, join/leave/heartbeat).
@@ -16,7 +17,7 @@ export const lmsVisioService = {
    */
   async toggleVisio(seanceId, enabled, visioType = 'jitsi') {
     try {
-      return await api.post(`/lms/seances/${seanceId}/toggle-visio`, {
+      return await api.post(endpoints.lms.visio.toggle(seanceId), {
         enabled,
         visio_type: visioType
       })
@@ -33,7 +34,7 @@ export const lmsVisioService = {
    */
   async activateVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/activate-visio`)
+      return await api.post(endpoints.lms.visio.activate(seanceId))
     } catch (error) {
       console.error('Erreur activation visio:', error)
       throw error
@@ -47,7 +48,7 @@ export const lmsVisioService = {
    */
   async deactivateVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/deactivate-visio`)
+      return await api.post(endpoints.lms.visio.deactivate(seanceId))
     } catch (error) {
       console.error('Erreur désactivation visio:', error)
       throw error
@@ -61,7 +62,7 @@ export const lmsVisioService = {
    */
   async startVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/start-visio`)
+      return await api.post(endpoints.lms.visio.start(seanceId))
     } catch (error) {
       console.error('Erreur démarrage visio:', error)
       throw error
@@ -75,7 +76,7 @@ export const lmsVisioService = {
    */
   async endVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/end-visio`)
+      return await api.post(endpoints.lms.visio.end(seanceId))
     } catch (error) {
       console.error('Erreur fin visio:', error)
       throw error
@@ -89,7 +90,7 @@ export const lmsVisioService = {
    */
   async joinVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/join`)
+      return await api.post(endpoints.lms.visio.join(seanceId))
     } catch (error) {
       console.error('Erreur rejoindre visio:', error)
       throw error
@@ -103,7 +104,7 @@ export const lmsVisioService = {
    */
   async leaveVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/leave`)
+      return await api.post(endpoints.lms.visio.leave(seanceId))
     } catch (error) {
       console.error('Erreur leave visio:', error)
       throw error
@@ -117,7 +118,7 @@ export const lmsVisioService = {
    */
   async heartbeatVisio(seanceId) {
     try {
-      return await api.post(`/lms/seances/${seanceId}/heartbeat`)
+      return await api.post(endpoints.lms.visio.heartbeat(seanceId))
     } catch (error) {
       console.error('Erreur heartbeat visio:', error)
       throw error
@@ -132,7 +133,7 @@ export const lmsVisioService = {
    */
   async getVisioParticipants(seanceId) {
     try {
-      return await api.get(`/lms/seances/${seanceId}/visio-participants`)
+      return await api.get(endpoints.lms.visio.participants(seanceId))
     } catch (error) {
       console.error('Erreur récupération participants:', error)
       throw error


### PR DESCRIPTION
Remplace les chemins d'API en dur par la carte centralisée endpoints.* (#105) dans lms{Classes,Matieres,Teachers,Seances,Visio,Notifications}.js. Comportement inchangé (parité contrat 28/28, suite 1387 tests verts). api.js/klassci.js non touchés (périmètre #110).