### PR TITLE
chore(theme): migrer les couleurs en dur exactes vers var(--…) dans c…

### DIFF
--- a/src/components/dashboard/DashboardClasses.vue
+++ b/src/components/dashboard/DashboardClasses.vue
@@ -116,8 +116,8 @@ defineProps({
 
 .class-niveau {
   padding: 0.25rem 0.5rem;
-  background: #e0e7ff;
-  color: #5b21b6;
+  background: var(--indigo-100);
+  color: var(--violet-800);
   border-radius: 0.25rem;
   font-size: 0.75rem;
 }
@@ -148,8 +148,8 @@ defineProps({
 
 .active-badge {
   padding: 0.25rem 0.5rem;
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
   border-radius: 0.25rem;
   font-size: 0.75rem;
 }

--- a/src/components/dashboard/DashboardInfoBanner.vue
+++ b/src/components/dashboard/DashboardInfoBanner.vue
@@ -23,14 +23,14 @@ defineProps({
   align-items: center;
   gap: 0.75rem;
   padding: 1rem 1.5rem;
-  background: #dbeafe;
+  background: var(--info-bg);
   border-radius: 0.75rem;
 }
 
 .info-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #1e40af;
+  color: var(--info-text);
 }
 
 .info-text {

--- a/src/components/dashboard/DashboardPendingTasks.vue
+++ b/src/components/dashboard/DashboardPendingTasks.vue
@@ -118,8 +118,8 @@ defineProps({
 }
 
 .task-item.urgent {
-  border-left-color: #ef4444;
-  background: linear-gradient(135deg, #fef2f2 0%, #fee2e2 100%);
+  border-left-color: var(--red-500);
+  background: linear-gradient(135deg, var(--red-50) 0%, var(--error-bg) 100%);
 }
 
 .task-icon {
@@ -153,7 +153,7 @@ defineProps({
 
 .task-urgent {
   font-size: 0.75rem;
-  color: #dc2626;
+  color: var(--red-600);
   font-weight: 600;
   margin: 0.25rem 0 0 0;
 }

--- a/src/components/dashboard/DashboardRecentUsers.vue
+++ b/src/components/dashboard/DashboardRecentUsers.vue
@@ -99,14 +99,14 @@ const { getInitials, getRoleLabel, getRoleClass, formatDate } = useDashboardForm
 .view-all-link {
   margin-left: auto;
   font-size: 0.875rem;
-  color: #3b82f6;
+  color: var(--blue-500);
   text-decoration: none;
   font-weight: 600;
   transition: color 0.2s;
 }
 
 .view-all-link:hover {
-  color: #2563eb;
+  color: var(--color-info-strong);
   text-decoration: underline;
 }
 
@@ -138,7 +138,7 @@ const { getInitials, getRoleLabel, getRoleClass, formatDate } = useDashboardForm
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   font-weight: 700;
   font-size: 0.875rem;
@@ -184,23 +184,23 @@ const { getInitials, getRoleLabel, getRoleClass, formatDate } = useDashboardForm
 }
 
 .role-student {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .role-teacher {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 .role-coordinator {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--amber-800);
 }
 
 .role-admin {
-  background: #fecaca;
-  color: #991b1b;
+  background: var(--red-200);
+  color: var(--error-text);
 }
 
 .role-default {

--- a/src/components/dashboard/DashboardRoleActions.vue
+++ b/src/components/dashboard/DashboardRoleActions.vue
@@ -72,7 +72,7 @@ defineProps({
 }
 
 .action-card.highlighted {
-  border: 2px solid #f59e0b;
+  border: 2px solid var(--amber-500);
 }
 
 .action-icon {

--- a/src/components/dashboard/DashboardStatsCards.vue
+++ b/src/components/dashboard/DashboardStatsCards.vue
@@ -67,19 +67,19 @@ defineProps({
 }
 
 .border-l-blue {
-  border-left-color: #3b82f6;
+  border-left-color: var(--blue-500);
 }
 
 .border-l-green {
-  border-left-color: #10b981;
+  border-left-color: var(--emerald-500);
 }
 
 .border-l-purple {
-  border-left-color: #8b5cf6;
+  border-left-color: var(--violet-500);
 }
 
 .border-l-orange {
-  border-left-color: #f59e0b;
+  border-left-color: var(--amber-500);
 }
 
 .stat-header {

--- a/src/components/student/CourseCard.vue
+++ b/src/components/student/CourseCard.vue
@@ -112,23 +112,23 @@ function truncateText(text, maxLength) {
 }
 
 .course-type-badge.cours {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .course-type-badge.tp {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
 }
 
 .course-type-badge.td {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--amber-800);
 }
 
 .course-type-badge.projet {
   background: #f3e8ff;
-  color: #7c3aed;
+  color: var(--violet-600);
 }
 
 .course-type-badge.autre {
@@ -196,7 +196,7 @@ function truncateText(text, maxLength) {
 
 .progress-bar {
   height: 100%;
-  background: linear-gradient(90deg, #3b82f6, #2563eb);
+  background: linear-gradient(90deg, var(--blue-500), var(--color-info-strong));
   border-radius: 3px;
   transition: width 0.3s ease;
 }
@@ -213,7 +213,7 @@ function truncateText(text, maxLength) {
   justify-content: center;
   gap: 0.5rem;
   padding: 0.75rem;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -224,7 +224,7 @@ function truncateText(text, maxLength) {
 }
 
 .course-button:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: scale(1.02);
 }
 

--- a/src/components/student/CoursesFilters.vue
+++ b/src/components/student/CoursesFilters.vue
@@ -112,9 +112,9 @@ defineEmits(['apply', 'reset'])
 }
 
 .reset-filters-btn:hover {
-  background: #fee2e2;
-  color: #dc2626;
-  border-color: #dc2626;
+  background: var(--error-bg);
+  color: var(--red-600);
+  border-color: var(--red-600);
 }
 
 @media (max-width: 768px) {

--- a/src/components/student/SettingsNotifications.vue
+++ b/src/components/student/SettingsNotifications.vue
@@ -88,7 +88,7 @@ defineEmits(['change'])
 }
 
 input:checked + .toggle-slider {
-  background-color: #3b82f6;
+  background-color: var(--blue-500);
 }
 
 input:checked + .toggle-slider:before {

--- a/src/components/student/SettingsPasswordModal.vue
+++ b/src/components/student/SettingsPasswordModal.vue
@@ -119,7 +119,7 @@ function submitPasswordChange() {
 
 .form-input:focus {
   outline: none;
-  border-color: #3B82F6;
+  border-color: var(--blue-500);
 }
 
 .form-input::placeholder {
@@ -137,12 +137,12 @@ function submitPasswordChange() {
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: scale(1.02);
 }
 

--- a/src/components/teacher/DashboardEvaluationsList.vue
+++ b/src/components/teacher/DashboardEvaluationsList.vue
@@ -115,13 +115,13 @@ defineProps({
 }
 
 .badge-success {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--success-bg);
+  color: var(--success-text);
 }
 
 .badge-info {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .badge-default {

--- a/src/components/teacher/HubNavCards.vue
+++ b/src/components/teacher/HubNavCards.vue
@@ -124,15 +124,15 @@ defineProps({
 }
 
 .classes-icon {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
 }
 
 .matieres-icon {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: linear-gradient(135deg, var(--amber-500) 0%, var(--amber-600) 100%);
 }
 
 .lecons-icon {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: linear-gradient(135deg, var(--emerald-500) 0%, var(--emerald-600) 100%);
 }
 
 .card-content {

--- a/src/components/teacher/HubQuickStats.vue
+++ b/src/components/teacher/HubQuickStats.vue
@@ -100,14 +100,14 @@ defineProps({
 
 /* Text color utilities */
 .text-blue-500 {
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .text-orange-500 {
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .text-green-500 {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 </style>

--- a/src/components/teacher/PasswordChangeModal.vue
+++ b/src/components/teacher/PasswordChangeModal.vue
@@ -85,7 +85,7 @@ defineEmits(['submit'])
 
 .form-input:focus {
   outline: none;
-  border-color: #3B82F6;
+  border-color: var(--blue-500);
 }
 
 .form-input::placeholder {
@@ -103,12 +103,12 @@ defineEmits(['submit'])
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: scale(1.02);
 }
 

--- a/src/components/teacher/ProfileInfoCard.vue
+++ b/src/components/teacher/ProfileInfoCard.vue
@@ -85,7 +85,7 @@ defineProps({
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .card-title {
@@ -113,7 +113,7 @@ defineProps({
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -168,7 +168,7 @@ defineProps({
 .info-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #3b82f6;
+  color: var(--blue-500);
   flex-shrink: 0;
   margin-top: 0.25rem;
 }

--- a/src/components/teacher/ProfileQuickActions.vue
+++ b/src/components/teacher/ProfileQuickActions.vue
@@ -68,7 +68,7 @@ import { BoltIcon, CogIcon, DocumentTextIcon, AcademicCapIcon, ChartBarIcon } fr
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .card-title {
@@ -103,7 +103,7 @@ import { BoltIcon, CogIcon, DocumentTextIcon, AcademicCapIcon, ChartBarIcon } fr
 
 .action-button:hover {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(37, 99, 235, 0.05) 100%);
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   transform: translateY(-2px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
 }
@@ -111,7 +111,7 @@ import { BoltIcon, CogIcon, DocumentTextIcon, AcademicCapIcon, ChartBarIcon } fr
 .action-icon {
   width: 2rem;
   height: 2rem;
-  color: #3b82f6;
+  color: var(--blue-500);
   flex-shrink: 0;
 }
 

--- a/src/components/teacher/ProfileStatsCard.vue
+++ b/src/components/teacher/ProfileStatsCard.vue
@@ -72,7 +72,7 @@ defineProps({
 .header-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #3b82f6;
+  color: var(--blue-500);
 }
 
 .card-title {

--- a/src/components/teacher/SettingsNotifications.vue
+++ b/src/components/teacher/SettingsNotifications.vue
@@ -150,7 +150,7 @@ defineEmits(['save'])
 }
 
 input:checked + .toggle-slider {
-  background-color: #3b82f6;
+  background-color: var(--blue-500);
 }
 
 input:checked + .toggle-slider:before {

--- a/src/components/teacher/TeacherClassCard.vue
+++ b/src/components/teacher/TeacherClassCard.vue
@@ -125,8 +125,8 @@ defineProps({
 .class-niveau {
   display: inline-block;
   padding: 0.25rem 0.75rem;
-  background: #e0e7ff;
-  color: #5b21b6;
+  background: var(--indigo-100);
+  color: var(--violet-800);
   border-radius: 0.5rem;
   font-size: 0.75rem;
   font-weight: 600;
@@ -137,7 +137,7 @@ defineProps({
   align-items: center;
   gap: 0.5rem;
   padding: 0.375rem 0.75rem;
-  background: #dcfce7;
+  background: var(--success-bg);
   color: #15803d;
   border-radius: 0.5rem;
   font-size: 0.75rem;

--- a/src/components/teacher/TeacherStatsActivity.vue
+++ b/src/components/teacher/TeacherStatsActivity.vue
@@ -113,11 +113,11 @@ defineProps({
 }
 
 .bg-blue-100 {
-  background: #dbeafe;
+  background: var(--info-bg);
 }
 
 .bg-green-100 {
-  background: #dcfce7;
+  background: var(--success-bg);
 }
 
 .bg-orange-100 {

--- a/src/components/teacher/TeacherStatsGlobalCards.vue
+++ b/src/components/teacher/TeacherStatsGlobalCards.vue
@@ -81,11 +81,11 @@ defineProps({
 }
 
 .bg-blue-100 {
-  background: #dbeafe;
+  background: var(--info-bg);
 }
 
 .bg-green-100 {
-  background: #dcfce7;
+  background: var(--success-bg);
 }
 
 .bg-orange-100 {

--- a/src/components/teacher/TeacherStatsParClasse.vue
+++ b/src/components/teacher/TeacherStatsParClasse.vue
@@ -104,8 +104,8 @@ defineProps({
 
 .classe-badge {
   padding: 0.25rem 0.5rem;
-  background: #e0e7ff;
-  color: #5b21b6;
+  background: var(--indigo-100);
+  color: var(--violet-800);
   border-radius: 0.25rem;
   font-size: 0.75rem;
   font-weight: 600;


### PR DESCRIPTION
…omponents/{student,teacher,dashboard} (#140)

Lot G4 : 72 remplacements 1:1 hex -> token (valeur identique en light) dans 22 fichiers jamais couverts, selon docs/theme-hardcoded-colors-v2.md (#135) et les tokens de themes.css (#136).

- #3b82f6 -> --blue-500 ; #2563eb -> --color-info-strong
- familles brutes invariantes : --emerald/violet/indigo/amber/red-*
- sémantiques : --info-bg/--info-text/--success-bg/--success-text/--warning-bg/--error-bg/--error-text
- #92400e -> --amber-800 (et non --warning-text = #854d0e)

Laissé exprès (aucun token exact dans themes.css, lacune #136) : palette Material « notes » (Grades*), familles Tailwind gray/green/orange/ purple/blue-700-900, ombres/overlays rgba() (la normalisation changerait la géométrie, cf. #112/#113), fallbacks var(--primary-color, #3b82f6).