### PR TITLE
chore(theme): tokens exacts views/student + views/teacher (#113, T3)

### DIFF
--- a/src/views/student/StudentCourses.vue
+++ b/src/views/student/StudentCourses.vue
@@ -187,7 +187,7 @@ const {
 }
 
 .btn-reload {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
 }
 
@@ -213,7 +213,7 @@ const {
   gap: 1.5rem;
   padding: 1.5rem;
   background: #FEF2F2;
-  border: 1px solid #FCA5A5;
+  border: 1px solid var(--error-border);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
 }
@@ -231,7 +231,7 @@ const {
 .error-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #991B1B;
+  color: var(--error-text);
   margin: 0 0 0.5rem 0;
 }
 

--- a/src/views/student/StudentEvaluationsList.vue
+++ b/src/views/student/StudentEvaluationsList.vue
@@ -231,7 +231,7 @@ const {
   gap: 1.5rem;
   padding: 1.5rem;
   background: #FEF2F2;
-  border: 1px solid #FCA5A5;
+  border: 1px solid var(--error-border);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
 }
@@ -249,7 +249,7 @@ const {
 .error-title {
   font-size: 1rem;
   font-weight: 700;
-  color: #991B1B;
+  color: var(--error-text);
   margin: 0 0 0.25rem 0;
 }
 

--- a/src/views/student/StudentLessonView.vue
+++ b/src/views/student/StudentLessonView.vue
@@ -104,8 +104,8 @@ const {
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: var(--bg-primary, #0f172a);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .top-bar {
@@ -113,8 +113,8 @@ const {
   align-items: center;
   gap: 1rem;
   padding: 0.75rem 1.5rem;
-  background: var(--card-bg, #1e293b);
-  border-bottom: 1px solid var(--border-primary, #334155);
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--border-primary);
   z-index: 20;
   flex-shrink: 0;
 }
@@ -125,17 +125,17 @@ const {
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   background: transparent;
-  border: 1px solid var(--border-primary, #334155);
+  border: 1px solid var(--border-primary);
   border-radius: 0.5rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: all 0.2s;
   white-space: nowrap;
 }
 
 .btn-back:hover {
-  background: var(--bg-secondary, #1e293b);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 .lesson-title-bar {
@@ -162,14 +162,14 @@ const {
 .progress-bar-top {
   width: 120px;
   height: 6px;
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   border-radius: 3px;
   overflow: hidden;
 }
 
 .progress-fill-top {
   height: 100%;
-  background: linear-gradient(90deg, #3b82f6, #10b981);
+  background: linear-gradient(90deg, var(--blue-500), #10b981);
   border-radius: 3px;
   transition: width 0.5s ease;
 }
@@ -206,14 +206,14 @@ const {
   height: 60vh;
   text-align: center;
   gap: 1rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .content-loading .spinner {
   width: 40px;
   height: 40px;
-  border: 3px solid var(--border-primary, #334155);
-  border-top-color: #3b82f6;
+  border: 3px solid var(--border-primary);
+  border-top-color: var(--blue-500);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -229,7 +229,7 @@ const {
 
 .btn-retry {
   padding: 0.5rem 1.5rem;
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -245,7 +245,7 @@ const {
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
   border: none;
   cursor: pointer;

--- a/src/views/teacher/TeacherClasses.vue
+++ b/src/views/teacher/TeacherClasses.vue
@@ -114,8 +114,8 @@ const { classes, loading, error, loadClasses } = useTeacherClasses()
 
 .btn-back:hover {
   background: var(--bg-hover);
-  border-color: var(--primary-color, #3b82f6);
-  color: var(--primary-color, #3b82f6);
+  border-color: var(--primary-color, var(--blue-500));
+  color: var(--primary-color, var(--blue-500));
 }
 
 .classes-grid {
@@ -161,7 +161,7 @@ const { classes, loading, error, loadClasses } = useTeacherClasses()
 
 .btn-reload {
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -182,7 +182,7 @@ const { classes, loading, error, loadClasses } = useTeacherClasses()
   gap: 1.5rem;
   padding: 1.5rem;
   background: #FEF2F2;
-  border: 1px solid #FCA5A5;
+  border: 1px solid var(--error-border);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
 }
@@ -200,7 +200,7 @@ const { classes, loading, error, loadClasses } = useTeacherClasses()
 .error-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #991B1B;
+  color: var(--error-text);
   margin: 0 0 0.5rem 0;
 }
 

--- a/src/views/teacher/TeacherStats.vue
+++ b/src/views/teacher/TeacherStats.vue
@@ -94,7 +94,7 @@ const { stats, loading, error, loadStats } = useTeacherStats()
   gap: 1.5rem;
   padding: 1.5rem;
   background: #FEF2F2;
-  border: 1px solid #FCA5A5;
+  border: 1px solid var(--error-border);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
 }
@@ -112,7 +112,7 @@ const { stats, loading, error, loadStats } = useTeacherStats()
 .error-title {
   font-size: 1.125rem;
   font-weight: 700;
-  color: #991B1B;
+  color: var(--error-text);
   margin: 0 0 0.5rem 0;
 }
 


### PR DESCRIPTION
@
## #113 (T3) — Tokens : lot `views/student` + `views/teacher`

Remplace les couleurs en dur par les tokens `var(--…)` de `themes.css`, **uniquement** pour les correspondances **exactes** (valeur light-mode identique au token) → **aucun changement visuel en thème clair**, vérifié ligne à ligne contre `themes.css`.

### Changements (5 fichiers, 27 lignes)
- `#3b82f6` → `var(--blue-500)`, `#fca5a5` → `var(--error-border)`, `#991b1b` → `var(--error-text)`
- `StudentLessonView.vue` : retrait des fallbacks morts `var(--x, #hex)` → `var(--x)` (les tokens sont toujours définis — `data-theme` posé au boot dans `main.js:37` — donc le fallback ne s’affichait jamais)

### Laissé volontairement (dette tracée, hors périmètre T3)
58 couleurs en dur restantes, toutes **`≈` approximations** (~56) ou **`⚠` sans token** (2 : `#f44336`, ombre teintée). Les migrer **glisserait la teinte même en clair** (viole « aucun changement visuel ») ou exigerait de **nouveaux tokens** (« aucune couleur nouvelle » interdit). → relève d’une extension de palette (lot T2).

### Notes
- L’audit #106 était antérieur aux refactos G3/G4 : `TeacherHub`, `TeacherMatieres`, `TeacherProfile` sont **déjà 100% tokenisés** (0 couleur en dur).
- ✅ `vite build` OK (built in 16.38s). Tokens introduits tous vérifiés comme définis dans `themes.css`.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@