### PR TITLE
chore(theme): tokens sémantiques + palette brute manquante (#136)

### DIFF
--- a/src/assets/styles/themes.css
+++ b/src/assets/styles/themes.css
@@ -54,6 +54,112 @@
   --z-modal: 1050;
   --z-popover: 1060;
   --z-tooltip: 1070;
+
+  /* ========================================
+     RAW ACCENT PALETTE (theme-invariant)
+     Tailwind-canonical scales recurring across components/ that the
+     surface-oriented --blue-* scale (defined per-theme below) does not
+     cover. Like the other tokens in :root (spacing, radius, shadows),
+     these accent hues are theme-invariant: a status accent keeps its
+     meaning in light and dark. Theme adaptation is handled by the
+     semantic surface tokens (--success-bg, --error-text, …).
+     Tones already tokenised as a status token are cross-referenced
+     rather than re-declared (no duplicate values).
+     ======================================== */
+
+  /* Emerald — success / positive accent (#10b981 &c.) */
+  --emerald-50: #ecfdf5;
+  --emerald-100: #d1fae5;
+  --emerald-200: #a7f3d0;
+  --emerald-300: #6ee7b7;
+  --emerald-400: #34d399;
+  --emerald-500: #10b981;
+  --emerald-600: #059669;
+  --emerald-700: #047857;
+  --emerald-800: #065f46;
+  --emerald-900: #064e3b;
+
+  /* Red — danger / destructive accent.
+     100 → --error-bg (#fee2e2) · 300 → --error-border (#fca5a5) · 800 → --error-text (#991b1b) */
+  --red-50: #fef2f2;
+  --red-200: #fecaca;
+  --red-400: #f87171;
+  --red-500: #ef4444;
+  --red-600: #dc2626;
+  --red-700: #b91c1c;
+  --red-900: #7f1d1d;
+
+  /* Amber — warning accent.
+     100 → --warning-bg (#fef3c7) */
+  --amber-50: #fffbeb;
+  --amber-200: #fde68a;
+  --amber-300: #fcd34d;
+  --amber-400: #fbbf24;
+  --amber-500: #f59e0b;
+  --amber-600: #d97706;
+  --amber-700: #b45309;
+  --amber-800: #92400e;
+  --amber-900: #78350f;
+
+  /* Indigo — secondary accent (#6366f1 &c.) */
+  --indigo-50: #eef2ff;
+  --indigo-100: #e0e7ff;
+  --indigo-200: #c7d2fe;
+  --indigo-300: #a5b4fc;
+  --indigo-400: #818cf8;
+  --indigo-500: #6366f1;
+  --indigo-600: #4f46e5;
+  --indigo-700: #4338ca;
+  --indigo-800: #3730a3;
+  --indigo-900: #312e81;
+
+  /* Violet — secondary accent (#8b5cf6 &c.); recurring purple tones consolidate here */
+  --violet-50: #f5f3ff;
+  --violet-100: #ede9fe;
+  --violet-200: #ddd6fe;
+  --violet-300: #c4b5fd;
+  --violet-400: #a78bfa;
+  --violet-500: #8b5cf6;
+  --violet-600: #7c3aed;
+  --violet-700: #6d28d9;
+  --violet-800: #5b21b6;
+  --violet-900: #4c1d95;
+
+  /* ========================================
+     SEMANTIC COLOR NAMESPACE (--color-*)
+     Intention-revealing aliases. Solid accents point at the raw scale
+     above; -bg/-border/-text reuse the existing per-theme status tokens
+     so they adapt automatically in dark mode (no values duplicated).
+     "danger" maps to the existing "error" surface tokens.
+     ======================================== */
+
+  /* Success */
+  --color-success: var(--emerald-500);
+  --color-success-strong: var(--emerald-600);
+  --color-success-bg: var(--success-bg);
+  --color-success-border: var(--success-border);
+  --color-success-text: var(--success-text);
+
+  /* Danger (a.k.a. error) */
+  --color-danger: var(--red-500);
+  --color-danger-strong: var(--red-600);
+  --color-danger-bg: var(--error-bg);
+  --color-danger-border: var(--error-border);
+  --color-danger-text: var(--error-text);
+
+  /* Warning */
+  --color-warning: var(--amber-500);
+  --color-warning-strong: var(--amber-600);
+  --color-warning-bg: var(--warning-bg);
+  --color-warning-border: var(--warning-border);
+  --color-warning-text: var(--warning-text);
+
+  /* Info — solid tracks the per-theme brand blue (#3b82f6 light / #60a5fa dark) */
+  --color-info: var(--blue-500);
+  --color-info-strong: #2563eb;
+  --color-info-bg: var(--info-bg);
+  --color-info-border: var(--info-border);
+  --color-info-text: var(--info-text);
 }
 
 /* ========================================


### PR DESCRIPTION
Closes #136. Fondation du round correctif #114.

## Périmètre
**Un seul fichier** : `src/assets/styles/themes.css`. **+106 lignes, additif.** Aucun `.vue` touché, aucun token existant altéré.

## Démarche (mesurée)
Re-grep réel de `src/components/**/*.vue` (audit v2 #135 pas encore livré) croisé avec l'audit #106. Familles récurrentes sans token : emerald `#10b981` (64×), red `#ef4444` (48×), indigo `#6366f1` (33×), violet `#8b5cf6` (32×), amber `#f59e0b` (30×), `#2563eb` (66×). Et aucun accent **solide** n'existait (seulement surfaces `--success-bg/-border/-text`).

## Architecture (couches de design tokens)
1. **Palette brute** `--emerald/red/amber/indigo/violet-50…900` (Tailwind canonique) dans `:root`, theme-invariant — comme les autres tokens invariants déjà dans `:root`. Tons déjà tokenisés **omis avec renvoi** (`--red-100`=`--error-bg`, `-300`=`--error-border`, `-800`=`--error-text`, `--amber-100`=`--warning-bg`) → zéro valeur dupliquée.
2. **Namespace `--color-*`** (`success/danger/warning/info` + `-strong` + `-bg/-border/-text`) en **références** : solides → palette brute, surfaces → tokens de statut existants. Theme-awareness via les références (`--color-success-bg`→`rgba(34,197,94,.1)` en dark ; `--color-info`→`#3b82f6` light / `#60a5fa` dark).

## Décisions déclarées
- **green→emerald** : tons Tailwind *green* (`#22c55e`/`#16a34a`/`#15803d`, ~40 occ.) sans scale séparée (dupliquerait `--success-*`) → consolidés sur emerald en #114 (normalisation visuelle légère, révisable).
- **purple→violet** : `#a855f7`/`#9333ea` → violet (quasi-identiques).
- **`--color-info-strong: #2563eb`** littéral (`--blue-600` = marque `#0052cc`).

## Validation
PostCSS parse OK · 34 `var()` toutes résolues (0 manquant) · braces 35/35.

## DoD
- [x] Tout hex récurrent a un token cible (light+dark).
- [x] Aucun token dupliqué ; conventions existantes réutilisées.
- [x] Aucun `.vue` modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)