### PR TITLE
chore(theme): tokens exacts attendance + seances + visio (#129, T4e)

### DIFF
--- a/src/components/attendance/AttendanceDetailModal.vue
+++ b/src/components/attendance/AttendanceDetailModal.vue
@@ -117,7 +117,7 @@ defineEmits(['close', 'export-pdf', 'export-excel', 'retry'])
   width: 3rem;
   height: 3rem;
   border: 3px solid var(--bg-secondary);
-  border-top-color: #3b82f6;
+  border-top-color: var(--blue-500);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }

--- a/src/components/attendance/AttendanceHistoryFilters.vue
+++ b/src/components/attendance/AttendanceHistoryFilters.vue
@@ -116,7 +116,7 @@ defineEmits(['change', 'input', 'reset'])
 .filter-input:focus,
 .filter-select:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 

--- a/src/components/attendance/AttendanceHistoryPagination.vue
+++ b/src/components/attendance/AttendanceHistoryPagination.vue
@@ -48,7 +48,7 @@ defineEmits(['load-page'])
 
 .btn-page {
   padding: 0.625rem 1rem;
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
   border: none;
   border-radius: 8px;

--- a/src/components/attendance/AttendanceHistoryRows.vue
+++ b/src/components/attendance/AttendanceHistoryRows.vue
@@ -161,7 +161,7 @@ defineEmits(['view-details'])
 
 .seance-id {
   font-weight: 500;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .seance-date {
@@ -194,8 +194,8 @@ defineEmits(['view-details'])
 }
 
 .status-disconnected {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--error-bg);
+  color: var(--error-text);
 }
 
 .duration-text {

--- a/src/components/attendance/AttendanceHistoryStats.vue
+++ b/src/components/attendance/AttendanceHistoryStats.vue
@@ -64,7 +64,7 @@ defineProps({
   border-left: 4px solid;
 }
 
-.border-l-blue { border-left-color: #3b82f6; }
+.border-l-blue { border-left-color: var(--blue-500); }
 .border-l-green { border-left-color: #10b981; }
 .border-l-orange { border-left-color: #f59e0b; }
 .border-l-red { border-left-color: #ef4444; }

--- a/src/components/attendance/AttendanceModalFooter.vue
+++ b/src/components/attendance/AttendanceModalFooter.vue
@@ -62,7 +62,7 @@ defineEmits(['export-pdf', 'export-excel', 'close'])
 }
 
 .btn-export-pdf:hover:not(:disabled) {
-  background: linear-gradient(135deg, #b91c1c 0%, #991b1b 100%);
+  background: linear-gradient(135deg, #b91c1c 0%, var(--error-text) 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(220, 38, 38, 0.4);
 }

--- a/src/components/attendance/AttendanceModalTable.vue
+++ b/src/components/attendance/AttendanceModalTable.vue
@@ -97,9 +97,9 @@ function formatDuration(minutes) {
 
 /* Modal Info Banner */
 .modal-info-banner {
-  background: #DBEAFE;
-  border: 1px solid #93C5FD;
-  color: #1E40AF;
+  background: var(--info-bg);
+  border: 1px solid var(--info-border);
+  color: var(--info-text);
   padding: 0.875rem 1rem;
   border-radius: 0.5rem;
   margin-bottom: 1.5rem;
@@ -141,7 +141,7 @@ function formatDuration(minutes) {
 }
 
 .modal-table tbody tr:hover {
-  background: var(--bg-hover, rgba(0, 0, 0, 0.02));
+  background: var(--bg-hover);
 }
 
 .modal-table td {
@@ -196,14 +196,14 @@ function formatDuration(minutes) {
 
 /* Absent - Rouge foncé (<20%) */
 .status-badge.status-absent {
-  background: #FEE2E2;
-  color: #991B1B;
+  background: var(--error-bg);
+  color: var(--error-text);
 }
 
 /* En cours - Bleu (séance non terminée) */
 .status-badge.status-ongoing {
-  background: #DBEAFE;
-  color: #1E40AF;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 /* Modal Stats */

--- a/src/components/attendance/SeancePeriodFilters.vue
+++ b/src/components/attendance/SeancePeriodFilters.vue
@@ -108,9 +108,9 @@ defineEmits(['select-period', 'apply-custom', 'search', 'clear'])
 }
 
 .period-tab.active {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
 }
 
@@ -158,13 +158,13 @@ defineEmits(['select-period', 'apply-custom', 'search', 'clear'])
 
 .date-input:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
 .btn-primary-action {
   padding: 0.75rem 2rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -216,7 +216,7 @@ defineEmits(['select-period', 'apply-custom', 'search', 'clear'])
 
 .search-input:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 

--- a/src/components/attendance/SeancesPagination.vue
+++ b/src/components/attendance/SeancesPagination.vue
@@ -59,9 +59,9 @@ defineEmits(['change-page'])
 }
 
 .pagination-btn:hover:not(:disabled) {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 2px 4px rgba(59, 130, 246, 0.2);
 }
 

--- a/src/components/attendance/SeancesTable.vue
+++ b/src/components/attendance/SeancesTable.vue
@@ -141,7 +141,7 @@ defineEmits(['view-attendances', 'delete-seance', 'change-page'])
 }
 
 .data-table tbody tr:hover {
-  background: var(--bg-hover, rgba(0, 0, 0, 0.02));
+  background: var(--bg-hover);
 }
 
 .data-table tbody tr.row-selected {

--- a/src/components/seances/CoordinatorVisioPanel.vue
+++ b/src/components/seances/CoordinatorVisioPanel.vue
@@ -155,7 +155,7 @@ defineEmits(['show-participants', 'join'])
 
 .participants-btn {
   padding: 0.75rem 1.25rem;
-  background: #3b82f6;
+  background: var(--blue-500);
   border: none;
   border-radius: 0.5rem;
   color: white;
@@ -197,7 +197,7 @@ defineEmits(['show-participants', 'join'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.25rem;
-  background: #fef3c7;
+  background: var(--warning-bg);
   border-radius: 0.5rem;
   border: 1px solid #fcd34d;
 }

--- a/src/components/seances/SeanceCardActions.vue
+++ b/src/components/seances/SeanceCardActions.vue
@@ -199,7 +199,7 @@ function formatTime(dateTimeStr) {
   font-size: 1.5rem;
   line-height: 1;
   flex-shrink: 0;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .action-content {

--- a/src/components/seances/SeanceCardHeader.vue
+++ b/src/components/seances/SeanceCardHeader.vue
@@ -71,7 +71,7 @@ defineProps({
   font-size: 2rem;
   line-height: 1;
   flex-shrink: 0;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .seance-title {
@@ -104,13 +104,13 @@ defineProps({
 }
 
 .status-scheduled {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .status-active {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
 }
 
 .status-finished {

--- a/src/components/visio/JitsiLoadingOverlay.vue
+++ b/src/components/visio/JitsiLoadingOverlay.vue
@@ -35,7 +35,7 @@ import ContentLoader from '@/components/common/ContentLoader.vue'
 .spinner {
   border: 4px solid rgba(255, 255, 255, 0.1);
   border-radius: 50%;
-  border-top: 4px solid #3b82f6;
+  border-top: 4px solid var(--blue-500);
   width: 50px;
   height: 50px;
   animation: spin 1s linear infinite;

--- a/src/components/visio/VisioSeanceCard.vue
+++ b/src/components/visio/VisioSeanceCard.vue
@@ -177,13 +177,13 @@ defineEmits(['start', 'end', 'activate'])
 }
 
 .badge-active {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
 }
 
 .badge-scheduled {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .pulse-dot {
@@ -256,7 +256,7 @@ defineEmits(['start', 'end', 'activate'])
 }
 
 .btn-start {
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
 }
 


### PR DESCRIPTION
Ferme #129 (sous-lot de #114). Re-grep du périmètre sur `dev` courant, remplacement **mécanique** des seules correspondances **EXACTES** light-canonical de `themes.css` → `var(--…)`. **Zéro changement visuel en thème clair** (vérifié ligne à ligne).

## Périmètre réel (après décompo G3/G4, ≠ numéros #106)
`attendance/**`, `seances/**`, `visio/**`, `charts/**`, `layout/**`, `Navbar.vue`. Dossier `enseignants/` disparu depuis #106.

## Remplacements (38, sur 15 fichiers)
- `#3b82f6 → var(--blue-500)` — border / bg / color, et le **stop exact** des gradients (voisin `#2563eb` ≈ laissé)
- `#fee2e2 → var(--error-bg)`, `#991b1b → var(--error-text)`
- `#dbeafe → var(--info-bg)`, `#93c5fd → var(--info-border)`, `#1e40af → var(--info-text)`
- `#dcfce7 → var(--success-bg)`, `#166534 → var(--success-text)`, `#fef3c7 → var(--warning-bg)`
- fallbacks morts `var(--bg-hover, rgba(0,0,0,0.02)) → var(--bg-hover)` (token toujours défini)

## Laissé volontairement (dette tracée)
- **`:global(.dark)`** : fills `#3B82F6`/`#60A5FA` de `SidebarHeader.vue` — le token light-canonical casserait le rendu sombre voulu.
- **Fallbacks vivants** : `var(--primary-color, #3b82f6)` (×2), `var(--card-bg-dark, #1f2937)` — tokens **non définis** dans `themes.css`.
- **Approximations (≈)** (décaleraient la teinte même en clair) : `#2563eb`, verts `#10b981/#059669/#22c55e/#16a34a/#15803d`, rouges `#ef4444/#dc2626/#b91c1c/#FECACA/#7F1D1D`, ambres `#f59e0b/#d97706/#92400e/#fcd34d/#FED7AA`, gris `#d1d5db/#e5e7eb/#6b7280/#4b5563/#f3f4f6`.
- **Sans token (⚠)** : violet/indigo, surfaces visio sombres (`#1f2937/#111827/#374151/#000`), voiles `rgba(255,255,255,α)`, overlays/ombres `rgba(0,0,0,α)` + ombres teintées `rgba(59,130,246,α)`, options JS Chart.js (`ActivityChart.vue`).

## Hors changement
- **`Navbar.vue`** : ses 2 seules couleurs = `#2563eb` (≈ `--blue-600`) → aucune correspondance exacte, non modifié.

## Caveat
Quelques badges ne sont tokenisés que partiellement (ex. badge « warning » de `CoordinatorVisioPanel` : `bg` tokenisé, `border #fcd34d` / `text #92400e` ≈ laissés). Identique en clair ; léger contraste à revérifier en sombre.

## Vérifications
- Diff = 38 insertions / 38 suppressions, aucune ligne ajoutée/supprimée.
- 0 hex exact-matchable restant dans le périmètre (hors `:global(.dark)` et fallbacks vivants ci-dessus).
- Les 10 tokens introduits existent tous dans `themes.css`.
- Balises `<style>` équilibrées.
- ⚠️ Pas de build/lint complet lancé (pas de script lint ; `node_modules` absent du worktree) — swap CSS trivial vérifié ligne à ligne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)