### PR TITLE
refactor(api): migrer api.js + services KLASSCI vers endpoints.* (#110)

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,6 +4,8 @@ import notificationsService from './notifications'
 // résout que les chemins relatifs.
 import { hasRole as roleHasRole } from '../constants/roles'
 import { normalizeError, logError, shouldForceLogout } from './errorHandler'
+// Carte unique des chemins d'API (#105/#110) — source de vérité des URLs.
+import { endpoints } from './endpoints'
 // useAuthStore : on importe la DÉFINITION au top-level (sûr) ; on n'APPELLE
 // useAuthStore() qu'à la volée dans les méthodes (Pinia actif à l'exécution).
 // Cycle api.js <-> auth.js sans danger : aucune des deux références n'est utilisée
@@ -96,43 +98,43 @@ export const auth = {
 // Fonctions pour les leçons
 export const lessons = {
   async getAll(params = {}) {
-    return await api.get('/lessons', { params })
+    return await api.get(endpoints.lessons.list, { params })
   },
 
   async getOne(id) {
-    return await api.get(`/lessons/${id}`)
+    return await api.get(endpoints.lessons.details(id))
   },
 
   async create(data) {
-    return await api.post('/lessons', data)
+    return await api.post(endpoints.lessons.list, data)
   },
 
   async update(id, data) {
-    return await api.put(`/lessons/${id}`, data)
+    return await api.put(endpoints.lessons.details(id), data)
   },
 
   async delete(id) {
-    return await api.delete(`/lessons/${id}`)
+    return await api.delete(endpoints.lessons.details(id))
   }
 }
 
 // Fonctions pour les quiz
 export const quizzes = {
   async getAll() {
-    return await api.get('/quizzes')
+    return await api.get(endpoints.quizzes.list)
   },
 
   async getOne(id) {
-    return await api.get(`/quizzes/${id}`)
+    return await api.get(endpoints.quizzes.details(id))
   },
 
   async startAttempt(quizId) {
-    return await api.post(`/quizzes/${quizId}/start`)
+    return await api.post(endpoints.quizzes.start(quizId))
   },
 
   async submitAttempt(attemptId, answers) {
     // Backend : POST /quiz-attempts/{id}/submit, corps { answers } (SubmitQuizAttemptRequest)
-    return await api.post(`/quiz-attempts/${attemptId}/submit`, { answers })
+    return await api.post(endpoints.quizzes.submitAttempt(attemptId), { answers })
   }
   // getMyAttempts supprimée (#17 Ék-3) : route /quizzes/{id}/my-attempts inexistante,
   // aucun consommateur. La consultation d'une tentative est GET /quiz-attempts/{id}.
@@ -141,15 +143,15 @@ export const quizzes = {
 // Fonctions pour le dashboard
 export const dashboard = {
   async getStudentDashboard() {
-    return await api.get('/dashboard/student')
+    return await api.get(endpoints.dashboard.student)
   },
 
   async getTeacherDashboard() {
-    return await api.get('/dashboard/teacher')
+    return await api.get(endpoints.dashboard.teacher)
   },
 
   async getStats() {
-    return await api.get('/dashboard/stats')
+    return await api.get(endpoints.dashboard.stats)
   }
 }
 
@@ -181,55 +183,55 @@ export const forum = {
     if (params.sort) queryParams.append('sort', params.sort)
 
     const queryString = queryParams.toString()
-    const url = queryString ? `/forum/topics?${queryString}` : '/forum/topics'
+    const url = queryString ? `${endpoints.forum.topics}?${queryString}` : endpoints.forum.topics
     return await api.get(url)
   },
 
   async getTopic(topicId) {
-    return await api.get(`/forum/topics/${topicId}`)
+    return await api.get(endpoints.forum.topic(topicId))
   },
 
   async createTopic(data) {
-    return await api.post('/forum/topics', data)
+    return await api.post(endpoints.forum.topics, data)
   },
 
   async replyToTopic(topicId, content) {
-    return await api.post(`/forum/topics/${topicId}/posts`, { content })
+    return await api.post(endpoints.forum.topicPosts(topicId), { content })
   },
 
   async updateTopic(topicId, data) {
-    return await api.put(`/forum/topics/${topicId}`, data)
+    return await api.put(endpoints.forum.topic(topicId), data)
   },
 
   async deleteTopic(topicId) {
-    return await api.delete(`/forum/topics/${topicId}`)
+    return await api.delete(endpoints.forum.topic(topicId))
   },
 
   async updatePost(postId, content) {
-    return await api.put(`/forum/posts/${postId}`, { content })
+    return await api.put(endpoints.forum.post(postId), { content })
   },
 
   async deletePost(postId) {
-    return await api.delete(`/forum/posts/${postId}`)
+    return await api.delete(endpoints.forum.post(postId))
   },
 
   async markAsSolution(postId) {
-    return await api.post(`/forum/posts/${postId}/solution`)
+    return await api.post(endpoints.forum.postSolution(postId))
   },
 
   async closeTopic(topicId) {
-    return await api.post(`/forum/topics/${topicId}/close`)
+    return await api.post(endpoints.forum.closeTopic(topicId))
   },
 
   async pinTopic(topicId) {
-    return await api.post(`/forum/topics/${topicId}/pin`)
+    return await api.post(endpoints.forum.pinTopic(topicId))
   }
 }
 
 // Teacher Stats
 export const teacherStats = {
   async getStats() {
-    const response = await api.get('/teacher/stats')
+    const response = await api.get(endpoints.teacher.stats)
     return response.data
   }
 }
@@ -237,31 +239,31 @@ export const teacherStats = {
 // Institution Management (superAdmin uniquement)
 export const institutions = {
   async getAll() {
-    return await api.get('/admin/institutions')
+    return await api.get(endpoints.admin.institutions.list)
   },
 
   async getOne(id) {
-    return await api.get(`/admin/institutions/${id}`)
+    return await api.get(endpoints.admin.institutions.details(id))
   },
 
   async create(data) {
-    return await api.post('/admin/institutions', data)
+    return await api.post(endpoints.admin.institutions.list, data)
   },
 
   async update(id, data) {
-    return await api.put(`/admin/institutions/${id}`, data)
+    return await api.put(endpoints.admin.institutions.details(id), data)
   },
 
   async toggle(id) {
-    return await api.patch(`/admin/institutions/${id}/toggle`)
+    return await api.patch(endpoints.admin.institutions.toggle(id))
   },
 
   async testConnection(id) {
-    return await api.post(`/admin/institutions/${id}/test-connection`)
+    return await api.post(endpoints.admin.institutions.testConnection(id))
   },
 
   async delete(id) {
-    return await api.delete(`/admin/institutions/${id}`)
+    return await api.delete(endpoints.admin.institutions.details(id))
   }
 }
 

--- a/src/services/klassciAdmin.js
+++ b/src/services/klassciAdmin.js
@@ -6,6 +6,7 @@
  * l'original.
  */
 import api from './api'
+import { endpoints } from './endpoints'
 
 export const klassciAdminService = {
   /**
@@ -35,7 +36,7 @@ export const klassciAdminService = {
    */
   async getLmsEnseignants(params = {}) {
     try {
-      const response = await api.get('/lms/enseignants', { params })
+      const response = await api.get(endpoints.lms.enseignants, { params })
       return response // Retourne l'objet complet avec success, data, etc.
     } catch (error) {
       console.error('[KlassciService] Erreur récupération enseignants LMS:', error)
@@ -49,7 +50,7 @@ export const klassciAdminService = {
    */
   async getAdminMatieres() {
     try {
-      const response = await api.get('/admin/matieres')
+      const response = await api.get(endpoints.admin.matieres)
       return response
     } catch (error) {
       console.error('Erreur récupération matières admin:', error)

--- a/src/services/klassciCourses.js
+++ b/src/services/klassciCourses.js
@@ -6,6 +6,7 @@
  * identiques à l'original.
  */
 import api from './api'
+import { endpoints } from './endpoints'
 
 export const klassciCoursesService = {
   /**
@@ -20,7 +21,7 @@ export const klassciCoursesService = {
       if (filters.enseignant_id) params.append('enseignant_id', filters.enseignant_id)
 
       const queryString = params.toString()
-      const url = queryString ? `/lessons/my-courses?${queryString}` : '/lessons/my-courses'
+      const url = queryString ? `${endpoints.lessons.myCourses}?${queryString}` : endpoints.lessons.myCourses
 
       const response = await api.get(url)
       return response.success ? response : { data: [], filters: { matieres: [], enseignants: [] }, total: 0 }

--- a/src/services/klassciDashboard.js
+++ b/src/services/klassciDashboard.js
@@ -5,6 +5,7 @@
  * dashboard élève. Comportement et payloads STRICTEMENT identiques à l'original.
  */
 import api from './api'
+import { endpoints } from './endpoints'
 
 export const klassciDashboardService = {
   /**
@@ -14,7 +15,7 @@ export const klassciDashboardService = {
    */
   async getStudentDashboard() {
     try {
-      const response = await api.get('/proxy/me/dashboard')
+      const response = await api.get(endpoints.klassci.studentDashboard)
       return response.success ? response.data : null
     } catch (error) {
       console.error('Erreur récupération dashboard étudiant:', error)
@@ -29,7 +30,7 @@ export const klassciDashboardService = {
    */
   async getTeacherDashboard() {
     try {
-      const response = await api.get('/proxy/me/teacher-dashboard')
+      const response = await api.get(endpoints.klassci.teacherDashboard)
       return response.success ? response.data : null
     } catch (error) {
       console.error('Erreur récupération dashboard enseignant:', error)

--- a/src/services/klassciEvaluations.js
+++ b/src/services/klassciEvaluations.js
@@ -6,6 +6,7 @@
  * l'original.
  */
 import api from './api'
+import { endpoints } from './endpoints'
 
 export const klassciEvaluationsService = {
   /**
@@ -15,7 +16,7 @@ export const klassciEvaluationsService = {
    */
   async getEvaluations(filters = {}) {
     try {
-      const response = await api.get('/proxy/evaluations', { params: filters })
+      const response = await api.get(endpoints.klassci.evaluations, { params: filters })
       return { success: true, data: response.data || response }
     } catch (error) {
       console.error('Erreur récupération évaluations KLASSCI:', error)
@@ -29,7 +30,7 @@ export const klassciEvaluationsService = {
    */
   async getMyEvaluations() {
     try {
-      const response = await api.get('/evaluations/student')
+      const response = await api.get(endpoints.evaluations.student)
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération mes évaluations:', error)

--- a/src/services/klassciSeances.js
+++ b/src/services/klassciSeances.js
@@ -6,6 +6,7 @@
  * à l'original.
  */
 import api from './api'
+import { endpoints } from './endpoints'
 
 export const klassciSeancesService = {
   /**
@@ -15,7 +16,7 @@ export const klassciSeancesService = {
    */
   async getSeances(filters = {}) {
     try {
-      const response = await api.get('/lms/seances/upcoming', { params: filters })
+      const response = await api.get(endpoints.lms.seances.upcoming, { params: filters })
       return response
     } catch (error) {
       console.error('Erreur récupération séances:', error)
@@ -30,7 +31,7 @@ export const klassciSeancesService = {
    */
   async getUpcomingSeances(filters = {}) {
     try {
-      const response = await api.get('/lms/seances/upcoming', { params: filters })
+      const response = await api.get(endpoints.lms.seances.upcoming, { params: filters })
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération séances à venir:', error)
@@ -44,7 +45,7 @@ export const klassciSeancesService = {
    */
   async getMyVisioConferences() {
     try {
-      const response = await api.get('/lms/seances/my-classes')
+      const response = await api.get(endpoints.lms.seances.myClasses)
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération mes visioconférences:', error)

--- a/src/services/klassciStructure.js
+++ b/src/services/klassciStructure.js
@@ -7,6 +7,7 @@
  * STRICTEMENT identiques à l'original.
  */
 import api from './api'
+import { endpoints } from './endpoints'
 
 export const klassciStructureService = {
   /**
@@ -15,7 +16,7 @@ export const klassciStructureService = {
    */
   async getClasses() {
     try {
-      const response = await api.get('/proxy/classes')
+      const response = await api.get(endpoints.klassci.classes)
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération classes:', error)
@@ -29,7 +30,7 @@ export const klassciStructureService = {
    */
   async getMatieres() {
     try {
-      const response = await api.get('/proxy/matieres')
+      const response = await api.get(endpoints.klassci.matieres)
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération matières:', error)
@@ -43,7 +44,7 @@ export const klassciStructureService = {
    */
   async getEnseignants() {
     try {
-      const response = await api.get('/proxy/enseignants')
+      const response = await api.get(endpoints.klassci.enseignants)
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération enseignants:', error)
@@ -58,7 +59,7 @@ export const klassciStructureService = {
    */
   async getEmploiTemps(filters = {}) {
     try {
-      const response = await api.get('/proxy/emploi-temps', { params: filters })
+      const response = await api.get(endpoints.klassci.emploiTemps, { params: filters })
       return response.success ? response.data : []
     } catch (error) {
       console.error('Erreur récupération emploi du temps:', error)
@@ -73,7 +74,7 @@ export const klassciStructureService = {
    */
   async getClasseDetails(classeId) {
     try {
-      const response = await api.get(`/proxy/classes/${classeId}`)
+      const response = await api.get(endpoints.klassci.classeDetails(classeId))
       return response.success ? response.data : null
     } catch (error) {
       console.error(`Erreur récupération classe ${classeId}:`, error)
@@ -88,7 +89,7 @@ export const klassciStructureService = {
    */
   async getClasseEtudiants(classeId) {
     try {
-      const response = await api.get(`/proxy/classes/${classeId}/etudiants`)
+      const response = await api.get(endpoints.klassci.classeEtudiants(classeId))
       return response.success ? response.data : []
     } catch (error) {
       console.error(`Erreur récupération étudiants classe ${classeId}:`, error)
@@ -102,7 +103,7 @@ export const klassciStructureService = {
    */
   async getStructure() {
     try {
-      const response = await api.get('/proxy/structure')
+      const response = await api.get(endpoints.klassci.structure)
       return response.success ? response.data : { filieres: [], niveaux_etude: [] }
     } catch (error) {
       console.error('Erreur récupération structure:', error)


### PR DESCRIPTION
Remplace les chemins en dur par la carte unique endpoints.* (#105) dans api.js et les 6 services de domaine klassci*.js (post-split G9, où vivent désormais les chemins /proxy ciblés par #110). Comportement strictement inchangé : substitution 1:1 des URLs, méthodes/params/corps préservés, frontière brut (endpoints.klassci.*) / enrichi (endpoints.lms.*) intacte.

- api.js : lessons, quizzes, dashboard, forum, teacher.stats, admin.institutions
- klassciStructure/Dashboard/Seances/Evaluations/Courses/Admin.js

Façade klassci.js inchangée (aucun chemin) ; services lms*.js hors périmètre (#111).

Vérification :
- Contrat #17 vert (2/2) — assertions URL/méthode/corps exactes intactes
- Suite complète : 0 régression (échecs identiques avec/sans le changement, tous environnementaux : transform CSS du node_modules partiel du worktree)
- Aucun chemin /proxy|/lms|/admin en dur restant dans les appels