### PR TITLE
chore(theme): tokens exacts components/admin sans impact visuel (#137)

### DIFF
--- a/src/components/admin/ClassCard.vue
+++ b/src/components/admin/ClassCard.vue
@@ -112,20 +112,20 @@ defineEmits(['view'])
   font-weight: 600;
 }
 .badge-filiere {
-  background: #e0e7ff;
-  color: #5b21b6;
+  background: var(--indigo-100);
+  color: var(--violet-800);
 }
 .badge-niveau {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--amber-800);
 }
 .active-badge {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.375rem 0.75rem;
-  background: #dcfce7;
-  color: #15803d;
+  background: var(--success-bg);
+  color: var(--emerald-700);
   border-radius: 0.5rem;
   font-size: 0.75rem;
   font-weight: 600;
@@ -134,7 +134,7 @@ defineEmits(['view'])
 .pulse-dot {
   width: 0.5rem;
   height: 0.5rem;
-  background: #22c55e;
+  background: var(--emerald-500);
   border-radius: 50%;
   animation: pulse 2s infinite;
 }
@@ -211,12 +211,12 @@ defineEmits(['view'])
   transition: all 0.2s;
 }
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
 }
 .btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
 }

--- a/src/components/admin/ClassesStatsCards.vue
+++ b/src/components/admin/ClassesStatsCards.vue
@@ -71,19 +71,19 @@ defineProps({
 }
 
 .border-l-blue {
-  border-left-color: #3b82f6;
+  border-left-color: var(--blue-500);
 }
 
 .border-l-green {
-  border-left-color: #10b981;
+  border-left-color: var(--emerald-500);
 }
 
 .border-l-purple {
-  border-left-color: #8b5cf6;
+  border-left-color: var(--violet-500);
 }
 
 .border-l-orange {
-  border-left-color: #f59e0b;
+  border-left-color: var(--amber-500);
 }
 
 .stat-header {

--- a/src/components/admin/ConnectionResultModal.vue
+++ b/src/components/admin/ConnectionResultModal.vue
@@ -60,10 +60,10 @@ defineEmits(['close'])
   margin-bottom: var(--spacing-md);
 }
 .connection-success .connection-icon {
-  color: #22c55e;
+  color: var(--emerald-500);
 }
 .connection-error .connection-icon {
-  color: #ef4444;
+  color: var(--red-500);
 }
 .connection-message {
   font-size: var(--font-size-lg);

--- a/src/components/admin/EnseignantCard.vue
+++ b/src/components/admin/EnseignantCard.vue
@@ -200,13 +200,13 @@ defineEmits(['view'])
 }
 
 .tag-classe {
-  background: #f0fdf4;
-  color: #15803d;
+  background: var(--emerald-50);
+  color: var(--emerald-700);
 }
 
 :global(.dark) .tag-classe {
   background: rgba(34, 197, 94, 0.2);
-  color: #86efac;
+  color: var(--success-border);
 }
 
 /* View Details Button */
@@ -226,7 +226,7 @@ defineEmits(['view'])
 }
 
 .view-details-btn:hover {
-  background: #3b82f6;
+  background: var(--blue-500);
   color: white;
   transform: translateY(-2px);
 }

--- a/src/components/admin/EnseignantClassesList.vue
+++ b/src/components/admin/EnseignantClassesList.vue
@@ -61,13 +61,13 @@ defineProps({ classes: { type: Array, default: () => [] } })
 }
 
 .badge-filiere {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .badge-niveau {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--amber-800);
 }
 
 .no-data {

--- a/src/components/admin/EvaluationResultsTable.vue
+++ b/src/components/admin/EvaluationResultsTable.vue
@@ -191,19 +191,19 @@ defineEmits(['export'])
 }
 
 .note-excellent {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 .note-good {
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .note-average {
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .note-poor {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .empty-state {

--- a/src/components/admin/HubCard.vue
+++ b/src/components/admin/HubCard.vue
@@ -85,15 +85,15 @@ defineProps({
 }
 
 .classes-icon {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
 }
 
 .matieres-icon {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: linear-gradient(135deg, var(--amber-500) 0%, var(--amber-600) 100%);
 }
 
 .enseignants-icon {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: linear-gradient(135deg, var(--emerald-500) 0%, var(--emerald-600) 100%);
 }
 
 .card-content {

--- a/src/components/admin/InstitutionFormModal.vue
+++ b/src/components/admin/InstitutionFormModal.vue
@@ -171,7 +171,7 @@ defineEmits(['close', 'save'])
 }
 .form-input:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
 }
 .input-readonly {
@@ -237,7 +237,7 @@ defineEmits(['close', 'save'])
   box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
 .toggle-input:checked + .toggle-switch {
-  background: #22c55e;
+  background: var(--emerald-500);
 }
 .toggle-input:checked + .toggle-switch::after {
   transform: translateX(20px);
@@ -257,7 +257,7 @@ defineEmits(['close', 'save'])
 }
 .form-error-item {
   font-size: var(--font-size-sm);
-  color: #dc2626;
+  color: var(--red-600);
   margin-bottom: var(--spacing-xs);
 }
 .form-error-item:last-child {

--- a/src/components/admin/InstitutionsStatsCards.vue
+++ b/src/components/admin/InstitutionsStatsCards.vue
@@ -59,21 +59,21 @@ defineProps({
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  background: linear-gradient(135deg, var(--indigo-500), var(--indigo-600));
   color: white;
   border-radius: var(--radius-lg);
 }
 
 .stat-icon-green {
-  background: linear-gradient(135deg, #22c55e, #16a34a);
+  background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600));
 }
 
 .stat-icon-blue {
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
+  background: linear-gradient(135deg, var(--blue-500), var(--color-info-strong));
 }
 
 .stat-icon-purple {
-  background: linear-gradient(135deg, #a855f7, #9333ea);
+  background: linear-gradient(135deg, var(--violet-500), var(--violet-600));
 }
 
 .stat-value {

--- a/src/components/admin/InstitutionsTable.vue
+++ b/src/components/admin/InstitutionsTable.vue
@@ -196,7 +196,7 @@ function formatDate(dateStr) {
 
 .status-active {
   background: rgba(34, 197, 94, 0.1);
-  color: #16a34a;
+  color: var(--emerald-600);
 }
 
 .status-inactive {
@@ -239,7 +239,7 @@ function formatDate(dateStr) {
 }
 
 .action-btn-green {
-  color: #16a34a;
+  color: var(--emerald-600);
 }
 
 .action-btn-gray {
@@ -247,7 +247,7 @@ function formatDate(dateStr) {
 }
 
 .action-btn-blue {
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 /* Responsive */

--- a/src/components/admin/ProfileActionsCard.vue
+++ b/src/components/admin/ProfileActionsCard.vue
@@ -76,7 +76,7 @@ import {
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #8b5cf6;
+  color: var(--violet-500);
 }
 
 .card-title {
@@ -111,7 +111,7 @@ import {
 
 .action-button:hover {
   background: linear-gradient(135deg, rgba(139, 92, 246, 0.1) 0%, rgba(124, 58, 237, 0.05) 100%);
-  border-color: #8b5cf6;
+  border-color: var(--violet-500);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(139, 92, 246, 0.2);
 }
@@ -119,7 +119,7 @@ import {
 .action-icon {
   width: 2rem;
   height: 2rem;
-  color: #8b5cf6;
+  color: var(--violet-500);
   flex-shrink: 0;
 }
 

--- a/src/components/admin/ProfileInfoCard.vue
+++ b/src/components/admin/ProfileInfoCard.vue
@@ -94,7 +94,7 @@ defineProps({
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #8b5cf6;
+  color: var(--violet-500);
 }
 
 .card-title {
@@ -122,7 +122,7 @@ defineProps({
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%);
+  background: linear-gradient(135deg, var(--violet-500) 0%, var(--violet-600) 100%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -177,7 +177,7 @@ defineProps({
 .info-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #8b5cf6;
+  color: var(--violet-500);
   flex-shrink: 0;
   margin-top: 0.25rem;
 }

--- a/src/components/admin/ProfilePermissionsCard.vue
+++ b/src/components/admin/ProfilePermissionsCard.vue
@@ -50,7 +50,7 @@ defineProps({
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #8b5cf6;
+  color: var(--violet-500);
 }
 
 .card-title {
@@ -74,10 +74,10 @@ defineProps({
 .permission-badge {
   padding: 0.5rem 1rem;
   background: linear-gradient(135deg, rgba(139, 92, 246, 0.1) 0%, rgba(124, 58, 237, 0.05) 100%);
-  border: 1px solid #8b5cf6;
+  border: 1px solid var(--violet-500);
   border-radius: 9999px;
   font-size: 0.875rem;
   font-weight: 600;
-  color: #8b5cf6;
+  color: var(--violet-500);
 }
 </style>

--- a/src/components/admin/ProfileStatsCard.vue
+++ b/src/components/admin/ProfileStatsCard.vue
@@ -83,7 +83,7 @@ defineProps({
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #8b5cf6;
+  color: var(--violet-500);
 }
 
 .card-title {

--- a/src/components/admin/SeancesList.vue
+++ b/src/components/admin/SeancesList.vue
@@ -192,13 +192,13 @@ function formatTime(dateString) {
 }
 
 .status-active {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
 }
 
 .status-scheduled {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .status-completed {

--- a/src/components/admin/SettingsNotifications.vue
+++ b/src/components/admin/SettingsNotifications.vue
@@ -154,7 +154,7 @@ const emit = defineEmits(['save'])
 }
 
 input:checked + .toggle-slider {
-  background-color: #3b82f6;
+  background-color: var(--blue-500);
 }
 
 input:checked + .toggle-slider:before {

--- a/src/components/admin/SettingsPasswordModal.vue
+++ b/src/components/admin/SettingsPasswordModal.vue
@@ -91,7 +91,7 @@ const emit = defineEmits(['submit'])
 
 .form-input:focus {
   outline: none;
-  border-color: #3B82F6;
+  border-color: var(--blue-500);
 }
 
 .form-input::placeholder {
@@ -109,12 +109,12 @@ const emit = defineEmits(['submit'])
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: scale(1.02);
 }
 

--- a/src/components/admin/SettingsSession.vue
+++ b/src/components/admin/SettingsSession.vue
@@ -75,12 +75,12 @@ const emit = defineEmits(['logout'])
 }
 
 .btn-danger {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  background: linear-gradient(135deg, var(--red-500) 0%, var(--red-600) 100%);
   color: white;
 }
 
 .btn-danger:hover {
-  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  background: linear-gradient(135deg, var(--red-600) 0%, var(--red-700) 100%);
   transform: scale(1.02);
 }
 </style>

--- a/src/components/admin/StatsMainGrid.vue
+++ b/src/components/admin/StatsMainGrid.vue
@@ -129,19 +129,19 @@ defineProps({
 }
 
 .stat-card-large.blue {
-  border-left-color: #3b82f6;
+  border-left-color: var(--blue-500);
 }
 
 .stat-card-large.purple {
-  border-left-color: #8b5cf6;
+  border-left-color: var(--violet-500);
 }
 
 .stat-card-large.green {
-  border-left-color: #10b981;
+  border-left-color: var(--emerald-500);
 }
 
 .stat-card-large.orange {
-  border-left-color: #f59e0b;
+  border-left-color: var(--amber-500);
 }
 
 .stat-header {

--- a/src/components/admin/VisioGrid.vue
+++ b/src/components/admin/VisioGrid.vue
@@ -159,13 +159,13 @@ defineEmits(['join', 'view'])
 }
 
 .status-active {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
 }
 
 .status-scheduled {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .status-completed {

--- a/src/components/admin/VisioStatsCards.vue
+++ b/src/components/admin/VisioStatsCards.vue
@@ -88,11 +88,11 @@ defineProps({
 }
 
 .stat-icon-wrapper.active {
-  background: #dcfce7;
+  background: var(--success-bg);
 }
 
 .stat-icon-wrapper.scheduled {
-  background: #dbeafe;
+  background: var(--info-bg);
 }
 
 .stat-icon-wrapper.completed {
@@ -100,7 +100,7 @@ defineProps({
 }
 
 .stat-icon-wrapper.total {
-  background: #fef3c7;
+  background: var(--warning-bg);
 }
 
 .stat-icon {
@@ -109,11 +109,11 @@ defineProps({
 }
 
 .stat-icon-wrapper.active .stat-icon {
-  color: #166534;
+  color: var(--success-text);
 }
 
 .stat-icon-wrapper.scheduled .stat-icon {
-  color: #1e40af;
+  color: var(--info-text);
 }
 
 .stat-icon-wrapper.completed .stat-icon {
@@ -121,7 +121,7 @@ defineProps({
 }
 
 .stat-icon-wrapper.total .stat-icon {
-  color: #b45309;
+  color: var(--amber-700);
 }
 
 .stat-content {


### PR DESCRIPTION
## #137 — Tokens (correctif) : `src/components/admin/**`

Round correctif #114. Base : **#135** (audit v2) + **#136** (palette brute + tokens sémantiques), tous deux sur `dev`. Périmètre strict `src/components/admin/**`, dossiers disjoints des autres lots G.

### Méthode
Re-grep du périmètre sur `dev` courant, puis remplacement **mécanique** par le `var(--…)` **exact** de `src/assets/styles/themes.css`, en suivant `docs/theme-hardcoded-colors-v2.md`. **86 occurrences migrées sur 21 fichiers** (74 lignes, diff strictement équilibré 74+/74−, aucun changement structurel).

| Bucket | Occ. | Traitement |
|---|---|---|
| **A — token exact** | 74 | Palette brute *theme-invariant* (`emerald/red/amber/indigo/violet`, `--color-info-strong`) → **pixel identique light & dark**. Tokens per-theme statut/info/blue (`--success-bg/-text`, `--info-bg/-text`, `--warning-bg`, `--success-border`, `--blue-500`) sur badges/états vérifiés en contexte. |
| **B — consolidation #136** | 12 | `green→--emerald-*`, `purple→--violet-*` (`#22c55e/#16a34a/#15803d/#f0fdf4`, `#a855f7/#9333ea`), comme décrété en #136. Léger shift de teinte assumé par cette décision. |

### ⚠️ Laissé intact — à signaler (dette tracée)

- **Bucket C — 29 hex solides sans token cible** : gris Tailwind `#6b7280 #f3f4f6 #9ca3af #d1d5db #ccc #4a90e2 #5a9df2`, sky/cyan `#0369a1 #075985 #0c4a6e #e0f2fe #7dd3fc #bae6fd #f0f9ff`, `#1d4ed8`, et `#ffffff` (MatieresTable:94, couplé au header gradient sky lui-même bucket C).
  👉 L'audit #135 les annonçait « besoin token #136 », **mais #136 n'a créé que `emerald/red/amber/indigo/violet`** — pas d'échelle gray ni sky. **Dette : ajouter les familles gray + sky dans `themes.css` avant de tokeniser ce bucket.** Les remplacer ici aurait introduit un changement visuel (slate ≠ gray) ou des tokens inventés.
- **Bucket D — 41 `rgba()` d'ombres/overlays** sans token (règle de l'issue).
- **8 exclus par l'audit** : fallbacks `var(--…, #hex)` (HubCard), `placeholder="#3b82f6"`, `:style` dynamiques.

### Validation
- 25 tokens introduits → **tous résolus** dans `themes.css`.
- 49 SFC compilés via `@vue/compiler-sfc` 3.5.28 (template + `<style>` PostCSS) → **21 fichiers modifiés OK** (seul faux positif : `UserDetailModal.vue`, SCSS non modifié, compilé en CSS brut).

### DoD
✅ 0 couleur **remplaçable** (token existant) en dur dans le périmètre. Les restants n'ont aucun token cible (bucket C bloqué par #136, bucket D hors-scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
