### PR TITLE
chore(theme): migrer les couleurs en dur exactes vers var(--…) dans c…

### DIFF
--- a/src/components/evaluations/EvaluationCardActions.vue
+++ b/src/components/evaluations/EvaluationCardActions.vue
@@ -118,7 +118,7 @@ defineEmits(['create', 'edit', 'view-results', 'publish', 'preview', 'sync', 'de
 }
 
 .btn-create {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
   color: white;
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
 }

--- a/src/components/evaluations/EvaluationCardHeader.vue
+++ b/src/components/evaluations/EvaluationCardHeader.vue
@@ -100,15 +100,15 @@ function getStatusIcon(status) {
 }
 
 .status-badge-planned {
-  background: #dbeafe;
-  color: #1e40af;
-  border: 1px solid #bfdbfe;
+  background: var(--info-bg);
+  color: var(--info-text);
+  border: 1px solid var(--blue-200);
 }
 
 .status-badge-active {
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #86efac;
+  background: var(--success-bg);
+  color: var(--success-text);
+  border: 1px solid var(--success-border);
   animation: pulse-badge 2s ease-in-out infinite;
 }
 
@@ -128,7 +128,7 @@ function getStatusIcon(status) {
 }
 
 .status-badge-draft {
-  background: #fef3c7;
+  background: var(--warning-bg);
   color: #92400e;
   border: 1px solid #fde68a;
 }

--- a/src/components/evaluations/EvaluationCardStatus.vue
+++ b/src/components/evaluations/EvaluationCardStatus.vue
@@ -170,8 +170,8 @@ defineProps({
   display: flex;
   gap: 1rem;
   padding: 1rem;
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
+  background: var(--blue-50);
+  border: 1px solid var(--blue-200);
   border-radius: 0.5rem;
   margin-bottom: 1.5rem;
 }
@@ -190,7 +190,7 @@ defineProps({
 .online-title {
   font-size: 0.9375rem;
   font-weight: 600;
-  color: #1e40af;
+  color: var(--info-text);
   margin: 0 0 0.5rem 0;
 }
 
@@ -205,6 +205,6 @@ defineProps({
   align-items: center;
   gap: 0.375rem;
   font-size: 0.875rem;
-  color: #1e40af;
+  color: var(--info-text);
 }
 </style>

--- a/src/components/evaluations/ResultChoiceOptions.vue
+++ b/src/components/evaluations/ResultChoiceOptions.vue
@@ -165,7 +165,7 @@ defineProps({
 /* Classes personnalisées pour les options - période d'attente (pas de correction) */
 .option-selected-waiting {
   background-color: var(--bg-tertiary) !important;
-  border: 2px solid #60a5fa !important;
+  border: 2px solid var(--blue-400) !important;
   border-radius: 0.5rem;
 }
 
@@ -204,7 +204,7 @@ defineProps({
 
 /* Texte dans option sélectionnée (attente) */
 .option-selected-waiting .option-text {
-  color: #60a5fa !important;
+  color: var(--blue-400) !important;
 }
 
 /* Texte dans option non sélectionnée */

--- a/src/components/evaluations/TakeEvaluationBanners.vue
+++ b/src/components/evaluations/TakeEvaluationBanners.vue
@@ -81,12 +81,12 @@ defineProps({
   align-items: center;
   gap: 1rem;
   padding: 1rem 1.5rem;
-  background: #fee2e2;
+  background: var(--error-bg);
   border: 2px solid #ef4444;
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
   animation: pulse 2s infinite;
-  color: #991b1b;
+  color: var(--error-text);
 }
 
 @keyframes pulse {

--- a/src/components/evaluations/TakeResultModals.vue
+++ b/src/components/evaluations/TakeResultModals.vue
@@ -171,7 +171,7 @@ defineEmits(['close-confirm', 'submit', 'return'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: #fef3c7;
+  background: var(--warning-bg);
   color: #92400e;
   border-radius: 0.5rem;
   font-size: 0.875rem;

--- a/src/components/evaluations/TeacherEvalCreateModal.vue
+++ b/src/components/evaluations/TeacherEvalCreateModal.vue
@@ -168,8 +168,8 @@ defineEmits(['close', 'submit'])
 }
 
 .modal-info {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
+  background: var(--blue-50);
+  border: 1px solid var(--blue-200);
   border-radius: 0.5rem;
   padding: 1rem;
   margin-bottom: 1.5rem;
@@ -177,7 +177,7 @@ defineEmits(['close', 'submit'])
 
 .info-text {
   font-size: 0.875rem;
-  color: #1e40af;
+  color: var(--info-text);
   margin: 0.25rem 0;
 }
 
@@ -263,7 +263,7 @@ defineEmits(['close', 'submit'])
 }
 
 .btn-submit {
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
 }
 

--- a/src/components/modals/GenerateReportModal.vue
+++ b/src/components/modals/GenerateReportModal.vue
@@ -255,13 +255,13 @@ onMounted(() => {
 .form-input:focus,
 .form-select:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
 .error-message {
   padding: 0.75rem;
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #dc2626;
   border-radius: 0.5rem;
   font-size: 0.875rem;
@@ -269,14 +269,14 @@ onMounted(() => {
 
 .info-box {
   padding: 0.75rem;
-  background: #dbeafe;
-  border-left: 4px solid #3b82f6;
+  background: var(--info-bg);
+  border-left: 4px solid var(--blue-500);
   border-radius: 0.5rem;
 }
 
 .info-box p {
   margin: 0;
   font-size: 0.875rem;
-  color: #1e40af;
+  color: var(--info-text);
 }
 </style>

--- a/src/components/modals/QuickAddTeacherModal.vue
+++ b/src/components/modals/QuickAddTeacherModal.vue
@@ -238,7 +238,7 @@ onMounted(() => {
 .form-input:focus,
 .form-select:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -258,7 +258,7 @@ onMounted(() => {
 
 .error-message {
   padding: 0.75rem;
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #dc2626;
   border-radius: 0.5rem;
   font-size: 0.875rem;

--- a/src/components/modals/QuickCreateClasseModal.vue
+++ b/src/components/modals/QuickCreateClasseModal.vue
@@ -242,7 +242,7 @@ onMounted(() => {
 .form-input:focus,
 .form-select:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -272,7 +272,7 @@ onMounted(() => {
 
 .error-message {
   padding: 0.75rem;
-  background: #fee2e2;
+  background: var(--error-bg);
   color: #dc2626;
   border-radius: 0.5rem;
   font-size: 0.875rem;

--- a/src/components/widgets/CalendarWidget.vue
+++ b/src/components/widgets/CalendarWidget.vue
@@ -211,7 +211,7 @@ const {
 
 /* Event Styles */
 :deep(.event-seance) {
-  background: #3b82f6 !important;
+  background: var(--blue-500) !important;
   border-color: #2563eb !important;
 }
 

--- a/src/components/widgets/CalendarWidgetLegend.vue
+++ b/src/components/widgets/CalendarWidgetLegend.vue
@@ -45,7 +45,7 @@
 }
 
 .legend-dot.seance {
-  background: #3b82f6;
+  background: var(--blue-500);
 }
 
 .legend-dot.evaluation {

--- a/src/components/widgets/NotificationItem.vue
+++ b/src/components/widgets/NotificationItem.vue
@@ -101,8 +101,8 @@ function getIconComponent(iconName) {
 }
 
 .notification-item.unread {
-  background: linear-gradient(90deg, #eff6ff 0%, transparent 100%);
-  border-left: 3px solid #3b82f6;
+  background: linear-gradient(90deg, var(--blue-50) 0%, transparent 100%);
+  border-left: 3px solid var(--blue-500);
 }
 
 .notification-icon {
@@ -116,8 +116,8 @@ function getIconComponent(iconName) {
 }
 
 .type-info {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .type-success {
@@ -126,13 +126,13 @@ function getIconComponent(iconName) {
 }
 
 .type-warning {
-  background: #fef3c7;
+  background: var(--warning-bg);
   color: #92400e;
 }
 
 .type-danger {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--error-bg);
+  color: var(--error-text);
 }
 
 .notification-content {
@@ -202,7 +202,7 @@ function getIconComponent(iconName) {
 }
 
 .delete-btn:hover {
-  background: #fee2e2;
+  background: var(--error-bg);
   border-color: #ef4444;
 }
 


### PR DESCRIPTION
…omponents/evaluations + widgets + modals (#128)

Remplacement mécanique des seules correspondances EXACTES (zéro changement visuel en mode clair, aucune couleur nouvelle) selon l'inventaire #106, re-grep sur dev courant (n° de ligne du doc périmés après décomposition) :
- #eff6ff -> var(--blue-50), #bfdbfe -> var(--blue-200), #60a5fa -> var(--blue-400), #3b82f6 -> var(--blue-500)
- #dbeafe -> var(--info-bg), #1e40af -> var(--info-text)
- #dcfce7 -> var(--success-bg), #166534 -> var(--success-text), #86efac -> var(--success-border)
- #fef3c7 -> var(--warning-bg)
- #fee2e2 -> var(--error-bg), #991b1b -> var(--error-text)

13 fichiers, 40 remplacements (evaluations, widgets, modals).

Volontairement non migré (dette tracée) : approximations (≈) qui décaleraient la teinte même en clair, valeurs sans token (⚠ violets/indigos), rgba() d'ombres/overlays/keyframes, et fallbacks var(--x, #hex) déjà tokenisés.