### PR TITLE
chore(theme): tokens exacts components/calendar (#126, T4b)

### DIFF
--- a/src/components/calendar/CalendarFilters.vue
+++ b/src/components/calendar/CalendarFilters.vue
@@ -108,25 +108,18 @@ defineEmits(['reset', 'apply-preset'])
 // Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé ;
 // les couleurs « système » passent par les CSS custom properties globales var(--…)).
 $lms-blue: #2563eb;
-$lms-blue-light: #3b82f6;
 $lms-blue-dark: #1e3a8a;
 $white: #ffffff;
-$text-primary: #1E293B;
-$text-secondary: #64748B;
-$text-tertiary: #6B7280;
-$gray-light: #F8FAFC;
-$gray-border: #E5E7EB;
-$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
 $transition-fast: all 0.2s ease;
 $border-radius-md: 6px;
 $border-radius-lg: 8px;
 $border-radius-full: 9999px;
 
 .card {
-  background: var(--card-bg, $white);
-  border: 1px solid var(--card-border, transparent);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: $border-radius-lg;
-  box-shadow: var(--card-shadow, $shadow-light);
+  box-shadow: var(--card-shadow);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
   transition: background 0.2s ease, border-color 0.2s ease;
@@ -164,14 +157,14 @@ $border-radius-full: 9999px;
       padding: 0.5rem 1rem;
       border: none;
       background: transparent;
-      color: var(--text-tertiary, $text-tertiary);
+      color: var(--text-tertiary);
       cursor: pointer;
       transition: $transition-fast;
       border-radius: $border-radius-md;
       font-weight: 500;
 
       &:hover {
-        background: var(--bg-hover, $gray-light);
+        background: var(--bg-hover);
         color: $lms-blue;
       }
     }
@@ -191,7 +184,7 @@ $border-radius-full: 9999px;
       label {
         font-size: 0.875rem;
         font-weight: 500;
-        color: var(--text-secondary, $text-secondary);
+        color: var(--text-secondary);
         display: flex;
         align-items: center;
         gap: 0.5rem;
@@ -204,21 +197,21 @@ $border-radius-full: 9999px;
 
       select {
         padding: 0.75rem 1rem;
-        border: 1px solid var(--input-border, $gray-border);
+        border: 1px solid var(--input-border);
         border-radius: $border-radius-md;
-        background: var(--input-bg, $white);
-        color: var(--input-text, $text-primary);
+        background: var(--input-bg);
+        color: var(--input-text);
         font-size: 0.875rem;
         cursor: pointer;
         transition: $transition-fast;
 
         option {
-          background: var(--bg-primary, $white);
-          color: var(--text-primary, $text-primary);
+          background: var(--bg-primary);
+          color: var(--text-primary);
         }
 
         &:hover {
-          border-color: $lms-blue-light;
+          border-color: var(--blue-500);
         }
 
         &:focus {

--- a/src/components/calendar/CalendarLegend.vue
+++ b/src/components/calendar/CalendarLegend.vue
@@ -36,20 +36,14 @@
 <style lang="scss" scoped>
 // Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
 $lms-blue: #2563eb;
-$white: #ffffff;
-$text-primary: #1E293B;
-$gray-lightest: #F9FAFB;
-$gray-border: #E5E7EB;
-$gray-dark: #374151;
-$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
 $border-radius-lg: 8px;
 
 // ========== CARD BASE ==========
 .card {
-  background: var(--card-bg, $white);
-  border: 1px solid var(--card-border, transparent);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: $border-radius-lg;
-  box-shadow: var(--card-shadow, $shadow-light);
+  box-shadow: var(--card-shadow);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
   transition: background 0.2s ease, border-color 0.2s ease;
@@ -83,9 +77,9 @@ $border-radius-lg: 8px;
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem;
-    background: var(--bg-tertiary, $gray-lightest);
+    background: var(--bg-tertiary);
     border-radius: $border-radius-lg;
-    border: 1px solid var(--border-primary, $gray-border);
+    border: 1px solid var(--border-primary);
 
     .color-dot {
       width: 16px;
@@ -95,7 +89,7 @@ $border-radius-lg: 8px;
 
     span {
       font-size: 0.875rem;
-      color: var(--text-primary, $gray-dark);
+      color: var(--text-primary);
       font-weight: 500;
     }
   }

--- a/src/components/calendar/CalendarNavigation.vue
+++ b/src/components/calendar/CalendarNavigation.vue
@@ -52,21 +52,16 @@ defineEmits(['previous', 'next', 'today', 'refresh', 'change-view'])
 // Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
 $lms-blue: #2563eb;
 $white: #ffffff;
-$text-primary: #1E293B;
-$text-tertiary: #6B7280;
-$gray-light: #F8FAFC;
-$gray-border: #E5E7EB;
-$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
 $transition-fast: all 0.2s ease;
 $border-radius-md: 6px;
 $border-radius-lg: 8px;
 
 // ========== CARD BASE ==========
 .card {
-  background: var(--card-bg, $white);
-  border: 1px solid var(--card-border, transparent);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: $border-radius-lg;
-  box-shadow: var(--card-shadow, $shadow-light);
+  box-shadow: var(--card-shadow);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
   transition: background 0.2s ease, border-color 0.2s ease;
@@ -88,20 +83,20 @@ $border-radius-lg: 8px;
       justify-content: center;
       width: 40px;
       height: 40px;
-      border: 1px solid var(--border-primary, $gray-border);
+      border: 1px solid var(--border-primary);
       border-radius: $border-radius-md;
       background: transparent;
-      color: var(--text-primary, $text-primary);
+      color: var(--text-primary);
       cursor: pointer;
       transition: $transition-fast;
 
       .material-icons {
         font-size: 1.5rem;
-        color: var(--text-primary, $text-primary);
+        color: var(--text-primary);
       }
 
       &:hover {
-        background: var(--bg-hover, $gray-light);
+        background: var(--bg-hover);
         border-color: $lms-blue;
         color: $lms-blue;
 
@@ -211,7 +206,6 @@ $border-radius-lg: 8px;
 
 <!-- Styles mode sombre non-scoped pour fonctionner avec data-theme -->
 <style lang="scss">
-$lms-blue: #2563eb;
 $lms-blue-light: #3b82f6;
 $white: #ffffff;
 

--- a/src/components/calendar/CalendarView.vue
+++ b/src/components/calendar/CalendarView.vue
@@ -39,23 +39,17 @@ defineExpose({
 <style lang="scss" scoped>
 // Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
 $lms-blue: #2563eb;
-$lms-blue-light: #3b82f6;
 $white: #ffffff;
-$text-primary: #1E293B;
-$text-secondary: #64748B;
-$text-tertiary: #6B7280;
-$gray-border: #E5E7EB;
-$shadow-light: 0 1px 3px rgba(0, 0, 0, 0.1);
 $shadow-hover: 0 4px 12px rgba(0, 0, 0, 0.1);
 $transition-fast: all 0.2s ease;
 $border-radius-lg: 8px;
 
 // ========== CARD BASE ==========
 .card {
-  background: var(--card-bg, $white);
-  border: 1px solid var(--card-border, transparent);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: $border-radius-lg;
-  box-shadow: var(--card-shadow, $shadow-light);
+  box-shadow: var(--card-shadow);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
   transition: background 0.2s ease, border-color 0.2s ease;
@@ -74,7 +68,7 @@ $border-radius-lg: 8px;
 .loading-container {
   padding: 4rem;
   text-align: center;
-  color: var(--text-tertiary, $text-tertiary);
+  color: var(--text-tertiary);
 
   .material-icons {
     font-size: 3rem;
@@ -88,7 +82,7 @@ $border-radius-lg: 8px;
 
   p {
     font-size: 1rem;
-    color: var(--text-secondary, $text-secondary);
+    color: var(--text-secondary);
   }
 }
 
@@ -115,8 +109,8 @@ $border-radius-lg: 8px;
     transition: $transition-fast;
 
     &:hover:not(:disabled) {
-      background: $lms-blue-light;
-      border-color: $lms-blue-light;
+      background: var(--blue-500);
+      border-color: var(--blue-500);
     }
 
     &:focus {
@@ -139,14 +133,14 @@ $border-radius-lg: 8px;
   // Cases des jours
   .fc-daygrid-day,
   .fc-timegrid-slot {
-    background: var(--bg-secondary, $white);
-    border-color: var(--border-primary, $gray-border);
+    background: var(--bg-secondary);
+    border-color: var(--border-primary);
   }
 
   // Numéros des jours
   .fc-daygrid-day-number,
   .fc-timegrid-slot-label {
-    color: var(--text-primary, $text-primary);
+    color: var(--text-primary);
     padding: 0.5rem;
   }
 

--- a/src/components/calendar/CalendarViewSelector.vue
+++ b/src/components/calendar/CalendarViewSelector.vue
@@ -43,14 +43,8 @@ defineEmits(['change-view'])
 
 <style lang="scss" scoped>
 // Variables LMS nécessaires à ce composant (copie locale du sous-ensemble utilisé).
-$lms-blue: #2563eb;
 $lms-blue-dark: #1e3a8a;
 $white: #ffffff;
-$text-tertiary: #6B7280;
-$gray-lightest: #F9FAFB;
-$gray-medium: #E2E8F0;
-$gray-border: #E5E7EB;
-$gray-dark: #374151;
 $transition-fast: all 0.2s ease;
 $border-radius-md: 6px;
 $border-radius-lg: 8px;
@@ -58,10 +52,10 @@ $border-radius-lg: 8px;
 .view-selector {
   display: flex;
   gap: 0.5rem;
-  border: 1px solid var(--border-primary, $gray-border);
+  border: 1px solid var(--border-primary);
   border-radius: $border-radius-lg;
   padding: 0.25rem;
-  background: var(--bg-tertiary, $gray-lightest);
+  background: var(--bg-tertiary);
 
   button {
     display: flex;
@@ -71,15 +65,15 @@ $border-radius-lg: 8px;
     border-radius: $border-radius-md;
     border: none;
     transition: $transition-fast;
-    color: var(--text-tertiary, $text-tertiary);
+    color: var(--text-tertiary);
     font-weight: 500;
     font-size: 0.875rem;
     cursor: pointer;
     background: transparent;
 
     &:hover {
-      background: var(--bg-hover, $gray-medium);
-      color: var(--text-primary, $gray-dark);
+      background: var(--bg-hover);
+      color: var(--text-primary);
     }
 
     &.active {

--- a/src/components/calendar/EventDetailActions.vue
+++ b/src/components/calendar/EventDetailActions.vue
@@ -133,7 +133,7 @@ defineEmits(['action'])
 .modal-footer {
   padding: 1.5rem;
   border-top: 1px solid var(--border-color, #e5e7eb);
-  background: var(--bg-secondary, #f9fafb);
+  background: var(--bg-secondary);
 }
 
 .action-buttons {
@@ -156,7 +156,7 @@ defineEmits(['action'])
 }
 
 .action-btn.primary {
-  background: var(--color-primary, #3b82f6);
+  background: var(--blue-500);
   color: white;
 }
 
@@ -183,24 +183,24 @@ defineEmits(['action'])
 }
 
 .action-btn.secondary {
-  background: var(--bg-secondary, #f3f4f6);
-  color: var(--text-primary, #111827);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   border: 1px solid var(--border-color, #e5e7eb);
 }
 
 .action-btn.secondary:hover {
-  background: var(--bg-primary, white);
-  border-color: var(--color-primary, #3b82f6);
+  background: var(--bg-primary);
+  border-color: var(--blue-500);
 }
 
 .action-btn.outline {
   background: transparent;
-  color: var(--color-primary, #3b82f6);
-  border: 1px solid var(--color-primary, #3b82f6);
+  color: var(--blue-500);
+  border: 1px solid var(--blue-500);
 }
 
 .action-btn.outline:hover {
-  background: var(--color-primary, #3b82f6);
+  background: var(--blue-500);
   color: white;
 }
 

--- a/src/components/calendar/EventDetailModal.vue
+++ b/src/components/calendar/EventDetailModal.vue
@@ -111,7 +111,7 @@ const {
 }
 
 .modal-container {
-  background: var(--bg-primary, white);
+  background: var(--bg-primary);
   border-radius: 1rem;
   box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
   max-width: 600px;
@@ -140,7 +140,7 @@ const {
 .modal-title {
   font-size: 1.25rem;
   font-weight: 700;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -173,7 +173,7 @@ const {
   flex-shrink: 0;
   background: transparent;
   border: none;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 0.25rem;
   border-radius: 0.375rem;
@@ -181,8 +181,8 @@ const {
 }
 
 .close-btn:hover {
-  background: var(--bg-secondary, #f3f4f6);
-  color: var(--text-primary, #111827);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 .modal-body {

--- a/src/components/calendar/EventEvaluationDetails.vue
+++ b/src/components/calendar/EventEvaluationDetails.vue
@@ -114,7 +114,7 @@ defineProps({
 .detail-icon {
   width: 1.25rem;
   height: 1.25rem;
-  color: var(--color-primary, #3b82f6);
+  color: var(--blue-500);
   flex-shrink: 0;
   margin-top: 0.125rem;
 }
@@ -122,13 +122,13 @@ defineProps({
 .detail-label {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   margin: 0 0 0.25rem 0;
 }
 
 .detail-value {
   font-size: 0.875rem;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -145,24 +145,24 @@ defineProps({
   gap: 0.5rem;
   font-size: 1rem;
   font-weight: 700;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0 0 1rem 0;
 }
 
 .result-score {
   font-size: 2.5rem;
   font-weight: 700;
-  color: var(--color-primary, #3b82f6);
+  color: var(--blue-500);
   text-align: center;
   margin: 1rem 0;
 }
 
 .score-value {
-  color: var(--color-primary, #3b82f6);
+  color: var(--blue-500);
 }
 
 .score-total {
   font-size: 1.5rem;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
 }
 </style>

--- a/src/components/calendar/EventSeanceDetails.vue
+++ b/src/components/calendar/EventSeanceDetails.vue
@@ -114,7 +114,7 @@ defineProps({
 .detail-icon {
   width: 1.25rem;
   height: 1.25rem;
-  color: var(--color-primary, #3b82f6);
+  color: var(--blue-500);
   flex-shrink: 0;
   margin-top: 0.125rem;
 }
@@ -122,13 +122,13 @@ defineProps({
 .detail-label {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--text-secondary, #6b7280);
+  color: var(--text-secondary);
   margin: 0 0 0.25rem 0;
 }
 
 .detail-value {
   font-size: 0.875rem;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -145,7 +145,7 @@ defineProps({
   gap: 0.5rem;
   font-size: 1rem;
   font-weight: 700;
-  color: var(--text-primary, #111827);
+  color: var(--text-primary);
   margin: 0 0 1rem 0;
 }
 


### PR DESCRIPTION
Ferme #126. Sous-lot de #114, dossiers disjoints des autres sous-lots.

## Méthode
Re-grep **sur le dev courant** (l'inventaire #106 était pré-décomposition #107 : il ne listait que 3 fichiers, le dossier en compte 10). Règle alignée sur le précédent mergé **#113 « tokens exacts »** : on ne remplace qu'une couleur dont la valeur **light-mode** de `themes.css` est **identique** au token. Les `≈`/`⚠` restent en dette tracée (extension de palette, T2).

`data-theme` est posé **avant le mount** (`main.js:37`) → les tokens sont toujours définis → les fallbacks `var(--token, $x)` sont morts : les retirer est **pixel-identique en clair ET sombre**.

## Changements (9 fichiers, 124 → 70 occurrences)
- **Fallbacks morts retirés** : `var(--card-bg, $white)` → `var(--card-bg)`, etc.
- **Remaps exacts** : `var(--color-primary, #3b82f6)` (token fantôme jamais défini) → `var(--blue-500)` ; `$lms-blue-light` (#3b82f6, usages clairs directs) → `var(--blue-500)`.
- **Déclarations SCSS de couleur orphelines supprimées.**
- **Contrainte SCSS respectée** : un `$var` consommé par `rgba($var, …)` n'est pas tokenisé (Sass casserait).

## Vérifications
- ✅ Les 9 blocs `<style lang="scss">` compilent (dart-sass).
- ✅ Aucune référence SCSS non déclarée.
- ✅ Clair inchangé au pixel (les fallbacks retirés ne gagnaient jamais).
- ⚠️ Build Vite complet non lancé : `node_modules` du worktree partiel (chunks Vite manquants).

## Dette laissée volontairement (T2 — extension de palette)
- Marque sans token exact : `#2563eb` (≈`--blue-600`), `#1e3a8a`, cyan `#06b6d4` ⚠, orange `#ea580c` ⚠, verts/rouges ≈.
- Texte blanc *on-color* `#ffffff` (`--bg-primary` flipperait en sombre).
- `rgba()` : overlays, ombres, anneaux de focus teintés.
- **Badges de statut** (`#dcfce7`/`#dbeafe`/`#fef3c7` + texte couplé) : fond à token exact mais texte `≈` → themer le seul fond régresserait le contraste en sombre, à traiter **en paire**.
- **En-tête des jours** (`#0052cc`/`#0747a6`, exacts) : gradient + texte blanc fixe → l'inversion de l'échelle bleue en sombre donnerait fond clair + texte blanc = régression.
- Tokens fantômes `--border-color`/`--color-primary-hover` et accents des blocs **dark** `$lms-blue-light`.

Hors périmètre : `src/assets/styles/calendar-fc-dark.scss` (partial dark importé par CalendarView).

🤖 Generated with [Claude Code](https://claude.com/claude-code)