### PR TITLE
chore(theme): tokens exacts sans impact visuel — components/ui + common (#127)

### DIFF
--- a/src/components/common/ContentLoader.vue
+++ b/src/components/common/ContentLoader.vue
@@ -144,7 +144,7 @@ defineProps({
 /* Texte de chargement */
 .loader-text {
   margin-top: 1.5rem;
-  color: #475569;
+  color: var(--text-secondary);
   font-size: 0.95rem;
   font-weight: 500;
   letter-spacing: 0.5px;

--- a/src/components/ui/BaseButton.vue
+++ b/src/components/ui/BaseButton.vue
@@ -69,7 +69,7 @@ const isDisabled = computed(() => props.disabled || props.loading)
 
 .base-btn--primary {
   background: var(--accent-primary, #4f46e5);
-  color: #fff;
+  color: var(--btn-primary-text);
 }
 
 .base-btn--primary:hover:not(:disabled) {
@@ -88,7 +88,7 @@ const isDisabled = computed(() => props.disabled || props.loading)
 
 .base-btn--danger {
   background: var(--danger, #dc2626);
-  color: #fff;
+  color: var(--btn-primary-text);
 }
 
 .base-btn--danger:hover:not(:disabled) {


### PR DESCRIPTION
## Sous-lot #127 (de #114) — `components/ui` + `components/common`

Remplacement **mécanique** des couleurs en dur par les tokens de [`themes.css`](src/assets/styles/themes.css), croisé avec l'inventaire #106. **Seules** les correspondances dont la valeur est identique au token **en clair ET en sombre** ont été migrées → **zéro changement visuel (light + dark)**, conforme au DoD.

### Diff (3 lignes, 2 fichiers)
| Fichier | Changement | Garantie « aucun changement visuel » |
|---|---|---|
| `ui/BaseButton.vue` | `color: #fff` → `var(--btn-primary-text)` (×2) | `--btn-primary-text` = `#ffffff` en clair **et** en sombre |
| `common/ContentLoader.vue` | `.loader-text` `#475569` → `var(--text-secondary)` | valeur light exacte ; règle **surchargée** par `:deep([data-theme="dark"])` → nulle en sombre |

### Volontairement NON migré (dette tracée)
- **Approximations `≈`** (teintes Tailwind/Material sans valeur identique) et **`⚠ aucun token`** (marque KLASSCI `#1B3B6F`/`#2D5A9E`/`#FFB81C`, violet/cyan, overlays/voiles `rgba`, ombres).
- **`#3b82f6` → `--blue-500`** dans `ProgressBar`/`QuickActionButton` et les **fonds de statut de `Toast`** : exclus car le token **décale le rendu sombre** (`--blue-500` = `#60a5fa`, `--error-bg`/`--info-bg`/`--warning-bg` deviennent translucides) — ces composants n'ont pas de bloc dark, une tokenisation y changerait le sombre. À traiter dans une passe dark dédiée (T2).
- **Fallbacks `var(--token, #hex)`** : laissés tels quels (pas de nettoyage hors périmètre).
- **`EditorTextGroup`** `value="#000000"`/`"#ffff00"` : valeurs par défaut d'`<input type=color>`, pas du style.

### Validation
- Mode clair : 0 changement (valeurs identiques).
- Mode sombre : 0 changement (blanc stable / règle surchargée).
- `vite build` : ✅ OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)