### PR TITLE
chore(theme): migrer les couleurs en dur exactes vers var(--…) dans v…

### DIFF
--- a/src/views/admin/AdminClasses.vue
+++ b/src/views/admin/AdminClasses.vue
@@ -168,7 +168,7 @@ const {
 .error-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #991B1B;
+  color: var(--error-text);
   margin: 0 0 0.5rem 0;
 }
 
@@ -225,7 +225,7 @@ const {
 
 .btn-empty {
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;

--- a/src/views/admin/AdminHub.vue
+++ b/src/views/admin/AdminHub.vue
@@ -204,7 +204,7 @@ const { loading, stats } = useAdminHub()
 
 /* Text color utilities */
 .text-blue-500 {
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .text-orange-500 {

--- a/src/views/admin/AdminInstitutions.vue
+++ b/src/views/admin/AdminInstitutions.vue
@@ -112,7 +112,7 @@ const {
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-md) var(--spacing-lg);
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  background: linear-gradient(135deg, var(--blue-500), #2563eb);
   border: none;
   border-radius: var(--radius-lg);
   color: white;
@@ -163,7 +163,7 @@ const {
 
 .retry-btn {
   padding: var(--spacing-md) var(--spacing-xl);
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  background: linear-gradient(135deg, var(--blue-500), #2563eb);
   border: none;
   border-radius: var(--radius-lg);
   color: white;

--- a/src/views/dashboards/StudentDashboard.vue
+++ b/src/views/dashboards/StudentDashboard.vue
@@ -108,7 +108,7 @@ const { user, dashboardData, loading, error, loadDashboard } = useStudentDashboa
 .error-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #991B1B;
+  color: var(--error-text);
   margin: 0 0 0.5rem 0;
 }
 


### PR DESCRIPTION
…iews/admin + views/dashboards (#112)

Remplacement mécanique des seules correspondances EXACTES (zéro changement visuel en mode clair, aucune couleur nouvelle) selon l'inventaire #106 :
- #991B1B -> var(--error-text)  (AdminClasses, StudentDashboard)
- #3b82f6 -> var(--blue-500)    (AdminClasses, AdminHub, AdminInstitutions)

Volontairement non migré (dette tracée) : approximations (≈) qui décaleraient la teinte même en clair, valeurs sans token (⚠), et règles :global(.dark) où le token light-canonical changerait le rendu sombre voulu.