### PR TITLE
chore(theme): tokens exacts long tail components/ (#141)

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -114,7 +114,7 @@ export default {
 
 <style scoped>
 .router-link-active {
-  border-bottom: 2px solid #2563eb;
-  color: #2563eb;
+  border-bottom: 2px solid var(--color-info-strong);
+  color: var(--color-info-strong);
 }
 </style>

--- a/src/components/attendance/AttendanceDetailModal.vue
+++ b/src/components/attendance/AttendanceDetailModal.vue
@@ -153,7 +153,7 @@ defineEmits(['close', 'export-pdf', 'export-excel', 'retry'])
 
 .modal-error span {
   font-size: 3rem;
-  color: #EF4444;
+  color: var(--red-500);
 }
 
 .btn-retry {
@@ -169,7 +169,7 @@ defineEmits(['close', 'export-pdf', 'export-excel', 'retry'])
 }
 
 .btn-retry:hover {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 /* Modal Transitions */

--- a/src/components/attendance/AttendanceHistoryFilters.vue
+++ b/src/components/attendance/AttendanceHistoryFilters.vue
@@ -128,7 +128,7 @@ defineEmits(['change', 'input', 'reset'])
 
 .btn-reset {
   padding: 0.625rem 1rem;
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
   border: none;
   border-radius: 8px;
@@ -139,7 +139,7 @@ defineEmits(['change', 'input', 'reset'])
 }
 
 .btn-reset:hover {
-  background: #dc2626;
+  background: var(--red-600);
   transform: translateY(-1px);
 }
 

--- a/src/components/attendance/AttendanceHistoryPagination.vue
+++ b/src/components/attendance/AttendanceHistoryPagination.vue
@@ -59,7 +59,7 @@ defineEmits(['load-page'])
 }
 
 .btn-page:hover:not(:disabled) {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 .btn-page:disabled {

--- a/src/components/attendance/AttendanceHistoryRows.vue
+++ b/src/components/attendance/AttendanceHistoryRows.vue
@@ -173,8 +173,8 @@ defineEmits(['view-details'])
 .classe-badge {
   display: inline-block;
   padding: 0.25rem 0.75rem;
-  background: #e0e7ff;
-  color: #3730a3;
+  background: var(--indigo-100);
+  color: var(--indigo-800);
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 500;
@@ -189,8 +189,8 @@ defineEmits(['view-details'])
 }
 
 .status-connected {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 .status-disconnected {
@@ -204,7 +204,7 @@ defineEmits(['view-details'])
 }
 
 .text-green {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 .text-gray {

--- a/src/components/attendance/AttendanceHistoryStats.vue
+++ b/src/components/attendance/AttendanceHistoryStats.vue
@@ -65,10 +65,10 @@ defineProps({
 }
 
 .border-l-blue { border-left-color: var(--blue-500); }
-.border-l-green { border-left-color: #10b981; }
-.border-l-orange { border-left-color: #f59e0b; }
-.border-l-red { border-left-color: #ef4444; }
-.border-l-purple { border-left-color: #8b5cf6; }
+.border-l-green { border-left-color: var(--emerald-500); }
+.border-l-orange { border-left-color: var(--amber-500); }
+.border-l-red { border-left-color: var(--red-500); }
+.border-l-purple { border-left-color: var(--violet-500); }
 
 .stat-header {
   display: flex;

--- a/src/components/attendance/AttendanceHistoryTable.vue
+++ b/src/components/attendance/AttendanceHistoryTable.vue
@@ -73,7 +73,7 @@ defineEmits(['export', 'view-details', 'load-page'])
 
 .btn-export {
   padding: 0.625rem 1rem;
-  background: #10b981;
+  background: var(--emerald-500);
   color: white;
   border: none;
   border-radius: 8px;
@@ -84,7 +84,7 @@ defineEmits(['export', 'view-details', 'load-page'])
 }
 
 .btn-export:hover {
-  background: #059669;
+  background: var(--emerald-600);
   transform: translateY(-1px);
 }
 

--- a/src/components/attendance/AttendanceModalFooter.vue
+++ b/src/components/attendance/AttendanceModalFooter.vue
@@ -50,7 +50,7 @@ defineEmits(['export-pdf', 'export-excel', 'close'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
+  background: linear-gradient(135deg, var(--red-600) 0%, var(--red-700) 100%);
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -62,7 +62,7 @@ defineEmits(['export-pdf', 'export-excel', 'close'])
 }
 
 .btn-export-pdf:hover:not(:disabled) {
-  background: linear-gradient(135deg, #b91c1c 0%, var(--error-text) 100%);
+  background: linear-gradient(135deg, var(--red-700) 0%, var(--error-text) 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(220, 38, 38, 0.4);
 }
@@ -78,7 +78,7 @@ defineEmits(['export-pdf', 'export-excel', 'close'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: linear-gradient(135deg, var(--emerald-500) 0%, var(--emerald-600) 100%);
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -90,7 +90,7 @@ defineEmits(['export-pdf', 'export-excel', 'close'])
 }
 
 .btn-export-excel:hover:not(:disabled) {
-  background: linear-gradient(135deg, #059669 0%, #047857 100%);
+  background: linear-gradient(135deg, var(--emerald-600) 0%, var(--emerald-700) 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
 }

--- a/src/components/attendance/AttendanceModalTable.vue
+++ b/src/components/attendance/AttendanceModalTable.vue
@@ -178,20 +178,20 @@ function formatDuration(minutes) {
 
 /* Présent - Vert (≥80%) */
 .status-badge.status-present {
-  background: #D1FAE5;
-  color: #065F46;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 /* Partiel - Orange (50-79%) */
 .status-badge.status-partial {
   background: #FED7AA;
-  color: #92400E;
+  color: var(--amber-800);
 }
 
 /* Faible - Rouge clair (20-49%) */
 .status-badge.status-low {
-  background: #FECACA;
-  color: #7F1D1D;
+  background: var(--red-200);
+  color: var(--red-900);
 }
 
 /* Absent - Rouge foncé (<20%) */

--- a/src/components/attendance/AttendanceParticipationModal.vue
+++ b/src/components/attendance/AttendanceParticipationModal.vue
@@ -172,11 +172,11 @@ defineEmits(['close'])
 }
 
 .text-green {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 .text-red {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .modal-footer {

--- a/src/components/attendance/SeancePeriodFilters.vue
+++ b/src/components/attendance/SeancePeriodFilters.vue
@@ -108,7 +108,7 @@ defineEmits(['select-period', 'apply-custom', 'search', 'clear'])
 }
 
 .period-tab.active {
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   border-color: var(--blue-500);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
@@ -164,7 +164,7 @@ defineEmits(['select-period', 'apply-custom', 'search', 'clear'])
 
 .btn-primary-action {
   padding: 0.75rem 2rem;
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   border: none;
   border-radius: 0.5rem;
@@ -176,7 +176,7 @@ defineEmits(['select-period', 'apply-custom', 'search', 'clear'])
 }
 
 .btn-primary-action:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
 }

--- a/src/components/attendance/SeancesPagination.vue
+++ b/src/components/attendance/SeancesPagination.vue
@@ -59,7 +59,7 @@ defineEmits(['change-page'])
 }
 
 .pagination-btn:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   border-color: var(--blue-500);
   box-shadow: 0 2px 4px rgba(59, 130, 246, 0.2);

--- a/src/components/attendance/SeancesTable.vue
+++ b/src/components/attendance/SeancesTable.vue
@@ -206,15 +206,15 @@ defineEmits(['view-attendances', 'delete-seance', 'change-page'])
 }
 
 .rate-text.rate-high {
-  color: #10B981;
+  color: var(--emerald-500);
 }
 
 .rate-text.rate-medium {
-  color: #F59E0B;
+  color: var(--amber-500);
 }
 
 .rate-text.rate-low {
-  color: #EF4444;
+  color: var(--red-500);
 }
 
 /* Action Buttons */
@@ -238,13 +238,13 @@ defineEmits(['view-attendances', 'delete-seance', 'change-page'])
 }
 
 .btn-view:hover {
-  background: #2563eb;
+  background: var(--color-info-strong);
   transform: translateY(-1px);
 }
 
 .btn-delete {
   padding: 0.5rem 1rem;
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
   border: none;
   border-radius: 0.375rem;
@@ -255,7 +255,7 @@ defineEmits(['view-attendances', 'delete-seance', 'change-page'])
 }
 
 .btn-delete:hover {
-  background: #dc2626;
+  background: var(--red-600);
   transform: translateY(-1px);
 }
 </style>

--- a/src/components/calendar/CalendarLegend.vue
+++ b/src/components/calendar/CalendarLegend.vue
@@ -6,11 +6,11 @@
     </h3>
     <div class="legend-items">
       <div class="legend-item">
-        <div class="color-dot" style="background: #2563eb; /* LMS blue (séances) */"></div>
+        <div class="color-dot" style="background: var(--color-info-strong); /* LMS blue (séances) */"></div>
         <span>Séances</span>
       </div>
       <div class="legend-item">
-        <div class="color-dot" style="background: #10b981"></div>
+        <div class="color-dot" style="background: var(--emerald-500)"></div>
         <span>Visio active</span>
       </div>
       <div class="legend-item">
@@ -18,7 +18,7 @@
         <span>Évaluations</span>
       </div>
       <div class="legend-item">
-        <div class="color-dot" style="background: #ef4444"></div>
+        <div class="color-dot" style="background: var(--red-500)"></div>
         <span>Urgent (&lt; 24h)</span>
       </div>
     </div>

--- a/src/components/calendar/CalendarNavigation.vue
+++ b/src/components/calendar/CalendarNavigation.vue
@@ -149,8 +149,8 @@ $border-radius-lg: 8px;
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      border: 1px solid #10b981;
-      color: #10b981;
+      border: 1px solid var(--emerald-500);
+      color: var(--emerald-500);
       padding: 0.5rem 1rem;
       border-radius: $border-radius-md;
       background: transparent;
@@ -159,7 +159,7 @@ $border-radius-lg: 8px;
       cursor: pointer;
 
       &:hover:not(:disabled) {
-        background: #10b981;
+        background: var(--emerald-500);
         color: $white;
 
         .material-icons {

--- a/src/components/calendar/CalendarView.vue
+++ b/src/components/calendar/CalendarView.vue
@@ -120,8 +120,8 @@ $border-radius-lg: 8px;
 
   // En-tête des jours (lun, mar, mer, etc.) - Couleur sidebar
   .fc-col-header-cell {
-    background: linear-gradient(180deg, #0052cc 0%, #0747a6 100%);
-    border-color: #0747a6;
+    background: linear-gradient(180deg, var(--blue-600) 0%, var(--blue-700) 100%);
+    border-color: var(--blue-700);
 
     .fc-col-header-cell-cushion {
       color: $white;
@@ -171,8 +171,8 @@ $border-radius-lg: 8px;
 
   // Couleurs des événements
   .event-seance {
-    background: #2563eb; /* LMS blue (séances) */;
-    border-color: #2563eb; /* LMS blue */
+    background: var(--color-info-strong); /* LMS blue (séances) */;
+    border-color: var(--color-info-strong); /* LMS blue */
   }
 
   .event-evaluation {
@@ -181,8 +181,8 @@ $border-radius-lg: 8px;
   }
 
   .event-urgent {
-    background: #ef4444 !important;
-    border-color: #ef4444 !important;
+    background: var(--red-500) !important;
+    border-color: var(--red-500) !important;
     animation: pulse 2s infinite;
   }
 

--- a/src/components/calendar/EventDetailActions.vue
+++ b/src/components/calendar/EventDetailActions.vue
@@ -165,21 +165,21 @@ defineEmits(['action'])
 }
 
 .action-btn.success {
-  background: #10b981;
+  background: var(--emerald-500);
   color: white;
 }
 
 .action-btn.success:hover {
-  background: #059669;
+  background: var(--emerald-600);
 }
 
 .action-btn.danger {
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
 }
 
 .action-btn.danger:hover {
-  background: #dc2626;
+  background: var(--red-600);
 }
 
 .action-btn.secondary {
@@ -210,8 +210,8 @@ defineEmits(['action'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--amber-800);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   font-weight: 500;

--- a/src/components/calendar/EventDetailModal.vue
+++ b/src/components/calendar/EventDetailModal.vue
@@ -155,13 +155,13 @@ const {
 }
 
 .status-active {
-  background-color: #dcfce7;
+  background-color: var(--success-bg);
   color: #16a34a;
 }
 
 .status-scheduled {
-  background-color: #dbeafe;
-  color: #2563eb;
+  background-color: var(--blue-100);
+  color: var(--color-info-strong);
 }
 
 .status-ended {

--- a/src/components/calendar/EventSeanceDetails.vue
+++ b/src/components/calendar/EventSeanceDetails.vue
@@ -158,13 +158,13 @@ defineProps({
 }
 
 .visio-status.active {
-  background-color: #dcfce7;
+  background-color: var(--success-bg);
   color: #16a34a;
 }
 
 .visio-status.programmee {
-  background-color: #dbeafe;
-  color: #2563eb;
+  background-color: var(--blue-100);
+  color: var(--color-info-strong);
 }
 
 .visio-status.terminee {

--- a/src/components/classes/ClasseTabsNav.vue
+++ b/src/components/classes/ClasseTabsNav.vue
@@ -67,8 +67,8 @@ button[class*="px-6 py-4"] {
 .tab-button-active,
 button[class*="px-6"][class*="py-4"][class*="border-green-600"],
 button.px-6.py-4.font-medium.text-sm.border-b-2.transition.border-green-600.text-green-600 {
-  border-bottom-color: #10b981 !important;
-  color: #10b981 !important;
+  border-bottom-color: var(--emerald-500) !important;
+  color: var(--emerald-500) !important;
 }
 
 /* Disable hover effect */
@@ -78,7 +78,7 @@ button[class*="px-6 py-4"]:hover {
 
 /* Badge in tabs */
 button[class*="px-6 py-4"] span[class*="bg-green-100"] {
-  background: #10b981 !important;
+  background: var(--emerald-500) !important;
   color: white !important;
 }
 

--- a/src/components/common/ContentLoader.vue
+++ b/src/components/common/ContentLoader.vue
@@ -172,7 +172,7 @@ defineProps({
 }
 
 :deep([data-theme="dark"]) .letter-m {
-  color: #fbbf24;
+  color: var(--amber-400);
 }
 
 :deep([data-theme="dark"]) .letter-s {

--- a/src/components/common/PageLoader.vue
+++ b/src/components/common/PageLoader.vue
@@ -63,7 +63,7 @@ defineProps({
 
 .cap-center i {
   font-size: 3.5rem;
-  color: #ffffff;
+  color: var(--btn-primary-text);
   filter: drop-shadow(0 4px 12px rgba(255, 255, 255, 0.4));
   animation: cap-pulse 2s ease-in-out infinite;
 }
@@ -108,7 +108,7 @@ defineProps({
 
 /* Lettre M - position 120deg */
 .letter-m {
-  color: #fbbf24;
+  color: var(--amber-400);
   transform: translate(-50%, -50%) rotate(120deg) translateY(-65px) rotate(-120deg);
   animation: letter-scale-m 3s ease-in-out infinite;
 }

--- a/src/components/forum/ForumPostList.vue
+++ b/src/components/forum/ForumPostList.vue
@@ -88,7 +88,7 @@ defineEmits(['mark-solution'])
 /* Force proper backgrounds for BOTH modes - Using data-theme attribute */
 html[data-theme="light"] .light-mode-card,
 html:not([data-theme="dark"]) .light-mode-card {
-  background-color: #ffffff !important;
+  background-color: var(--card-bg) !important;
 }
 
 html[data-theme="dark"] .light-mode-card {

--- a/src/components/forum/ForumReplyForm.vue
+++ b/src/components/forum/ForumReplyForm.vue
@@ -60,7 +60,7 @@ defineEmits(['submit'])
 /* Force proper backgrounds for BOTH modes - Using data-theme attribute */
 html[data-theme="light"] .light-mode-card,
 html:not([data-theme="dark"]) .light-mode-card {
-  background-color: #ffffff !important;
+  background-color: var(--card-bg) !important;
 }
 
 html[data-theme="dark"] .light-mode-card {
@@ -70,7 +70,7 @@ html[data-theme="dark"] .light-mode-card {
 /* Textarea styling - FORCE visible text in all modes */
 html[data-theme="light"] .forum-textarea,
 html:not([data-theme="dark"]) .forum-textarea {
-  background-color: #ffffff !important;
+  background-color: var(--input-bg) !important;
   color: #1f2937 !important;
 }
 

--- a/src/components/forum/ForumTopicHeader.vue
+++ b/src/components/forum/ForumTopicHeader.vue
@@ -60,7 +60,7 @@ defineProps({
 /* Force proper backgrounds for BOTH modes - Using data-theme attribute */
 html[data-theme="light"] .light-mode-card,
 html:not([data-theme="dark"]) .light-mode-card {
-  background-color: #ffffff !important;
+  background-color: var(--card-bg) !important;
 }
 
 html[data-theme="dark"] .light-mode-card {

--- a/src/components/layout/MobileHeader.vue
+++ b/src/components/layout/MobileHeader.vue
@@ -161,7 +161,7 @@ const {
   right: 8px;
   width: 8px;
   height: 8px;
-  background: #ef4444;
+  background: var(--red-500);
   border-radius: 50%;
   border: 2px solid var(--card-bg);
 }

--- a/src/components/layout/mobile/MobileSidebarNav.vue
+++ b/src/components/layout/mobile/MobileSidebarNav.vue
@@ -137,7 +137,7 @@ function isActive(path) {
 }
 
 .logout-link {
-  color: #ef4444;
+  color: var(--red-500);
   margin-top: 0.5rem;
   border-top: 1px solid var(--border-color);
   padding-top: 1rem;

--- a/src/components/layout/mobile/MobileUserMenuPanel.vue
+++ b/src/components/layout/mobile/MobileUserMenuPanel.vue
@@ -158,7 +158,7 @@ defineEmits(['close', 'logout'])
 }
 
 .logout-item {
-  color: #ef4444;
+  color: var(--red-500);
   margin-top: 0.5rem;
   border-top: 1px solid var(--border-color);
   border-radius: 0;

--- a/src/components/layout/navbar/NavbarNotifications.vue
+++ b/src/components/layout/navbar/NavbarNotifications.vue
@@ -102,7 +102,7 @@ const getIconEmoji = (iconCode) => {
   position: absolute;
   top: 4px;
   right: 4px;
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
   font-size: 0.625rem;
   font-weight: 700;

--- a/src/components/matieres/CreateLessonModal.vue
+++ b/src/components/matieres/CreateLessonModal.vue
@@ -209,7 +209,7 @@ defineEmits(['close', 'submit'])
 
 .form-label.required::after {
   content: ' *';
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .form-input,
@@ -229,7 +229,7 @@ defineEmits(['close', 'submit'])
 .form-textarea:focus,
 .form-select:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--blue-500);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
@@ -269,12 +269,12 @@ defineEmits(['close', 'submit'])
 }
 
 .btn-primary {
-  background-color: #3b82f6;
+  background-color: var(--blue-500);
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background-color: #2563eb;
+  background-color: var(--color-info-strong);
 }
 
 .btn-primary:disabled {

--- a/src/components/matieres/MatiereLessonsTab.vue
+++ b/src/components/matieres/MatiereLessonsTab.vue
@@ -134,7 +134,7 @@ defineEmits(['create', 'view', 'edit', 'delete', 'publish', 'unpublish'])
 
 .toggle-btn.active {
   background: var(--card-bg);
-  color: #3b82f6;
+  color: var(--blue-500);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 

--- a/src/components/matieres/MatiereNotifications.vue
+++ b/src/components/matieres/MatiereNotifications.vue
@@ -98,30 +98,30 @@ defineProps({
 
 /* Success notification */
 .notification-success {
-  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  background: linear-gradient(135deg, var(--emerald-500) 0%, var(--emerald-600) 100%);
   color: white;
-  border-left: 4px solid #065f46;
+  border-left: 4px solid var(--emerald-800);
 }
 
 /* Error notification */
 .notification-error {
-  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+  background: linear-gradient(135deg, var(--red-500) 0%, var(--red-600) 100%);
   color: white;
-  border-left: 4px solid #991b1b;
+  border-left: 4px solid var(--error-text);
 }
 
 /* Warning notification */
 .notification-warning {
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+  background: linear-gradient(135deg, var(--amber-500) 0%, var(--amber-600) 100%);
   color: white;
-  border-left: 4px solid #92400e;
+  border-left: 4px solid var(--amber-800);
 }
 
 /* Info notification */
 .notification-info {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
-  border-left: 4px solid #1e40af;
+  border-left: 4px solid var(--info-text);
 }
 
 /* Transitions pour Vue */

--- a/src/components/modals/GenerateReportModal.vue
+++ b/src/components/modals/GenerateReportModal.vue
@@ -238,7 +238,7 @@ onMounted(() => {
 }
 
 .required {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .form-input,
@@ -262,7 +262,7 @@ onMounted(() => {
 .error-message {
   padding: 0.75rem;
   background: var(--error-bg);
-  color: #dc2626;
+  color: var(--red-600);
   border-radius: 0.5rem;
   font-size: 0.875rem;
 }

--- a/src/components/modals/QuickAddTeacherModal.vue
+++ b/src/components/modals/QuickAddTeacherModal.vue
@@ -221,7 +221,7 @@ onMounted(() => {
 }
 
 .required {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .form-input,
@@ -259,7 +259,7 @@ onMounted(() => {
 .error-message {
   padding: 0.75rem;
   background: var(--error-bg);
-  color: #dc2626;
+  color: var(--red-600);
   border-radius: 0.5rem;
   font-size: 0.875rem;
 }

--- a/src/components/modals/QuickCreateClasseModal.vue
+++ b/src/components/modals/QuickCreateClasseModal.vue
@@ -225,7 +225,7 @@ onMounted(() => {
 }
 
 .required {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .form-input,
@@ -273,7 +273,7 @@ onMounted(() => {
 .error-message {
   padding: 0.75rem;
   background: var(--error-bg);
-  color: #dc2626;
+  color: var(--red-600);
   border-radius: 0.5rem;
   font-size: 0.875rem;
 }

--- a/src/components/seances/CoordinatorSeanceCard.vue
+++ b/src/components/seances/CoordinatorSeanceCard.vue
@@ -195,7 +195,7 @@ const formatDate = (date) => {
 
 .visio-active {
   background: #f3e8ff;
-  color: #7c3aed;
+  color: var(--violet-600);
 }
 
 .visio-active:hover {

--- a/src/components/seances/CoordinatorSeanceStats.vue
+++ b/src/components/seances/CoordinatorSeanceStats.vue
@@ -58,7 +58,7 @@ defineProps({
 }
 
 .stat-card-primary .stat-label {
-  color: #7c3aed;
+  color: var(--violet-600);
 }
 
 .stat-value {
@@ -69,7 +69,7 @@ defineProps({
 }
 
 .stat-card-primary .stat-value {
-  color: #6d28d9;
+  color: var(--violet-700);
 }
 
 /* Responsive */

--- a/src/components/seances/CoordinatorVisioPanel.vue
+++ b/src/components/seances/CoordinatorVisioPanel.vue
@@ -169,7 +169,7 @@ defineEmits(['show-participants', 'join'])
 }
 
 .participants-btn:hover {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 .open-jitsi-btn {
@@ -199,7 +199,7 @@ defineEmits(['show-participants', 'join'])
   padding: 0.75rem 1.25rem;
   background: var(--warning-bg);
   border-radius: 0.5rem;
-  border: 1px solid #fcd34d;
+  border: 1px solid var(--amber-300);
 }
 
 .waiting-icon {
@@ -210,7 +210,7 @@ defineEmits(['show-participants', 'join'])
 .waiting-text {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #92400e;
+  color: var(--amber-800);
 }
 
 /* btn-icon : partagé avec la carte (copie verbatim pour le scoping) */

--- a/src/components/seances/TeacherSeancesStats.vue
+++ b/src/components/seances/TeacherSeancesStats.vue
@@ -88,7 +88,7 @@ defineProps({
 }
 
 .stat-icon-scheduled {
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .stat-icon-finished {

--- a/src/components/search/SearchResultsList.vue
+++ b/src/components/search/SearchResultsList.vue
@@ -124,18 +124,18 @@ defineEmits(['select', 'highlight'])
 }
 
 .icon-user {
-  background: #dbeafe;
-  color: #1e40af;
+  background: var(--info-bg);
+  color: var(--info-text);
 }
 
 .icon-lesson {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 .icon-evaluation {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--warning-bg);
+  color: var(--amber-800);
 }
 
 .icon-classe {
@@ -144,8 +144,8 @@ defineEmits(['select', 'highlight'])
 }
 
 .icon-matiere {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--error-bg);
+  color: var(--error-text);
 }
 
 .result-content {

--- a/src/components/visio/JitsiModal.vue
+++ b/src/components/visio/JitsiModal.vue
@@ -163,7 +163,7 @@ watch(() => props.isOpen, (newValue) => {
 
 .close-button {
   color: white;
-  background: #ef4444;
+  background: var(--red-500);
   border: none;
   border-radius: 0.375rem;
   padding: 0.5rem;
@@ -175,7 +175,7 @@ watch(() => props.isOpen, (newValue) => {
 }
 
 .close-button:hover {
-  background: #dc2626;
+  background: var(--red-600);
 }
 
 /* Contenu Jitsi */

--- a/src/components/visio/VisioSeanceCard.vue
+++ b/src/components/visio/VisioSeanceCard.vue
@@ -261,25 +261,25 @@ defineEmits(['start', 'end', 'activate'])
 }
 
 .btn-start:hover {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 .btn-activate {
-  background: #f59e0b;
+  background: var(--amber-500);
   color: white;
 }
 
 .btn-activate:hover {
-  background: #d97706;
+  background: var(--amber-600);
 }
 
 .btn-end {
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
 }
 
 .btn-end:hover {
-  background: #dc2626;
+  background: var(--red-600);
 }
 
 /* Responsive */

--- a/src/components/widgets/CalendarEventModal.vue
+++ b/src/components/widgets/CalendarEventModal.vue
@@ -206,7 +206,7 @@ function formatEventTime(date) {
 }
 
 .action-btn:hover {
-  background: #2563eb;
+  background: var(--color-info-strong);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
 }

--- a/src/components/widgets/CalendarWidget.vue
+++ b/src/components/widgets/CalendarWidget.vue
@@ -212,17 +212,17 @@ const {
 /* Event Styles */
 :deep(.event-seance) {
   background: var(--blue-500) !important;
-  border-color: #2563eb !important;
+  border-color: var(--color-info-strong) !important;
 }
 
 :deep(.event-evaluation) {
-  background: #f59e0b !important;
-  border-color: #d97706 !important;
+  background: var(--amber-500) !important;
+  border-color: var(--amber-600) !important;
 }
 
 :deep(.event-visio) {
-  background: #10b981 !important;
-  border-color: #059669 !important;
+  background: var(--emerald-500) !important;
+  border-color: var(--emerald-600) !important;
 }
 
 :deep(.fc-event) {

--- a/src/components/widgets/CalendarWidgetLegend.vue
+++ b/src/components/widgets/CalendarWidgetLegend.vue
@@ -49,11 +49,11 @@
 }
 
 .legend-dot.evaluation {
-  background: #f59e0b;
+  background: var(--amber-500);
 }
 
 .legend-dot.visio {
-  background: #10b981;
+  background: var(--emerald-500);
 }
 
 .legend-label {

--- a/src/components/widgets/NotificationItem.vue
+++ b/src/components/widgets/NotificationItem.vue
@@ -121,13 +121,13 @@ function getIconComponent(iconName) {
 }
 
 .type-success {
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
 }
 
 .type-warning {
   background: var(--warning-bg);
-  color: #92400e;
+  color: var(--amber-800);
 }
 
 .type-danger {
@@ -189,21 +189,21 @@ function getIconComponent(iconName) {
 }
 
 .mark-read-btn {
-  color: #10b981;
+  color: var(--emerald-500);
 }
 
 .mark-read-btn:hover {
-  background: #d1fae5;
-  border-color: #10b981;
+  background: var(--emerald-100);
+  border-color: var(--emerald-500);
 }
 
 .delete-btn {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .delete-btn:hover {
   background: var(--error-bg);
-  border-color: #ef4444;
+  border-color: var(--red-500);
 }
 
 /* Responsive */

--- a/src/components/widgets/NotificationsWidget.vue
+++ b/src/components/widgets/NotificationsWidget.vue
@@ -132,7 +132,7 @@ const {
 }
 
 .widget-icon.has-unread {
-  color: #f59e0b;
+  color: var(--amber-500);
   animation: ring 2s ease-in-out infinite;
 }
 
@@ -156,7 +156,7 @@ const {
   min-width: 1.5rem;
   height: 1.5rem;
   padding: 0 0.5rem;
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
   border-radius: 9999px;
   font-size: 0.75rem;
@@ -272,7 +272,7 @@ const {
 }
 
 .view-all-link:hover {
-  color: #2563eb;
+  color: var(--color-info-strong);
   text-decoration: underline;
 }
 


### PR DESCRIPTION
Closes #141.

## Quoi
Re-grep du périmètre #141 sur `origin/dev` (après #135/#136 et les lots #125–#129 déjà mergés) et remplacement **mécanique** des couleurs en dur par les `var(--…)` exacts de `themes.css`. **137 remplacements, 47 fichiers `.vue`** (swaps mono-ligne uniquement, 137 ins / 137 del).

Périmètre : `calendar, attendance, seances, visio, common, widgets, modals, classes, matieres, coordinateur, forum, search, charts, layout` + `Navbar.vue`.

## Règles appliquées (convention #126/#113)
- **Aucun changement visuel en clair** ; le sombre s'adapte via le token.
- Accents **theme-invariant** (`--emerald/red/amber/indigo/violet-*`, `--color-info-strong`) → valeur identique clair+sombre, pixel-identique.
- Tokens **per-theme** remplacés uniquement quand la **valeur light-mode == valeur en dur** (bleu, statuts, neutres), choix **par propriété CSS**.
- `calendar/` : couleurs remplacées **sur place**, y compris dans les blocs `:deep()` du chrome partagé dans le parent (structure parent/enfant intacte).
- `#ffffff` désambiguïsé par propriété (`--card-bg` / `--input-bg` / `--btn-primary-text`) ; blancs ambigus laissés.

## Vérifications
- **Build vite vert** (`✓ built in 28.37s`, seul warning préexistant de taille de chunk).
- Appariement **valeur ↔ token** contrôlé par script (multiset par fichier) : chaque hex remplacé == valeur **light-mode** exacte du token.
- 0 double-wrap `var(--x, var(--x))`, 0 fallback `var(--token, #hex)` cassé.
- 1 bug intercepté en revue et corrigé (`SearchResultsList.vue` : `--emerald-900` → `--emerald-800` pour `#065f46`).

## Laissé volontairement (aucun token exact — cf. #136 qui ne crée pas ces familles)
- **Gris Tailwind** `#1f2937 #374151 #6b7280 #9ca3af #e5e7eb #4b5563 #f9fafb #f3f4f6 #2d3748` — surtout `forum/` (blocs clair+sombre manuels).
- **Verts hors-palette** `#22c55e #16a34a #15803d`, `#1d4ed8`, cyan `#06b6d4`, orange `#ea580c`, violets one-off (`#f3e8ff #6b21a8 #c084fc #e9d5ff`).
- **Couleurs de marque** : loader `#1B3B6F #FFB81C #2D5A9E`, logo SVG SidebarHeader `#1E6FD9 #1F2937`.
- **Blocs `[data-theme="dark"]` manuels** : valeurs bleues per-theme laissées (les remplacer changerait le sombre) ; seul l'amber theme-invariant y a été tokenisé.
- `charts/ActivityChart.vue` : couleurs dans les options JS Chart.js (non CSS).

### rgba() d'ombres/overlays laissés (signalés)
`themes.css` n'expose que des `box-shadow` complets (`--shadow-*`, `--card-shadow`), pas de token rgba mono-valeur → non remplaçables :
- Ombres noires `rgba(0,0,0,0.04…0.95)` (overlays plein écran visio, modals, widgets, cartes).
- Overlays d'accent `rgba(59,130,246,·)` bleu, `rgba(34,197,94,·)` vert, `rgba(99,102,241,0.1)` indigo, `rgba(255,255,255,·)` blanc.

## DoD
0 couleur **remplaçable** (= avec token exact) restante dans le périmètre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
