### PR TITLE
chore(theme): tokens evaluations + ui (#139)

### DIFF
--- a/src/components/evaluations/EvalResultCountdown.vue
+++ b/src/components/evaluations/EvalResultCountdown.vue
@@ -58,7 +58,7 @@ defineProps({
 /* Alerte de compte à rebours */
 .countdown-alert {
   background-color: var(--bg-tertiary);
-  border-left: 4px solid #f59e0b;
+  border-left: 4px solid var(--amber-500);
   border-radius: 0.5rem;
   padding: 1rem;
   margin-bottom: 1.5rem;
@@ -66,7 +66,7 @@ defineProps({
 }
 
 .countdown-alert svg {
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .countdown-title {
@@ -82,18 +82,18 @@ defineProps({
   box-shadow: var(--card-shadow);
   padding: 1rem;
   text-align: center;
-  border: 2px solid #fbbf24;
+  border: 2px solid var(--amber-400);
 }
 
 .countdown-number {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .countdown-label {
   font-size: 0.75rem;
-  color: #d97706;
+  color: var(--amber-600);
   font-weight: 600;
 }
 
@@ -113,7 +113,7 @@ defineProps({
 }
 
 .progress-bar-fill {
-  background-color: #f59e0b;
+  background-color: var(--amber-500);
   height: 0.5rem;
   border-radius: 9999px;
   transition: all 0.5s;
@@ -121,7 +121,7 @@ defineProps({
 
 .countdown-percent {
   font-size: 0.75rem;
-  color: #d97706;
+  color: var(--amber-600);
   margin-top: 0.25rem;
 }
 

--- a/src/components/evaluations/EvaluationCardActions.vue
+++ b/src/components/evaluations/EvaluationCardActions.vue
@@ -118,69 +118,69 @@ defineEmits(['create', 'edit', 'view-results', 'publish', 'preview', 'sync', 'de
 }
 
 .btn-create {
-  background: linear-gradient(135deg, var(--blue-500) 0%, #2563eb 100%);
+  background: linear-gradient(135deg, var(--blue-500) 0%, var(--color-info-strong) 100%);
   color: white;
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
 }
 
 .btn-create:hover:not(:disabled) {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
 }
 
 .btn-edit {
-  background: #f59e0b;
+  background: var(--amber-500);
   color: white;
 }
 
 .btn-edit:hover:not(:disabled) {
-  background: #d97706;
+  background: var(--amber-600);
 }
 
 .btn-view-results {
-  background: #8b5cf6;
+  background: var(--violet-500);
   color: white;
 }
 
 .btn-view-results:hover:not(:disabled) {
-  background: #7c3aed;
+  background: var(--violet-600);
 }
 
 .btn-sync {
-  background: #22c55e;
+  background: var(--emerald-500);
   color: white;
 }
 
 .btn-sync:hover:not(:disabled) {
-  background: #16a34a;
+  background: var(--emerald-600);
 }
 
 .btn-publish {
-  background: #8b5cf6;
+  background: var(--violet-500);
   color: white;
 }
 
 .btn-publish:hover:not(:disabled) {
-  background: #7c3aed;
+  background: var(--violet-600);
 }
 
 .btn-preview {
-  background: #6366f1;
+  background: var(--indigo-500);
   color: white;
 }
 
 .btn-preview:hover:not(:disabled) {
-  background: #4f46e5;
+  background: var(--indigo-600);
 }
 
 .btn-delete {
-  background: #ef4444;
+  background: var(--red-500);
   color: white;
 }
 
 .btn-delete:hover:not(:disabled) {
-  background: #dc2626;
+  background: var(--red-600);
 }
 
 .animate-spin {

--- a/src/components/evaluations/EvaluationCardHeader.vue
+++ b/src/components/evaluations/EvaluationCardHeader.vue
@@ -129,8 +129,8 @@ function getStatusIcon(status) {
 
 .status-badge-draft {
   background: var(--warning-bg);
-  color: #92400e;
-  border: 1px solid #fde68a;
+  color: var(--amber-800);
+  border: 1px solid var(--amber-200);
 }
 
 .status-badge-default {
@@ -147,9 +147,9 @@ function getStatusIcon(status) {
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 600;
-  background: #d1fae5;
-  color: #065f46;
-  border: 1px solid #6ee7b7;
+  background: var(--emerald-100);
+  color: var(--emerald-800);
+  border: 1px solid var(--emerald-300);
   cursor: help;
   transition: all 0.2s;
 }

--- a/src/components/evaluations/EvaluationCardStatus.vue
+++ b/src/components/evaluations/EvaluationCardStatus.vue
@@ -83,16 +83,16 @@ defineProps({
 }
 
 .status-pending {
-  border-color: #f59e0b;
+  border-color: var(--amber-500);
   background: rgba(245, 158, 11, 0.05);
 }
 
 .status-pending .status-icon {
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .status-pending .status-text {
-  color: #d97706;
+  color: var(--amber-600);
 }
 
 .status-pending .status-detail {
@@ -100,12 +100,12 @@ defineProps({
 }
 
 .status-active {
-  border-color: #10b981;
+  border-color: var(--emerald-500);
   background: rgba(16, 185, 129, 0.05);
 }
 
 .status-active .status-text {
-  color: #059669;
+  color: var(--emerald-600);
 }
 
 .status-active .status-detail {
@@ -138,7 +138,7 @@ defineProps({
 .pulse-dot {
   width: 0.75rem;
   height: 0.75rem;
-  background: #22c55e;
+  background: var(--emerald-500);
   border-radius: 50%;
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   flex-shrink: 0;
@@ -179,7 +179,7 @@ defineProps({
 .online-icon {
   width: 1.5rem;
   height: 1.5rem;
-  color: #2563eb;
+  color: var(--color-info-strong);
   flex-shrink: 0;
 }
 

--- a/src/components/evaluations/PreviewActionsFooter.vue
+++ b/src/components/evaluations/PreviewActionsFooter.vue
@@ -124,7 +124,7 @@ defineEmits(['back', 'edit', 'publish'])
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: #22c55e;
+  background: var(--emerald-500);
   color: white;
   border: none;
   border-radius: var(--radius-md);
@@ -134,7 +134,7 @@ defineEmits(['back', 'edit', 'publish'])
 }
 
 .btn-publish:hover:not(:disabled) {
-  background: #16a34a;
+  background: var(--emerald-600);
   transform: translateY(-1px);
 }
 

--- a/src/components/evaluations/PreviewProgress.vue
+++ b/src/components/evaluations/PreviewProgress.vue
@@ -51,7 +51,7 @@ defineProps({
 
 .progress-bar {
   height: 100%;
-  background: linear-gradient(90deg, #8b5cf6 0%, #6366f1 100%);
+  background: linear-gradient(90deg, var(--violet-500) 0%, var(--indigo-500) 100%);
   border-radius: var(--radius-full);
   transition: width 0.3s ease;
 }

--- a/src/components/evaluations/PreviewQuestionsList.vue
+++ b/src/components/evaluations/PreviewQuestionsList.vue
@@ -118,14 +118,14 @@ defineEmits(['select'])
 
 .preview-badge {
   background: rgba(139, 92, 246, 0.1);
-  color: #8b5cf6;
+  color: var(--violet-500);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-md);
   font-size: 0.75rem;
 }
 
 .answered-icon {
-  color: #8b5cf6;
+  color: var(--violet-500);
 }
 
 .question-text {
@@ -158,12 +158,12 @@ defineEmits(['select'])
 }
 
 .option-button:hover {
-  border-color: #8b5cf6;
+  border-color: var(--violet-500);
   background: rgba(139, 92, 246, 0.05);
 }
 
 .option-button.option-selected {
-  border-color: #8b5cf6;
+  border-color: var(--violet-500);
   background: rgba(139, 92, 246, 0.1);
 }
 
@@ -180,8 +180,8 @@ defineEmits(['select'])
 }
 
 .option-radio.selected {
-  border-color: #8b5cf6;
-  background: #8b5cf6;
+  border-color: var(--violet-500);
+  background: var(--violet-500);
 }
 
 .option-radio-dot {
@@ -210,7 +210,7 @@ defineEmits(['select'])
 
 .answer-input:focus {
   outline: none;
-  border-color: #8b5cf6;
+  border-color: var(--violet-500);
   background: var(--input-bg);
 }
 

--- a/src/components/evaluations/ResultChoiceOptions.vue
+++ b/src/components/evaluations/ResultChoiceOptions.vue
@@ -178,13 +178,13 @@ defineProps({
 /* Classes personnalisées pour les options - avec correction */
 .option-correct {
   background-color: rgba(34, 197, 94, 0.15) !important;
-  border: 2px solid #22c55e !important;
+  border: 2px solid var(--emerald-500) !important;
   border-radius: 0.5rem;
 }
 
 .option-incorrect {
   background-color: rgba(239, 68, 68, 0.15) !important;
-  border: 2px solid #ef4444 !important;
+  border: 2px solid var(--red-500) !important;
   border-radius: 0.5rem;
 }
 
@@ -214,12 +214,12 @@ defineProps({
 
 /* Texte dans bonnes réponses */
 .option-correct .option-text {
-  color: #22c55e !important;
+  color: var(--emerald-500) !important;
 }
 
 /* Texte dans mauvaises réponses */
 .option-incorrect .option-text {
-  color: #ef4444 !important;
+  color: var(--red-500) !important;
 }
 
 /* Texte dans options neutres */

--- a/src/components/evaluations/TakeEvaluationActions.vue
+++ b/src/components/evaluations/TakeEvaluationActions.vue
@@ -79,7 +79,7 @@ defineEmits(['cancel', 'submit'])
 }
 
 .btn-submit:hover {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background: linear-gradient(135deg, var(--color-info-strong), #1d4ed8);
   transform: translateY(-1px);
 }
 

--- a/src/components/evaluations/TakeEvaluationBanners.vue
+++ b/src/components/evaluations/TakeEvaluationBanners.vue
@@ -51,11 +51,11 @@ defineProps({
   align-items: center;
   gap: 1rem;
   padding: 1rem 1.5rem;
-  background: linear-gradient(135deg, #f3e8ff, #ede9fe);
-  border: 2px solid #8b5cf6;
+  background: linear-gradient(135deg, #f3e8ff, var(--violet-100));
+  border: 2px solid var(--violet-500);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
-  color: #5b21b6;
+  color: var(--violet-800);
 }
 
 .practice-banner .fa {
@@ -82,7 +82,7 @@ defineProps({
   gap: 1rem;
   padding: 1rem 1.5rem;
   background: var(--error-bg);
-  border: 2px solid #ef4444;
+  border: 2px solid var(--red-500);
   border-radius: 0.75rem;
   margin-bottom: 1.5rem;
   animation: pulse 2s infinite;

--- a/src/components/evaluations/TakeEvaluationHeader.vue
+++ b/src/components/evaluations/TakeEvaluationHeader.vue
@@ -93,11 +93,11 @@ defineProps({
 }
 
 .timer-warning .timer-value {
-  color: #f59e0b;
+  color: var(--amber-500);
 }
 
 .timer-danger .timer-value {
-  color: #ef4444;
+  color: var(--red-500);
   animation: pulse 1s infinite;
 }
 

--- a/src/components/evaluations/TakeQuestionCard.vue
+++ b/src/components/evaluations/TakeQuestionCard.vue
@@ -111,7 +111,7 @@ defineEmits(['toggle-multiple'])
 }
 
 .question-answered {
-  border-left-color: #22c55e;
+  border-left-color: var(--emerald-500);
 }
 
 .question-header {
@@ -142,7 +142,7 @@ defineEmits(['toggle-multiple'])
 }
 
 .question-check {
-  color: #22c55e;
+  color: var(--emerald-500);
   font-size: 1.25rem;
 }
 

--- a/src/components/evaluations/TakeResultModals.vue
+++ b/src/components/evaluations/TakeResultModals.vue
@@ -102,7 +102,7 @@ defineEmits(['close-confirm', 'submit', 'return'])
 }
 
 .btn-submit:hover {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background: linear-gradient(135deg, var(--color-info-strong), #1d4ed8);
   transform: translateY(-1px);
 }
 
@@ -117,13 +117,13 @@ defineEmits(['close-confirm', 'submit', 'return'])
 }
 
 .results-practice {
-  border-color: #8b5cf6 !important;
-  background: #f5f3ff !important;
+  border-color: var(--violet-500) !important;
+  background: var(--violet-50) !important;
 }
 
 .practice-note-info {
   font-size: 0.8rem;
-  color: #7c3aed;
+  color: var(--violet-600);
   margin-top: 0.5rem;
   font-style: italic;
 }
@@ -172,7 +172,7 @@ defineEmits(['close-confirm', 'submit', 'return'])
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   background: var(--warning-bg);
-  color: #92400e;
+  color: var(--amber-800);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   font-weight: 500;
@@ -197,7 +197,7 @@ defineEmits(['close-confirm', 'submit', 'return'])
 
 .results-icon .fa {
   font-size: 3rem;
-  color: #22c55e;
+  color: var(--emerald-500);
 }
 
 /* Results score */

--- a/src/components/evaluations/TeacherEvalCreateModal.vue
+++ b/src/components/evaluations/TeacherEvalCreateModal.vue
@@ -201,7 +201,7 @@ defineEmits(['close', 'submit'])
 
 .form-label.required::after {
   content: ' *';
-  color: #dc2626;
+  color: var(--red-600);
 }
 
 .form-select,
@@ -268,7 +268,7 @@ defineEmits(['close', 'submit'])
 }
 
 .btn-submit:hover:not(:disabled) {
-  background: #2563eb;
+  background: var(--color-info-strong);
 }
 
 .btn-submit:disabled {

--- a/src/components/ui/ProgressBar.vue
+++ b/src/components/ui/ProgressBar.vue
@@ -174,7 +174,7 @@ export default {
 }
 
 .progress-green {
-  background: linear-gradient(90deg, #22c55e 0%, #16a34a 100%);
+  background: linear-gradient(90deg, var(--emerald-500) 0%, var(--emerald-600) 100%);
 }
 
 .progress-yellow {
@@ -182,14 +182,14 @@ export default {
 }
 
 .progress-red {
-  background: linear-gradient(90deg, #ef4444 0%, #dc2626 100%);
+  background: linear-gradient(90deg, var(--red-500) 0%, var(--red-600) 100%);
 }
 
 .progress-purple {
-  background: linear-gradient(90deg, #a855f7 0%, #9333ea 100%);
+  background: linear-gradient(90deg, var(--violet-500) 0%, var(--violet-600) 100%);
 }
 
 .progress-gradient {
-  background: linear-gradient(90deg, #06b6d4 0%, #3b82f6 50%, #a855f7 100%);
+  background: linear-gradient(90deg, #06b6d4 0%, var(--blue-500) 50%, var(--violet-500) 100%);
 }
 </style>

--- a/src/components/ui/QuickActionButton.vue
+++ b/src/components/ui/QuickActionButton.vue
@@ -86,8 +86,8 @@ function handleClick() {
 
 /* Variants */
 .quick-action-btn.primary:hover:not(:disabled) {
-  border-color: #3b82f6;
-  background: #3b82f6;
+  border-color: var(--blue-500);
+  background: var(--blue-500);
 }
 
 .quick-action-btn.primary:hover:not(:disabled) .action-icon {
@@ -112,8 +112,8 @@ function handleClick() {
 }
 
 .quick-action-btn.success:hover:not(:disabled) {
-  border-color: #10b981;
-  background: #10b981;
+  border-color: var(--emerald-500);
+  background: var(--emerald-500);
 }
 
 .quick-action-btn.success:hover:not(:disabled) .action-icon {
@@ -125,8 +125,8 @@ function handleClick() {
 }
 
 .quick-action-btn.warning:hover:not(:disabled) {
-  border-color: #f59e0b;
-  background: #f59e0b;
+  border-color: var(--amber-500);
+  background: var(--amber-500);
 }
 
 .quick-action-btn.warning:hover:not(:disabled) .action-icon {
@@ -138,8 +138,8 @@ function handleClick() {
 }
 
 .quick-action-btn.danger:hover:not(:disabled) {
-  border-color: #ef4444;
-  background: #ef4444;
+  border-color: var(--red-500);
+  background: var(--red-500);
 }
 
 .quick-action-btn.danger:hover:not(:disabled) .action-icon {

--- a/src/components/ui/StatCard.vue
+++ b/src/components/ui/StatCard.vue
@@ -196,11 +196,11 @@ export default {
 }
 
 .trend-up {
-  color: #22c55e;
+  color: var(--emerald-500);
 }
 
 .trend-down {
-  color: #ef4444;
+  color: var(--red-500);
 }
 
 .trend-neutral {

--- a/src/components/ui/Toast.vue
+++ b/src/components/ui/Toast.vue
@@ -154,78 +154,78 @@ export default {
 
 /* Success Toast */
 .toast-success {
-  border-left-color: #10B981;
+  border-left-color: var(--emerald-500);
   background: #F0FDF4;
 }
 
 .toast-success .toast-icon {
-  color: #10B981;
-  background: #D1FAE5;
+  color: var(--emerald-500);
+  background: var(--emerald-100);
 }
 
 .toast-success .toast-title {
-  color: #065F46;
+  color: var(--emerald-800);
 }
 
 .toast-success .toast-message {
-  color: #047857;
+  color: var(--emerald-700);
 }
 
 /* Error Toast */
 .toast-error {
-  border-left-color: #EF4444;
-  background: #FEF2F2;
+  border-left-color: var(--red-500);
+  background: var(--red-50);
 }
 
 .toast-error .toast-icon {
-  color: #EF4444;
-  background: #FEE2E2;
+  color: var(--red-500);
+  background: var(--error-bg);
 }
 
 .toast-error .toast-title {
-  color: #991B1B;
+  color: var(--error-text);
 }
 
 .toast-error .toast-message {
-  color: #B91C1C;
+  color: var(--red-700);
 }
 
 /* Warning Toast */
 .toast-warning {
-  border-left-color: #F59E0B;
-  background: #FFFBEB;
+  border-left-color: var(--amber-500);
+  background: var(--amber-50);
 }
 
 .toast-warning .toast-icon {
-  color: #F59E0B;
-  background: #FEF3C7;
+  color: var(--amber-500);
+  background: var(--warning-bg);
 }
 
 .toast-warning .toast-title {
-  color: #92400E;
+  color: var(--amber-800);
 }
 
 .toast-warning .toast-message {
-  color: #B45309;
+  color: var(--amber-700);
 }
 
 /* Info Toast */
 .toast-info {
-  border-left-color: #3B82F6;
-  background: #EFF6FF;
+  border-left-color: var(--blue-500);
+  background: var(--blue-50);
 }
 
 .toast-info .toast-icon {
-  color: #3B82F6;
-  background: #DBEAFE;
+  color: var(--blue-500);
+  background: var(--info-bg);
 }
 
 .toast-info .toast-title {
-  color: #1E40AF;
+  color: var(--info-text);
 }
 
 .toast-info .toast-message {
-  color: #2563EB;
+  color: var(--color-info-strong);
 }
 
 /* Animation */


### PR DESCRIPTION
Closes #139. Round correctif #114, suite de #135 (audit v2) et #136 (tokens sémantiques).

## Ce qui est fait
Remplacement **mécanique 1:1** des couleurs en dur par les `var(--…)` exacts de `themes.css` dans `src/components/evaluations/**` et `src/components/ui/**`.
**101 occurrences, 18 fichiers**, light pixel-identique (compte de lignes inchangé).

- **Accents solides** → palette brute theme-invariante (#136) : `--emerald/red/amber/indigo/violet-*` (identique light ET dark). `#2563eb` → `--color-info-strong`.
- **Surfaces statut « remplaçable »** → tokens adaptatifs : `--info-bg/-text`, `--error-bg/-text`, `--warning-bg`, `--blue-50/100/400/500` (dark s'adapte, convention #112/#113).
- **Consolidation #136 assumée** : green Tailwind (`#22c55e`/`#16a34a`) → emerald, purple (`#a855f7`/`#9333ea`) → violet. ⚠️ Léger décalage de teinte (vert→sarcelle surtout), conforme à la décision déclarée de #136.

## Laissés et signalés (aucun token exact dans themes.css)
- **rgba() d'ombres/overlays/glows** (noir, blanc, alphas colorés) : pas d'équivalent token en light+dark.
- **hex hors périmètre #136** (nécessiteraient de nouveaux tokens) : gris Tailwind `#6b7280`/`#4b5563`/`#e5e7eb`/`#f3f4f6`, `#1d4ed8` (fin de dégradé), jaune `#facc15`/`#eab308`, cyan `#06b6d4`, `#f3e8ff`, `#F0FDF4`.

## DoD
✅ 0 couleur **remplaçable** en dur dans le périmètre (hex avec token exact, ou sémantique via #136).

## Vérification
✅ `vite build` vert — `built in 30s`, 0 erreur (seul l'avertissement de taille de chunk préexistant `LessonChapters` subsiste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)