### PR TITLE
chore(theme): tokens exacts components/lessons (#125, T4a)

### DIFF
--- a/src/components/lessons/ChapterContent.vue
+++ b/src/components/lessons/ChapterContent.vue
@@ -119,7 +119,7 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 
 .chapter-breadcrumb {
   font-size: 0.8rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   margin-bottom: 0.5rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -141,12 +141,12 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
   font-size: 0.75rem;
   font-weight: 600;
   background: rgba(59, 130, 246, 0.1);
-  color: #60a5fa;
+  color: var(--blue-400);
 }
 
 .chapter-type-badge.video { background: rgba(239, 68, 68, 0.1); color: #f87171; }
 .chapter-type-badge.powerpoint { background: rgba(249, 115, 22, 0.1); color: #fb923c; }
-.chapter-type-badge.word { background: rgba(59, 130, 246, 0.1); color: #60a5fa; }
+.chapter-type-badge.word { background: rgba(59, 130, 246, 0.1); color: var(--blue-400); }
 .chapter-type-badge.pdf { background: rgba(220, 38, 38, 0.1); color: #f87171; }
 .chapter-type-badge.link { background: rgba(139, 92, 246, 0.1); color: #a78bfa; }
 .chapter-type-badge.quiz { background: rgba(16, 185, 129, 0.1); color: #34d399; }
@@ -160,7 +160,7 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 .content-empty-chapter {
   text-align: center;
   padding: 3rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .content-empty-chapter i {
@@ -175,7 +175,7 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
   align-items: center;
   justify-content: space-between;
   padding: 1.5rem 0;
-  border-top: 1px solid var(--border-primary, #334155);
+  border-top: 1px solid var(--border-primary);
   margin-top: 2rem;
   gap: 1rem;
   flex-wrap: wrap;
@@ -223,9 +223,9 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 
 .btn-nav {
   padding: 0.625rem 1.25rem;
-  background: var(--card-bg, #1e293b);
-  border: 1px solid var(--border-primary, #334155);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--card-bg);
+  border: 1px solid var(--border-primary);
+  color: var(--text-primary);
   border-radius: 0.5rem;
   cursor: pointer;
   font-weight: 600;
@@ -236,8 +236,8 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 }
 
 .btn-nav:hover:not(:disabled) {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--blue-500);
+  border-color: var(--blue-500);
   color: white;
 }
 
@@ -247,8 +247,8 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 }
 
 .btn-nav.next {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--blue-500);
+  border-color: var(--blue-500);
   color: white;
 }
 

--- a/src/components/lessons/ChapterContentField.vue
+++ b/src/components/lessons/ChapterContentField.vue
@@ -144,7 +144,7 @@ function handleFileSelect(event) {
 .file-upload-label {
   display: inline-block;
   padding: 10px 20px;
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
   border-radius: 4px;
   cursor: pointer;

--- a/src/components/lessons/ChapterMediaRenderer.vue
+++ b/src/components/lessons/ChapterMediaRenderer.vue
@@ -102,7 +102,7 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
   align-items: center;
   justify-content: center;
   gap: 1rem;
-  color: #94a3b8;
+  color: var(--text-disabled);
 }
 
 .video-fallback i {
@@ -112,7 +112,7 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
 
 .btn-external-video {
   padding: 0.75rem 1.5rem;
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
   text-decoration: none;
   border-radius: 0.5rem;
@@ -130,13 +130,13 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
   width: 100%;
   height: 75vh;
   border-radius: 0.75rem;
-  border: 1px solid var(--border-primary, #334155);
+  border: 1px solid var(--border-primary);
 }
 
 .btn-open-pdf {
   align-self: flex-end;
   padding: 0.5rem 1rem;
-  color: #60a5fa;
+  color: var(--blue-400);
   text-decoration: none;
   font-size: 0.85rem;
 }
@@ -148,7 +148,7 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
 .pdf-empty {
   text-align: center;
   padding: 3rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .pdf-empty i {
@@ -162,8 +162,8 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
   align-items: center;
   gap: 1.25rem;
   padding: 1.5rem;
-  background: var(--card-bg, #1e293b);
-  border: 1px solid var(--border-primary, #334155);
+  background: var(--card-bg);
+  border: 1px solid var(--border-primary);
   border-radius: 0.75rem;
 }
 
@@ -184,7 +184,7 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
 
 .link-url {
   font-size: 0.85rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/lessons/ChapterQuizRenderer.vue
+++ b/src/components/lessons/ChapterQuizRenderer.vue
@@ -39,8 +39,8 @@ defineEmits(['completed', 'close'])
 .quiz-card {
   text-align: center;
   padding: 3rem 2rem;
-  background: var(--card-bg, #1e293b);
-  border: 1px solid var(--border-primary, #334155);
+  background: var(--card-bg);
+  border: 1px solid var(--border-primary);
   border-radius: 0.75rem;
 }
 
@@ -56,7 +56,7 @@ defineEmits(['completed', 'close'])
 }
 
 .quiz-meta {
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   margin-bottom: 1.5rem;
 }
 
@@ -113,7 +113,7 @@ defineEmits(['completed', 'close'])
 .quiz-empty {
   text-align: center;
   padding: 3rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .quiz-empty i {

--- a/src/components/lessons/ChapterTextRenderer.vue
+++ b/src/components/lessons/ChapterTextRenderer.vue
@@ -32,7 +32,7 @@ defineProps({
 .rendered-html {
   line-height: 1.8;
   font-size: 1.05rem;
-  color: var(--text-primary, #e2e8f0);
+  color: var(--text-primary);
 }
 
 .rendered-html :deep(h1),
@@ -40,7 +40,7 @@ defineProps({
 .rendered-html :deep(h3) {
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;
-  color: var(--text-primary, #e2e8f0);
+  color: var(--text-primary);
 }
 
 .rendered-html :deep(p) {
@@ -58,7 +58,7 @@ defineProps({
 }
 
 .rendered-html :deep(blockquote) {
-  border-left: 4px solid #3b82f6;
+  border-left: 4px solid var(--blue-500);
   padding: 1rem 1.25rem;
   margin: 1.5rem 0;
   background: rgba(59, 130, 246, 0.05);
@@ -66,14 +66,14 @@ defineProps({
 }
 
 .rendered-html :deep(code) {
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   padding: 0.15rem 0.4rem;
   border-radius: 0.25rem;
   font-size: 0.9em;
 }
 
 .rendered-html :deep(pre) {
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   padding: 1rem;
   border-radius: 0.5rem;
   overflow-x: auto;
@@ -95,20 +95,20 @@ defineProps({
 .rendered-html :deep(th),
 .rendered-html :deep(td) {
   padding: 0.75rem;
-  border: 1px solid var(--border-primary, #334155);
+  border: 1px solid var(--border-primary);
   text-align: left;
 }
 
 .rendered-html :deep(th) {
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   font-weight: 700;
 }
 
 /* Word documents specific */
 .word-document {
-  background: var(--card-bg, #1e293b);
+  background: var(--card-bg);
   padding: 2rem;
   border-radius: 0.75rem;
-  border: 1px solid var(--border-primary, #334155);
+  border: 1px solid var(--border-primary);
 }
 </style>

--- a/src/components/lessons/ChapterViewMode.vue
+++ b/src/components/lessons/ChapterViewMode.vue
@@ -130,7 +130,7 @@ function getQuizScoreBadge(q) {
   line-height: 1.6;
   margin: 12px 0;
   padding: 16px;
-  background: var(--bg-secondary, #f9fafb);
+  background: var(--bg-secondary);
   border-radius: 8px;
   border: 1px solid var(--border-color, #e5e7eb);
   max-height: 400px;

--- a/src/components/lessons/LessonBasicInfoFields.vue
+++ b/src/components/lessons/LessonBasicInfoFields.vue
@@ -179,7 +179,7 @@ defineEmits(['load-chapters'])
 .form-select:focus,
 .form-textarea:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 

--- a/src/components/lessons/LessonCard.vue
+++ b/src/components/lessons/LessonCard.vue
@@ -101,7 +101,7 @@ const { getContentTypeIcon, getContentTypeLabel, formatDuration, formatDate } = 
 .lesson-card:hover {
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
   transform: translateY(-2px);
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
 }
 
 /* Header */

--- a/src/components/lessons/LessonCardActions.vue
+++ b/src/components/lessons/LessonCardActions.vue
@@ -99,16 +99,16 @@ defineEmits(['view', 'edit', 'delete', 'publish', 'unpublish'])
 }
 
 .btn-unpublish:hover {
-  background: #fef3c7;
+  background: var(--warning-bg);
 }
 
 .btn-edit {
-  color: #3b82f6;
-  border-color: #3b82f6;
+  color: var(--blue-500);
+  border-color: var(--blue-500);
 }
 
 .btn-edit:hover {
-  background: #dbeafe;
+  background: var(--blue-100);
 }
 
 .btn-delete {
@@ -117,11 +117,11 @@ defineEmits(['view', 'edit', 'delete', 'publish', 'unpublish'])
 }
 
 .btn-delete:hover {
-  background: #fee2e2;
+  background: var(--error-bg);
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  background: linear-gradient(135deg, var(--blue-500), #8b5cf6);
   color: white;
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
 }

--- a/src/components/lessons/LessonCardBadges.vue
+++ b/src/components/lessons/LessonCardBadges.vue
@@ -46,8 +46,8 @@ const statusBadge = computed(() => getStatusBadge(props.lesson.status))
 
 /* Badges par type */
 .badge-cours {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .badge-tp {
@@ -72,7 +72,7 @@ const statusBadge = computed(() => getStatusBadge(props.lesson.status))
 
 /* Badges par status */
 .badge-status-draft {
-  background: #fef3c7;
+  background: var(--warning-bg);
   color: #92400e;
 }
 
@@ -82,7 +82,7 @@ const statusBadge = computed(() => getStatusBadge(props.lesson.status))
 }
 
 .badge-status-archived {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--error-bg);
+  color: var(--error-text);
 }
 </style>

--- a/src/components/lessons/LessonChapterSidebar.vue
+++ b/src/components/lessons/LessonChapterSidebar.vue
@@ -75,8 +75,8 @@ function isChapterCompleted(chapterId) {
 <style scoped>
 .chapter-sidebar {
   width: 300px;
-  background: var(--card-bg, #1e293b);
-  border-right: 1px solid var(--border-primary, #334155);
+  background: var(--card-bg);
+  border-right: 1px solid var(--border-primary);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -95,20 +95,20 @@ function isChapterCompleted(chapterId) {
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border-primary, #334155);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .sidebar-title {
   font-size: 1rem;
   font-weight: 700;
   margin: 0;
-  color: var(--text-primary, #e2e8f0);
+  color: var(--text-primary);
 }
 
 .btn-toggle-sidebar {
   background: transparent;
   border: none;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 0.25rem;
   font-size: 1rem;
@@ -116,7 +116,7 @@ function isChapterCompleted(chapterId) {
 
 .sidebar-meta {
   padding: 0.75rem 1.25rem;
-  border-bottom: 1px solid var(--border-primary, #334155);
+  border-bottom: 1px solid var(--border-primary);
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
@@ -127,13 +127,13 @@ function isChapterCompleted(chapterId) {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.8rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .meta-row i {
   width: 1rem;
   text-align: center;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 /* Chapter navigation items */
@@ -152,7 +152,7 @@ function isChapterCompleted(chapterId) {
   background: transparent;
   border: none;
   border-left: 3px solid transparent;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
   cursor: pointer;
   text-align: left;
   transition: all 0.2s;
@@ -160,13 +160,13 @@ function isChapterCompleted(chapterId) {
 
 .chapter-nav-item:hover {
   background: rgba(59, 130, 246, 0.05);
-  color: var(--text-primary, #e2e8f0);
+  color: var(--text-primary);
 }
 
 .chapter-nav-item.active {
   background: rgba(59, 130, 246, 0.1);
-  border-left-color: #3b82f6;
-  color: var(--text-primary, #e2e8f0);
+  border-left-color: var(--blue-500);
+  color: var(--text-primary);
 }
 
 .chapter-nav-item.completed .chapter-status-icon {
@@ -180,14 +180,14 @@ function isChapterCompleted(chapterId) {
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   flex-shrink: 0;
   font-size: 0.75rem;
   font-weight: 700;
 }
 
 .chapter-nav-item.active .chapter-status-icon {
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
 }
 

--- a/src/components/lessons/LessonContentFields.vue
+++ b/src/components/lessons/LessonContentFields.vue
@@ -196,7 +196,7 @@ defineProps({
 .form-select:focus,
 .form-textarea:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -236,7 +236,7 @@ defineProps({
 
 .radio-card.active {
   background: rgba(59, 130, 246, 0.1);
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
 }
 
 .radio-card input[type="radio"] {

--- a/src/components/lessons/LessonContentTypePicker.vue
+++ b/src/components/lessons/LessonContentTypePicker.vue
@@ -77,7 +77,7 @@ defineProps({
 
 .content-type-card.active {
   background: rgba(59, 130, 246, 0.1);
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
 }
 
 .content-type-radio {

--- a/src/components/lessons/LessonEditorActions.vue
+++ b/src/components/lessons/LessonEditorActions.vue
@@ -66,7 +66,7 @@ defineEmits(['cancel', 'delete'])
 }
 
 .btn-save {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
 }
 
@@ -81,9 +81,9 @@ defineEmits(['cancel', 'delete'])
 }
 
 .btn-delete {
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #dc2626;
-  border: 1px solid #fca5a5;
+  border: 1px solid var(--error-border);
 }
 
 .btn-delete:hover:not(:disabled) {

--- a/src/components/lessons/LessonFormModal.vue
+++ b/src/components/lessons/LessonFormModal.vue
@@ -191,7 +191,7 @@ defineEmits(['close', 'save'])
 .form-select:focus,
 .form-textarea:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -224,7 +224,7 @@ defineEmits(['close', 'save'])
 }
 
 .btn-save {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
 }
 

--- a/src/components/lessons/LessonInfoCard.vue
+++ b/src/components/lessons/LessonInfoCard.vue
@@ -79,7 +79,7 @@ function getNiveauLabel(niveau) {
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 24px;
-  box-shadow: var(--card-shadow, 0 1px 3px rgba(0, 0, 0, 0.1));
+  box-shadow: var(--card-shadow);
   margin-bottom: 24px;
 }
 
@@ -122,7 +122,7 @@ function getNiveauLabel(niveau) {
 
 .badge-debutant {
   background-color: rgba(59, 130, 246, 0.1);
-  color: #3b82f6;
+  color: var(--blue-500);
   border: 1px solid rgba(59, 130, 246, 0.3);
 }
 

--- a/src/components/lessons/LessonResourcesFields.vue
+++ b/src/components/lessons/LessonResourcesFields.vue
@@ -172,7 +172,7 @@ defineEmits(['add', 'remove'])
 .form-select:focus,
 .form-textarea:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -214,9 +214,9 @@ defineEmits(['add', 'remove'])
 
 .btn-remove {
   padding: 0.5rem 1rem;
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #dc2626;
-  border: 1px solid #fca5a5;
+  border: 1px solid var(--error-border);
   border-radius: 0.375rem;
   font-size: 0.813rem;
   font-weight: 600;
@@ -244,9 +244,9 @@ defineEmits(['add', 'remove'])
 
 .btn-add {
   padding: 0.75rem 1.5rem;
-  background: #dbeafe;
+  background: var(--blue-100);
   color: #1d4ed8;
-  border: 1px solid #93c5fd;
+  border: 1px solid var(--blue-300);
   border-radius: 0.5rem;
   font-weight: 600;
   cursor: pointer;
@@ -254,7 +254,7 @@ defineEmits(['add', 'remove'])
 }
 
 .btn-add:hover {
-  background: #bfdbfe;
+  background: var(--blue-200);
 }
 
 /* Responsive */

--- a/src/components/lessons/LessonRichTextEditor.vue
+++ b/src/components/lessons/LessonRichTextEditor.vue
@@ -70,7 +70,7 @@ const showPreview = ref(false)
 
 .form-textarea:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -114,8 +114,8 @@ const showPreview = ref(false)
 }
 
 .tab-btn.active {
-  color: #3b82f6;
-  border-bottom-color: #3b82f6;
+  color: var(--blue-500);
+  border-bottom-color: var(--blue-500);
 }
 
 /* Preview Panel */

--- a/src/components/lessons/LessonStatsGrid.vue
+++ b/src/components/lessons/LessonStatsGrid.vue
@@ -39,7 +39,7 @@ defineProps({
 }
 
 .stat-started {
-  background: #dbeafe;
+  background: var(--info-bg);
 }
 
 .stat-completed {
@@ -56,7 +56,7 @@ defineProps({
 }
 
 .stat-started .stat-value {
-  color: #1e40af;
+  color: var(--info-text);
 }
 
 .stat-completed .stat-value {

--- a/src/components/lessons/LessonStatusPicker.vue
+++ b/src/components/lessons/LessonStatusPicker.vue
@@ -90,7 +90,7 @@ const status = defineModel({ type: String, default: 'draft' })
 
 .status-card.active {
   background: rgba(59, 130, 246, 0.1);
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
 }
 
 .status-card input[type="radio"] {

--- a/src/components/lessons/LessonsEmptyState.vue
+++ b/src/components/lessons/LessonsEmptyState.vue
@@ -65,7 +65,7 @@ defineProps({
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;

--- a/src/components/lessons/QuizPlayerIntro.vue
+++ b/src/components/lessons/QuizPlayerIntro.vue
@@ -133,7 +133,7 @@ defineEmits(['start'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.25rem;
-  background: #fef3c7;
+  background: var(--warning-bg);
   color: #b45309;
   border-radius: 8px;
   font-weight: 500;
@@ -179,7 +179,7 @@ defineEmits(['start'])
   justify-content: center;
   gap: 0.5rem;
   padding: 1rem;
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #b91c1c;
   border-radius: 8px;
   font-weight: 500;

--- a/src/components/lessons/QuizPlayerQuestion.vue
+++ b/src/components/lessons/QuizPlayerQuestion.vue
@@ -153,7 +153,7 @@ function isOptionSelected(index) {
 }
 
 .quiz-timer.warning {
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #b91c1c;
   animation: pulse 1s infinite;
 }

--- a/src/components/lessons/QuizPlayerResults.vue
+++ b/src/components/lessons/QuizPlayerResults.vue
@@ -72,7 +72,7 @@ defineEmits(['retry', 'close'])
   text-align: center;
   padding: 2rem;
   margin: -2rem -2rem 2rem;
-  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  background: linear-gradient(135deg, var(--warning-bg) 0%, #fde68a 100%);
 }
 
 .results-header.passed {

--- a/src/components/lessons/SlidesViewer.vue
+++ b/src/components/lessons/SlidesViewer.vue
@@ -104,9 +104,9 @@ function nextSlide() {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
-  background: var(--card-bg, #1e293b);
-  border: 1px solid var(--border-primary, #334155);
-  color: var(--text-primary, #e2e8f0);
+  background: var(--card-bg);
+  border: 1px solid var(--border-primary);
+  color: var(--text-primary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -115,8 +115,8 @@ function nextSlide() {
 }
 
 .btn-slide:hover:not(:disabled) {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--blue-500);
+  border-color: var(--blue-500);
   color: white;
 }
 
@@ -128,7 +128,7 @@ function nextSlide() {
 .slide-counter {
   font-size: 0.9rem;
   font-weight: 700;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .slides-thumbnails {
@@ -147,12 +147,12 @@ function nextSlide() {
   border: 2px solid transparent;
   cursor: pointer;
   position: relative;
-  background: var(--bg-secondary, #334155);
+  background: var(--bg-secondary);
   padding: 0;
 }
 
 .slide-thumb.active {
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
 }
 
 .slide-thumb img {
@@ -174,7 +174,7 @@ function nextSlide() {
 .slides-empty {
   text-align: center;
   padding: 3rem;
-  color: var(--text-secondary, #94a3b8);
+  color: var(--text-secondary);
 }
 
 .slides-empty i {

--- a/src/components/lessons/TeacherLessonCard.vue
+++ b/src/components/lessons/TeacherLessonCard.vue
@@ -140,12 +140,12 @@ function formatDate(dateString) {
 }
 
 .status-published {
-  background: #dcfce7;
+  background: var(--success-bg);
   color: #15803d;
 }
 
 .status-draft {
-  background: #fef3c7;
+  background: var(--warning-bg);
   color: #92400e;
 }
 
@@ -210,7 +210,7 @@ function formatDate(dateString) {
   border: none;
 }
 
-.btn-view {  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);  color: white;  border: none;}.btn-view:hover {  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);  transform: translateY(-2px);  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);}
+.btn-view {  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);  color: white;  border: none;}.btn-view:hover {  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);  transform: translateY(-2px);  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);}
 
 .btn-edit:hover {
   background: var(--bg-tertiary);


### PR DESCRIPTION
Sous-lot **#125** de #114. Re-grep du périmètre réel sur `dev` (l'audit #106 est périmé — `LessonCard` décomposé depuis).

## Méthode
Remplacement **mécanique exact uniquement** : seules les couleurs dont la valeur **light-mode** de `themes.css` est identique au token sont migrées → **aucun changement visuel en clair**. `26 fichiers, 101 insertions / 101 suppressions` (pur swap de valeurs, zéro changement structurel).

### Remplacé
- **Hex standalone → token exact** : `#3b82f6→--blue-500`, `#60a5fa→--blue-400`, `#94a3b8→--text-disabled`, `#dcfce7→--success-bg`, `#fef3c7→--warning-bg`, `#fee2e2→--error-bg`, `#991b1b→--error-text`, `#fca5a5→--error-border`, `#bfdbfe/#93c5fd→--blue-200/300`, `#dbeafe/#1e40af→--blue-100|--info-bg / --info-text`.
- **Fallbacks morts** `var(--token, #hex)→var(--token)` pour les tokens **définis** (`--border-primary`, `--text-secondary`, `--card-bg`, `--text-primary`, `--bg-secondary`, `--card-shadow`) — `data-theme` posé au boot (`main.js`).

### Choix sémantique `#dbeafe` (= `--blue-100` **et** `--info-bg`, identiques en clair, divergents en sombre)
- accent bleu (`btn-edit:hover`, `btn-add`) → `--blue-100`
- badge/stat « info » apparié à `#1e40af` → `--info-bg` + `--info-text` (cohérent avec les `--warning-bg`/`--error-bg` voisins)

## Laissé volontairement (dette tracée)
- **Fallbacks vivants conservés** (tokens **non définis** dans `themes.css`, le hex est la valeur effective) : `var(--color-primary, #10b981 / #3b82f6)`, `var(--text-muted, #9ca3af)`, `var(--border-color, #e5e7eb)`.
- **`#ffffff`** (ChapterEditForm.vue:143) : ambigu (= `--bg-primary`/`--card-bg`/`--input-bg`/…), non remplacé — comme #113.
- **Approximations (`≈`)** qui glisseraient la teinte même en clair : `#2563eb`, `#10b981`, `#059669`, `#dc2626`, `#ef4444`, `#6b7280`, `#111827`, `#f9fafb`, `#92400e`, `#b45309`…
- **Sans token** : indigo/violet `#6366f1`/`#4f46e5`/`#8b5cf6`/`#7c3aed`, rose `#fce7f3`/`#be123c`, `#000`, et **tous les `rgba()` d'ombres/overlays/teintes** (`rgba(0,0,0,…)`, `rgba(59,130,246,…)`, etc.).

## Validation
- ✅ Les 26 SFCs parsent et leurs `<style>` compilent proprement (`@vue/compiler-sfc`).
- ✅ Aucun `var()` malformé ; aucune imbrication accidentelle ; fallbacks vivants intacts.
- ⚠️ `vite build` non exécutable dans le worktree (`node_modules` commité partiel, chunk vite manquant) → validation via le compilateur SFC du repo principal.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)