### PR TITLE
chore(theme): tokens components/lessons (re-sweep) (#138)

### DIFF
--- a/src/components/lessons/ChapterContent.vue
+++ b/src/components/lessons/ChapterContent.vue
@@ -144,12 +144,12 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
   color: var(--blue-400);
 }
 
-.chapter-type-badge.video { background: rgba(239, 68, 68, 0.1); color: #f87171; }
+.chapter-type-badge.video { background: rgba(239, 68, 68, 0.1); color: var(--red-400); }
 .chapter-type-badge.powerpoint { background: rgba(249, 115, 22, 0.1); color: #fb923c; }
 .chapter-type-badge.word { background: rgba(59, 130, 246, 0.1); color: var(--blue-400); }
-.chapter-type-badge.pdf { background: rgba(220, 38, 38, 0.1); color: #f87171; }
-.chapter-type-badge.link { background: rgba(139, 92, 246, 0.1); color: #a78bfa; }
-.chapter-type-badge.quiz { background: rgba(16, 185, 129, 0.1); color: #34d399; }
+.chapter-type-badge.pdf { background: rgba(220, 38, 38, 0.1); color: var(--red-400); }
+.chapter-type-badge.link { background: rgba(139, 92, 246, 0.1); color: var(--violet-400); }
+.chapter-type-badge.quiz { background: rgba(16, 185, 129, 0.1); color: var(--emerald-400); }
 
 /* Content blocks */
 .content-block {
@@ -183,7 +183,7 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 
 .btn-mark-complete {
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #10b981, #059669);
+  background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600));
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -211,7 +211,7 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
   background: rgba(16, 185, 129, 0.1);
-  color: #10b981;
+  color: var(--emerald-500);
   border-radius: 0.5rem;
   font-weight: 700;
 }
@@ -253,7 +253,7 @@ const isContentEmpty = (chapter) => isChapterContentEmpty(chapter, !!props.quiz)
 }
 
 .btn-nav.next:hover:not(:disabled) {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 /* ==================== RESPONSIVE ==================== */

--- a/src/components/lessons/ChapterContentField.vue
+++ b/src/components/lessons/ChapterContentField.vue
@@ -112,7 +112,7 @@ function handleFileSelect(event) {
 
 .url-input:focus {
   outline: none;
-  border-color: var(--color-primary, #10b981);
+  border-color: var(--color-primary, var(--emerald-500));
   background-color: rgba(16, 185, 129, 0.05);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1), 0 0 0 5px rgba(16, 185, 129, 0.2), 0 4px 12px rgba(0, 0, 0, 0.1);
   transform: translateY(-2px);
@@ -153,7 +153,7 @@ function handleFileSelect(event) {
 }
 
 .file-upload-label:hover {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 .file-selected-name {

--- a/src/components/lessons/ChapterEditForm.vue
+++ b/src/components/lessons/ChapterEditForm.vue
@@ -114,7 +114,7 @@ defineEmits(['save', 'cancel', 'open-quiz-editor'])
 
 .title-input:focus {
   outline: none;
-  border-color: var(--color-primary, #10b981);
+  border-color: var(--color-primary, var(--emerald-500));
   background-color: rgba(16, 185, 129, 0.05);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1), 0 0 0 5px rgba(16, 185, 129, 0.2), 0 4px 12px rgba(0, 0, 0, 0.1);
   transform: translateY(-2px);
@@ -140,7 +140,7 @@ defineEmits(['save', 'cancel', 'open-quiz-editor'])
 
 /* Options styling - Mode clair par défaut */
 .content-type-select option {
-  background-color: #ffffff;
+  background-color: var(--bg-primary);
   color: #111827;
   padding: 10px;
 }
@@ -171,7 +171,7 @@ defineEmits(['save', 'cancel', 'open-quiz-editor'])
 
 .content-type-select:focus {
   outline: none;
-  border-color: var(--color-primary, #10b981);
+  border-color: var(--color-primary, var(--emerald-500));
   background-color: rgba(16, 185, 129, 0.05);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1), 0 0 0 5px rgba(16, 185, 129, 0.2), 0 4px 12px rgba(0, 0, 0, 0.1);
 }
@@ -207,7 +207,7 @@ defineEmits(['save', 'cancel', 'open-quiz-editor'])
   font-size: 0.875rem;
   font-weight: 500;
   color: white;
-  background: var(--color-primary, #10b981);
+  background: var(--color-primary, var(--emerald-500));
   border: none;
   border-radius: 6px;
   cursor: pointer;

--- a/src/components/lessons/ChapterList.vue
+++ b/src/components/lessons/ChapterList.vue
@@ -80,7 +80,7 @@ defineEmits(['edit', 'delete', 'save', 'cancel', 'open-quiz-editor', 'open-quiz-
 .chapter-block {
   background: var(--card-bg);
   border: 3px solid var(--border-color);
-  border-left: 6px solid var(--color-primary, #10b981);
+  border-left: 6px solid var(--color-primary, var(--emerald-500));
   border-radius: 12px;
   margin-bottom: 24px;
   overflow: hidden;
@@ -91,7 +91,7 @@ defineEmits(['edit', 'delete', 'save', 'cancel', 'open-quiz-editor', 'open-quiz-
 .chapter-block:hover {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
   transform: translateY(-3px);
-  border-color: var(--color-primary, #10b981);
+  border-color: var(--color-primary, var(--emerald-500));
 }
 
 .chapter-header-bar {
@@ -100,7 +100,7 @@ defineEmits(['edit', 'delete', 'save', 'cancel', 'open-quiz-editor', 'open-quiz-
   align-items: center;
   padding: 16px 20px;
   background: var(--bg-secondary);
-  border-bottom: 3px solid var(--color-primary, #10b981);
+  border-bottom: 3px solid var(--color-primary, var(--emerald-500));
   position: relative;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
@@ -108,7 +108,7 @@ defineEmits(['edit', 'delete', 'save', 'cancel', 'open-quiz-editor', 'open-quiz-
 .chapter-number-badge {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary, var(--blue-500));
 }
 
 .chapter-actions-inline {
@@ -129,23 +129,23 @@ defineEmits(['edit', 'delete', 'save', 'cancel', 'open-quiz-editor', 'open-quiz-
 }
 
 .btn-edit {
-  color: var(--color-primary, #10b981);
+  color: var(--color-primary, var(--emerald-500));
 }
 
 .btn-edit:hover {
   background: rgba(16, 185, 129, 0.15);
-  border-color: var(--color-primary, #10b981);
+  border-color: var(--color-primary, var(--emerald-500));
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
 }
 
 .btn-delete {
-  color: #dc2626;
+  color: var(--red-600);
 }
 
 .btn-delete:hover {
   background: rgba(220, 38, 38, 0.15);
-  border-color: #dc2626;
+  border-color: var(--red-600);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(220, 38, 38, 0.3);
 }
@@ -160,9 +160,9 @@ defineEmits(['edit', 'delete', 'save', 'cancel', 'open-quiz-editor', 'open-quiz-
   padding: 14px 36px;
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-primary, #10b981);
+  color: var(--color-primary, var(--emerald-500));
   background: var(--card-bg);
-  border: 4px dashed var(--color-primary, #10b981);
+  border: 4px dashed var(--color-primary, var(--emerald-500));
   border-radius: 12px;
   cursor: pointer;
   transition: all 0.3s ease;

--- a/src/components/lessons/ChapterManager.vue
+++ b/src/components/lessons/ChapterManager.vue
@@ -132,7 +132,7 @@ const {
   width: 40px;
   height: 40px;
   border: 3px solid var(--border-color);
-  border-top-color: var(--color-primary, #10b981);
+  border-top-color: var(--color-primary, var(--emerald-500));
   border-radius: 50%;
   animation: spin 1s linear infinite;
   margin: 0 auto 16px;
@@ -184,7 +184,7 @@ const {
 
 .progress-bar-fill {
   height: 100%;
-  background: var(--color-primary, #10b981);
+  background: var(--color-primary, var(--emerald-500));
   transition: width 0.3s;
 }
 

--- a/src/components/lessons/ChapterMediaRenderer.vue
+++ b/src/components/lessons/ChapterMediaRenderer.vue
@@ -169,7 +169,7 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
 
 .link-card > i {
   font-size: 2rem;
-  color: #a78bfa;
+  color: var(--violet-400);
 }
 
 .link-info {
@@ -193,7 +193,7 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
 
 .btn-open-link {
   padding: 0.625rem 1.25rem;
-  background: #7c3aed;
+  background: var(--violet-600);
   color: white;
   text-decoration: none;
   border-radius: 0.5rem;
@@ -206,6 +206,6 @@ const getPdfUrl = (chapter) => pdfUrl(chapter)
 }
 
 .btn-open-link:hover {
-  background: #6d28d9;
+  background: var(--violet-700);
 }
 </style>

--- a/src/components/lessons/ChapterQuizField.vue
+++ b/src/components/lessons/ChapterQuizField.vue
@@ -74,7 +74,7 @@ defineEmits(['open-quiz-editor'])
 
 .quiz-summary i {
   font-size: 1.5rem;
-  color: #6366f1;
+  color: var(--indigo-500);
 }
 
 .quiz-summary-text {
@@ -98,7 +98,7 @@ defineEmits(['open-quiz-editor'])
   align-items: center;
   gap: 6px;
   padding: 8px 16px;
-  background: #6366f1;
+  background: var(--indigo-500);
   color: white;
   border: none;
   border-radius: 6px;
@@ -109,7 +109,7 @@ defineEmits(['open-quiz-editor'])
 }
 
 .btn-edit-inline-quiz:hover {
-  background: #4f46e5;
+  background: var(--indigo-600);
 }
 
 .btn-edit-inline-quiz i {
@@ -131,7 +131,7 @@ defineEmits(['open-quiz-editor'])
   align-items: center;
   gap: 6px;
   padding: 10px 20px;
-  background: #6366f1;
+  background: var(--indigo-500);
   color: white;
   border: none;
   border-radius: 8px;
@@ -142,7 +142,7 @@ defineEmits(['open-quiz-editor'])
 }
 
 .btn-create-quiz:hover {
-  background: #4f46e5;
+  background: var(--indigo-600);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
 }
@@ -159,7 +159,7 @@ defineEmits(['open-quiz-editor'])
   background: rgba(245, 158, 11, 0.1);
   border: 1px solid rgba(245, 158, 11, 0.3);
   border-radius: 8px;
-  color: #b45309;
+  color: var(--amber-700);
 }
 
 .quiz-save-first i {

--- a/src/components/lessons/ChapterQuizRenderer.vue
+++ b/src/components/lessons/ChapterQuizRenderer.vue
@@ -46,7 +46,7 @@ defineEmits(['completed', 'close'])
 
 .quiz-icon {
   font-size: 3rem;
-  color: #34d399;
+  color: var(--emerald-400);
   margin-bottom: 1rem;
 }
 
@@ -81,19 +81,19 @@ defineEmits(['completed', 'close'])
 
 .score-circle.passed {
   background: rgba(16, 185, 129, 0.15);
-  color: #10b981;
-  border: 2px solid #10b981;
+  color: var(--emerald-500);
+  border: 2px solid var(--emerald-500);
 }
 
 .score-circle.failed {
   background: rgba(239, 68, 68, 0.15);
-  color: #ef4444;
-  border: 2px solid #ef4444;
+  color: var(--red-500);
+  border: 2px solid var(--red-500);
 }
 
 .btn-start-quiz {
   padding: 0.75rem 2rem;
-  background: linear-gradient(135deg, #10b981, #059669);
+  background: linear-gradient(135deg, var(--emerald-500), var(--emerald-600));
   color: white;
   border: none;
   border-radius: 0.5rem;

--- a/src/components/lessons/ChapterViewMode.vue
+++ b/src/components/lessons/ChapterViewMode.vue
@@ -104,7 +104,7 @@ function getQuizScoreBadge(q) {
 .meta-type {
   padding: 4px 12px;
   background: rgba(59, 130, 246, 0.1);
-  color: var(--color-primary, #3b82f6);
+  color: var(--color-primary, var(--blue-500));
   font-size: 0.75rem;
   font-weight: 500;
   border-radius: 12px;
@@ -172,7 +172,7 @@ function getQuizScoreBadge(q) {
 
 .quiz-view-info .quiz-icon {
   font-size: 2rem;
-  color: #6366f1;
+  color: var(--indigo-500);
 }
 
 .quiz-view-details {
@@ -216,7 +216,7 @@ function getQuizScoreBadge(q) {
   align-items: center;
   gap: 8px;
   padding: 12px 28px;
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: linear-gradient(135deg, var(--emerald-500) 0%, var(--emerald-600) 100%);
   color: white;
   border: none;
   border-radius: 10px;
@@ -262,7 +262,7 @@ function getQuizScoreBadge(q) {
   align-items: center;
   gap: 8px;
   padding: 12px 24px;
-  background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+  background: linear-gradient(135deg, var(--indigo-500) 0%, var(--indigo-600) 100%);
   color: white;
   border: none;
   border-radius: 10px;

--- a/src/components/lessons/KnowledgeCheckEditor.vue
+++ b/src/components/lessons/KnowledgeCheckEditor.vue
@@ -122,7 +122,7 @@ const { saving, isEditing, quiz, isValid, addQuestion, removeQuestion, save } =
 }
 
 .editor-title i {
-  color: #6366f1;
+  color: var(--indigo-500);
 }
 
 .close-btn {
@@ -182,7 +182,7 @@ const { saving, isEditing, quiz, isValid, addQuestion, removeQuestion, save } =
 
 .form-input:focus {
   outline: none;
-  border-color: #6366f1;
+  border-color: var(--indigo-500);
 }
 
 .editor-footer {
@@ -215,7 +215,7 @@ const { saving, isEditing, quiz, isValid, addQuestion, removeQuestion, save } =
   align-items: center;
   gap: 0.375rem;
   padding: 0.625rem 1.25rem;
-  background: #6366f1;
+  background: var(--indigo-500);
   color: white;
   border: none;
   border-radius: 6px;
@@ -226,7 +226,7 @@ const { saving, isEditing, quiz, isValid, addQuestion, removeQuestion, save } =
 }
 
 .save-btn:hover:not(:disabled) {
-  background: #4f46e5;
+  background: var(--indigo-600);
 }
 
 .save-btn:disabled {

--- a/src/components/lessons/LessonBasicInfoFields.vue
+++ b/src/components/lessons/LessonBasicInfoFields.vue
@@ -159,7 +159,7 @@ defineEmits(['load-chapters'])
 
 .form-label.required::after {
   content: ' *';
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .form-input,

--- a/src/components/lessons/LessonCardActions.vue
+++ b/src/components/lessons/LessonCardActions.vue
@@ -85,17 +85,17 @@ defineEmits(['view', 'edit', 'delete', 'publish', 'unpublish'])
 }
 
 .btn-publish {
-  color: #059669;
-  border-color: #059669;
+  color: var(--emerald-600);
+  border-color: var(--emerald-600);
 }
 
 .btn-publish:hover {
-  background: #d1fae5;
+  background: var(--emerald-100);
 }
 
 .btn-unpublish {
-  color: #d97706;
-  border-color: #d97706;
+  color: var(--amber-600);
+  border-color: var(--amber-600);
 }
 
 .btn-unpublish:hover {
@@ -112,8 +112,8 @@ defineEmits(['view', 'edit', 'delete', 'publish', 'unpublish'])
 }
 
 .btn-delete {
-  color: #dc2626;
-  border-color: #dc2626;
+  color: var(--red-600);
+  border-color: var(--red-600);
 }
 
 .btn-delete:hover {
@@ -121,13 +121,13 @@ defineEmits(['view', 'edit', 'delete', 'publish', 'unpublish'])
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--blue-500), #8b5cf6);
+  background: linear-gradient(135deg, var(--blue-500), var(--violet-500));
   color: white;
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  background: linear-gradient(135deg, var(--color-info-strong), var(--violet-600));
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
   transform: translateY(-1px);
 }

--- a/src/components/lessons/LessonCardBadges.vue
+++ b/src/components/lessons/LessonCardBadges.vue
@@ -52,12 +52,12 @@ const statusBadge = computed(() => getStatusBadge(props.lesson.status))
 
 .badge-tp {
   background: #e9d5ff;
-  color: #7c3aed;
+  color: var(--violet-600);
 }
 
 .badge-td {
-  background: #ddd6fe;
-  color: #6366f1;
+  background: var(--violet-200);
+  color: var(--indigo-500);
 }
 
 .badge-projet {
@@ -73,12 +73,12 @@ const statusBadge = computed(() => getStatusBadge(props.lesson.status))
 /* Badges par status */
 .badge-status-draft {
   background: var(--warning-bg);
-  color: #92400e;
+  color: var(--amber-800);
 }
 
 .badge-status-published {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 .badge-status-archived {

--- a/src/components/lessons/LessonChapterSidebar.vue
+++ b/src/components/lessons/LessonChapterSidebar.vue
@@ -170,7 +170,7 @@ function isChapterCompleted(chapterId) {
 }
 
 .chapter-nav-item.completed .chapter-status-icon {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 .chapter-status-icon {

--- a/src/components/lessons/LessonContentFields.vue
+++ b/src/components/lessons/LessonContentFields.vue
@@ -176,7 +176,7 @@ defineProps({
 
 .form-label.required::after {
   content: ' *';
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .form-input,

--- a/src/components/lessons/LessonEditorActions.vue
+++ b/src/components/lessons/LessonEditorActions.vue
@@ -66,12 +66,12 @@ defineEmits(['cancel', 'delete'])
 }
 
 .btn-save {
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
 }
 
 .btn-save:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: translateY(-1px);
 }
 
@@ -82,12 +82,12 @@ defineEmits(['cancel', 'delete'])
 
 .btn-delete {
   background: var(--error-bg);
-  color: #dc2626;
+  color: var(--red-600);
   border: 1px solid var(--error-border);
 }
 
 .btn-delete:hover:not(:disabled) {
-  background: #fecaca;
+  background: var(--red-200);
 }
 
 .btn-delete:disabled {

--- a/src/components/lessons/LessonFormModal.vue
+++ b/src/components/lessons/LessonFormModal.vue
@@ -172,7 +172,7 @@ defineEmits(['close', 'save'])
 
 .form-label.required::after {
   content: ' *';
-  color: #dc2626;
+  color: var(--red-600);
 }
 
 .form-input,
@@ -224,12 +224,12 @@ defineEmits(['close', 'save'])
 }
 
 .btn-save {
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
 }
 
 .btn-save:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
 }
 
 .btn-save:disabled {

--- a/src/components/lessons/LessonInfoCard.vue
+++ b/src/components/lessons/LessonInfoCard.vue
@@ -128,13 +128,13 @@ function getNiveauLabel(niveau) {
 
 .badge-intermediaire {
   background-color: rgba(245, 158, 11, 0.1);
-  color: #f59e0b;
+  color: var(--amber-500);
   border: 1px solid rgba(245, 158, 11, 0.3);
 }
 
 .badge-avance {
   background-color: rgba(239, 68, 68, 0.1);
-  color: #ef4444;
+  color: var(--red-500);
   border: 1px solid rgba(239, 68, 68, 0.3);
 }
 
@@ -159,13 +159,13 @@ function getNiveauLabel(niveau) {
 
 .status-published {
   background-color: rgba(16, 185, 129, 0.15);
-  color: #10b981;
+  color: var(--emerald-500);
   border: 1px solid rgba(16, 185, 129, 0.3);
 }
 
 .status-draft {
   background-color: rgba(245, 158, 11, 0.15);
-  color: #f59e0b;
+  color: var(--amber-500);
   border: 1px solid rgba(245, 158, 11, 0.3);
 }
 
@@ -194,7 +194,7 @@ function getNiveauLabel(niveau) {
 
 .btn-publish {
   padding: 10px 20px;
-  background-color: var(--color-primary, #10b981);
+  background-color: var(--color-primary, var(--emerald-500));
   color: white;
   border: none;
   border-radius: 8px;

--- a/src/components/lessons/LessonResourcesFields.vue
+++ b/src/components/lessons/LessonResourcesFields.vue
@@ -215,7 +215,7 @@ defineEmits(['add', 'remove'])
 .btn-remove {
   padding: 0.5rem 1rem;
   background: var(--error-bg);
-  color: #dc2626;
+  color: var(--red-600);
   border: 1px solid var(--error-border);
   border-radius: 0.375rem;
   font-size: 0.813rem;
@@ -225,7 +225,7 @@ defineEmits(['add', 'remove'])
 }
 
 .btn-remove:hover {
-  background: #fecaca;
+  background: var(--red-200);
 }
 
 .resources-empty {

--- a/src/components/lessons/LessonStatsGrid.vue
+++ b/src/components/lessons/LessonStatsGrid.vue
@@ -43,7 +43,7 @@ defineProps({
 }
 
 .stat-completed {
-  background: #d1fae5;
+  background: var(--emerald-100);
 }
 
 .stat-average {
@@ -60,11 +60,11 @@ defineProps({
 }
 
 .stat-completed .stat-value {
-  color: #065f46;
+  color: var(--emerald-800);
 }
 
 .stat-average .stat-value {
-  color: #7c3aed;
+  color: var(--violet-600);
 }
 
 .stat-label {

--- a/src/components/lessons/LessonsEmptyState.vue
+++ b/src/components/lessons/LessonsEmptyState.vue
@@ -65,7 +65,7 @@ defineProps({
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -75,7 +75,7 @@ defineProps({
 }
 
 .btn-create-empty:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: translateY(-2px);
 }
 </style>

--- a/src/components/lessons/QuestionEditorCard.vue
+++ b/src/components/lessons/QuestionEditorCard.vue
@@ -113,7 +113,7 @@ function onTypeChange() {
 
 .form-input:focus {
   outline: none;
-  border-color: #6366f1;
+  border-color: var(--indigo-500);
 }
 
 .question-card {
@@ -126,7 +126,7 @@ function onTypeChange() {
 
 .ghost-question {
   opacity: 0.5;
-  background: #6366f1 !important;
+  background: var(--indigo-500) !important;
 }
 
 .question-header {
@@ -168,7 +168,7 @@ function onTypeChange() {
   cursor: pointer;
   padding: 0.375rem;
   border-radius: 4px;
-  color: #ef4444;
+  color: var(--red-500);
   transition: all 0.2s;
 }
 

--- a/src/components/lessons/QuestionOptionsEditor.vue
+++ b/src/components/lessons/QuestionOptionsEditor.vue
@@ -139,7 +139,7 @@ function toggleCorrectMultiple(optionIndex) {
 
 .option-input:focus {
   outline: none;
-  border-color: #6366f1;
+  border-color: var(--indigo-500);
 }
 
 .option-input:disabled {
@@ -157,7 +157,7 @@ function toggleCorrectMultiple(optionIndex) {
 }
 
 .remove-option-btn:hover {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .add-option-btn {
@@ -175,7 +175,7 @@ function toggleCorrectMultiple(optionIndex) {
 }
 
 .add-option-btn:hover {
-  border-color: #6366f1;
-  color: #6366f1;
+  border-color: var(--indigo-500);
+  color: var(--indigo-500);
 }
 </style>

--- a/src/components/lessons/QuestionsSection.vue
+++ b/src/components/lessons/QuestionsSection.vue
@@ -89,7 +89,7 @@ defineEmits(['add-question', 'remove-question'])
   align-items: center;
   gap: 0.25rem;
   padding: 0.5rem 1rem;
-  background: #6366f1;
+  background: var(--indigo-500);
   color: white;
   border: none;
   border-radius: 6px;
@@ -100,7 +100,7 @@ defineEmits(['add-question', 'remove-question'])
 }
 
 .add-question-btn:hover {
-  background: #4f46e5;
+  background: var(--indigo-600);
 }
 
 .add-question-section {
@@ -123,7 +123,7 @@ defineEmits(['add-question', 'remove-question'])
   background: rgba(245, 158, 11, 0.1);
   border: 1px solid rgba(245, 158, 11, 0.3);
   border-radius: 8px;
-  color: #b45309;
+  color: var(--amber-700);
   font-size: 0.8125rem;
   margin-top: 1rem;
 }

--- a/src/components/lessons/QuizPlayerCorrections.vue
+++ b/src/components/lessons/QuizPlayerCorrections.vue
@@ -71,12 +71,12 @@ function getAnswerText(questionIndex, answerValue) {
 
 .correction-item.correct {
   background: rgba(16, 185, 129, 0.1);
-  border-color: #10b981;
+  border-color: var(--emerald-500);
 }
 
 .correction-item.incorrect {
   background: rgba(239, 68, 68, 0.1);
-  border-color: #ef4444;
+  border-color: var(--red-500);
 }
 
 .correction-header {
@@ -91,11 +91,11 @@ function getAnswerText(questionIndex, answerValue) {
 }
 
 .correction-item.correct .correction-header i {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 .correction-item.incorrect .correction-header i {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .correction-question {
@@ -121,7 +121,7 @@ function getAnswerText(questionIndex, answerValue) {
   padding: 0.5rem;
   background: rgba(99, 102, 241, 0.1);
   border-radius: 6px;
-  color: #4f46e5 !important;
+  color: var(--indigo-600) !important;
 }
 
 .explanation i {

--- a/src/components/lessons/QuizPlayerIntro.vue
+++ b/src/components/lessons/QuizPlayerIntro.vue
@@ -76,7 +76,7 @@ defineEmits(['start'])
   width: 80px;
   height: 80px;
   margin: 0 auto 1.5rem;
-  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--indigo-500) 0%, var(--violet-500) 100%);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -121,7 +121,7 @@ defineEmits(['start'])
 
 .stat-item i {
   font-size: 1.125rem;
-  color: #6366f1;
+  color: var(--indigo-500);
 }
 
 .previous-attempts {
@@ -134,14 +134,14 @@ defineEmits(['start'])
   gap: 0.5rem;
   padding: 0.75rem 1.25rem;
   background: var(--warning-bg);
-  color: #b45309;
+  color: var(--amber-700);
   border-radius: 8px;
   font-weight: 500;
 }
 
 .best-score.passed {
-  background: #d1fae5;
-  color: #047857;
+  background: var(--emerald-100);
+  color: var(--emerald-700);
 }
 
 .best-score i {
@@ -153,7 +153,7 @@ defineEmits(['start'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.875rem 2rem;
-  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--indigo-500) 0%, var(--violet-500) 100%);
   color: white;
   border: none;
   border-radius: 8px;
@@ -180,7 +180,7 @@ defineEmits(['start'])
   gap: 0.5rem;
   padding: 1rem;
   background: var(--error-bg);
-  color: #b91c1c;
+  color: var(--red-700);
   border-radius: 8px;
   font-weight: 500;
 }

--- a/src/components/lessons/QuizPlayerQuestion.vue
+++ b/src/components/lessons/QuizPlayerQuestion.vue
@@ -127,7 +127,7 @@ function isOptionSelected(index) {
 
 .progress-fill {
   height: 100%;
-  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--indigo-500) 0%, var(--violet-500) 100%);
   transition: width 0.3s ease;
 }
 
@@ -154,7 +154,7 @@ function isOptionSelected(index) {
 
 .quiz-timer.warning {
   background: var(--error-bg);
-  color: #b91c1c;
+  color: var(--red-700);
   animation: pulse 1s infinite;
 }
 
@@ -194,12 +194,12 @@ function isOptionSelected(index) {
 }
 
 .option-item:hover {
-  border-color: #6366f1;
+  border-color: var(--indigo-500);
 }
 
 .option-item.selected {
   background: rgba(99, 102, 241, 0.1);
-  border-color: #6366f1;
+  border-color: var(--indigo-500);
 }
 
 .option-item input {

--- a/src/components/lessons/QuizPlayerResults.vue
+++ b/src/components/lessons/QuizPlayerResults.vue
@@ -72,11 +72,11 @@ defineEmits(['retry', 'close'])
   text-align: center;
   padding: 2rem;
   margin: -2rem -2rem 2rem;
-  background: linear-gradient(135deg, var(--warning-bg) 0%, #fde68a 100%);
+  background: linear-gradient(135deg, var(--warning-bg) 0%, var(--amber-200) 100%);
 }
 
 .results-header.passed {
-  background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%);
+  background: linear-gradient(135deg, var(--emerald-100) 0%, var(--emerald-200) 100%);
 }
 
 .results-icon {
@@ -93,22 +93,22 @@ defineEmits(['retry', 'close'])
 
 .results-icon i {
   font-size: 2.5rem;
-  color: #b45309;
+  color: var(--amber-700);
 }
 
 .results-header.passed .results-icon i {
-  color: #047857;
+  color: var(--emerald-700);
 }
 
 .results-title {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #92400e;
+  color: var(--amber-800);
   margin: 0 0 0.5rem 0;
 }
 
 .results-header.passed .results-title {
-  color: #047857;
+  color: var(--emerald-700);
 }
 
 .results-message {
@@ -117,7 +117,7 @@ defineEmits(['retry', 'close'])
 }
 
 .results-header.passed .results-message {
-  color: #059669;
+  color: var(--emerald-600);
 }
 
 .score-display {
@@ -135,7 +135,7 @@ defineEmits(['retry', 'close'])
   width: 100px;
   height: 100px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+  background: linear-gradient(135deg, var(--indigo-500) 0%, var(--violet-500) 100%);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -144,7 +144,7 @@ defineEmits(['retry', 'close'])
 }
 
 .score-circle.passed {
-  background: linear-gradient(135deg, #10b981 0%, #34d399 100%);
+  background: linear-gradient(135deg, var(--emerald-500) 0%, var(--emerald-400) 100%);
 }
 
 .score-value {
@@ -187,13 +187,13 @@ defineEmits(['retry', 'close'])
 }
 
 .retry-btn {
-  background: #6366f1;
+  background: var(--indigo-500);
   border: none;
   color: white;
 }
 
 .retry-btn:hover {
-  background: #4f46e5;
+  background: var(--indigo-600);
 }
 
 .close-btn {

--- a/src/components/lessons/QuizQuestionNav.vue
+++ b/src/components/lessons/QuizQuestionNav.vue
@@ -100,23 +100,23 @@ defineEmits(['prev', 'next', 'goto', 'submit'])
 }
 
 .next-btn {
-  background: #6366f1;
+  background: var(--indigo-500);
   border: none;
   color: white;
 }
 
 .next-btn:hover {
-  background: #4f46e5;
+  background: var(--indigo-600);
 }
 
 .submit-btn {
-  background: #10b981;
+  background: var(--emerald-500);
   border: none;
   color: white;
 }
 
 .submit-btn:hover:not(:disabled) {
-  background: #059669;
+  background: var(--emerald-600);
 }
 
 .submit-btn:disabled {
@@ -144,15 +144,15 @@ defineEmits(['prev', 'next', 'goto', 'submit'])
 }
 
 .dot.active {
-  border-color: #6366f1;
-  background: #6366f1;
+  border-color: var(--indigo-500);
+  background: var(--indigo-500);
   color: white;
 }
 
 .dot.answered:not(.active) {
-  border-color: #10b981;
+  border-color: var(--emerald-500);
   background: rgba(16, 185, 129, 0.1);
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 @media (max-width: 640px) {

--- a/src/components/lessons/TeacherLessonCard.vue
+++ b/src/components/lessons/TeacherLessonCard.vue
@@ -146,7 +146,7 @@ function formatDate(dateString) {
 
 .status-draft {
   background: var(--warning-bg);
-  color: #92400e;
+  color: var(--amber-800);
 }
 
 .status-archived {
@@ -210,7 +210,7 @@ function formatDate(dateString) {
   border: none;
 }
 
-.btn-view {  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);  color: white;  border: none;}.btn-view:hover {  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);  transform: translateY(-2px);  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);}
+.btn-view {  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);  color: white;  border: none;}.btn-view:hover {  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);  transform: translateY(-2px);  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);}
 
 .btn-edit:hover {
   background: var(--bg-tertiary);


### PR DESCRIPTION
Closes #138.

Re-sweep correctif de `src/components/lessons/**` après #135 (audit v2) et #136 (tokens sémantiques). Re-grep sur le dev courant ; mapping **re-dérivé contre le `src/assets/styles/themes.css` réellement mergé** (la colonne « token cible » du docs étant datée de l'audit pré-#136, et ses n° de ligne ne correspondant plus aux fichiers).

## Résultat
- **132 remplacements / 30 fichiers**, swaps de valeur purs (132 insertions = 132 deletions, aucune édition de structure).
- **DoD atteint : 0 couleur remplaçable en dur** dans le périmètre.
- Vérif : les 30 SFC parsent proprement via `@vue/compiler-sfc` (build vite complet non lancé — `node_modules` du worktree incomplet ; validation au niveau parse SFC).

## Remplacé
- Scales `:root` **theme-invariantes** (identiques clair **et** sombre → aucun changement visuel) : `--emerald/red/amber/indigo/violet-*`, `#2563eb`→`--color-info-strong`, `#ffffff`→`--bg-primary` (clair exact, sombre déjà géré par `[data-theme="dark"]`).
- `#3b82f6`→`var(--blue-500)` sur 2 fallbacks `var(--color-primary, …)` (`.meta-type`, `.chapter-number-badge`) : texte info bleu sur fond sombre → en sombre passe à #60a5fa (bleu calibré dark, lisibilité améliorée). **Adaptation thème voulue, pas une régression** ; conforme au mapping docs et aux lots #112/#113.

## Laissé volontairement — à signaler (aucun token exact = lacune de #136, pas un échec DoD)
#136 n'a ajouté que les scales emerald/red/amber/indigo/violet + le namespace `--color-*`. Restent donc sans token :
- **`rgba()` ombres / overlays / teintes accent** (≈115) : `rgba(0,0,0,*)`, `rgba(255,255,255,0.05)`, et teintes `rgba(59,130,246 / 16,185,129 / 99,102,241 / 245,158,11 / 239,68,68 / 220,38,38 / 139,92,246 / 249,115,22 / 234,88,12, *)`.
- **Solides sans scale** : grays Tailwind (`#111827 #1f2937 #6b7280 #9ca3af #f3f4f6 #e5e7eb #f9fafb`), `#1d4ed8` (blue-700, fins de dégradés ×5), `#fb923c` (orange), `#fce7f3`/`#be123c` (pink/rose), `#e9d5ff` (purple-200), `#a16207` (yellow), `#15803d` (green), `#000` ×2 (fonds vidéo/slides intentionnels).

→ Ces cas nécessitent un round de tokens ultérieur (scales gray/orange/pink/rose côté `themes.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)