### PR TITLE
chore(theme): échelles gray + sky + --color-info-stronger, tokenise le reliquat admin (dette #137)

### DIFF
--- a/src/assets/styles/themes.css
+++ b/src/assets/styles/themes.css
@@ -125,6 +125,37 @@
   --violet-800: #5b21b6;
   --violet-900: #4c1d95;
 
+  /* Sky — cyan/info-adjacent accent (#0ea5e9 &c.); recurring sky tones
+     (badges « visio/permissions », dégradés d'en-tête) sans équivalent
+     dans le --blue-* de marque (azure). */
+  --sky-50: #f0f9ff;
+  --sky-100: #e0f2fe;
+  --sky-200: #bae6fd;
+  --sky-300: #7dd3fc;
+  --sky-400: #38bdf8;
+  --sky-500: #0ea5e9;
+  --sky-600: #0284c7;
+  --sky-700: #0369a1;
+  --sky-800: #075985;
+  --sky-900: #0c4a6e;
+
+  /* Neutral gray (Tailwind « gray ») — tons gris one-off (fonds de badges
+     d'état « completed », textes secondaires, séparateurs) dont la valeur
+     exacte diffère de l'échelle slate des tokens --text-, --bg-, --border-.
+     Theme-invariant : migration à pixel identique sans toucher au gris
+     adaptatif du thème (une éventuelle bascule vers les tokens sémantiques
+     adaptatifs reste un choix de design ultérieur, pas une simple tokenisation). */
+  --gray-50: #f9fafb;
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+  --gray-400: #9ca3af;
+  --gray-500: #6b7280;
+  --gray-600: #4b5563;
+  --gray-700: #374151;
+  --gray-800: #1f2937;
+  --gray-900: #111827;
+
   /* ========================================
      SEMANTIC COLOR NAMESPACE (--color-*)
      Intention-revealing aliases. Solid accents point at the raw scale
@@ -157,6 +188,7 @@
   /* Info — solid tracks the per-theme brand blue (#3b82f6 light / #60a5fa dark) */
   --color-info: var(--blue-500);
   --color-info-strong: #2563eb;
+  --color-info-stronger: #1d4ed8;
   --color-info-bg: var(--info-bg);
   --color-info-border: var(--info-border);
   --color-info-text: var(--info-text);

--- a/src/components/admin/ClassCard.vue
+++ b/src/components/admin/ClassCard.vue
@@ -216,7 +216,7 @@ defineEmits(['view'])
   box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
 }
 .btn-primary:hover {
-  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, var(--color-info-stronger) 100%);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
 }

--- a/src/components/admin/EnseignantCard.vue
+++ b/src/components/admin/EnseignantCard.vue
@@ -190,13 +190,13 @@ defineEmits(['view'])
 }
 
 .tag-matiere {
-  background: #e0f2fe;
-  color: #0369a1;
+  background: var(--sky-100);
+  color: var(--sky-700);
 }
 
 :global(.dark) .tag-matiere {
   background: rgba(14, 165, 233, 0.2);
-  color: #7dd3fc;
+  color: var(--sky-300);
 }
 
 .tag-classe {

--- a/src/components/admin/InstitutionFormModal.vue
+++ b/src/components/admin/InstitutionFormModal.vue
@@ -219,7 +219,7 @@ defineEmits(['close', 'save'])
 .toggle-switch {
   width: 44px;
   height: 24px;
-  background: #d1d5db;
+  background: var(--gray-300);
   border-radius: 12px;
   position: relative;
   transition: background var(--transition-fast);

--- a/src/components/admin/InstitutionsTable.vue
+++ b/src/components/admin/InstitutionsTable.vue
@@ -201,7 +201,7 @@ function formatDate(dateStr) {
 
 .status-inactive {
   background: rgba(107, 114, 128, 0.1);
-  color: #6b7280;
+  color: var(--gray-500);
 }
 
 /* Actions */
@@ -243,7 +243,7 @@ function formatDate(dateStr) {
 }
 
 .action-btn-gray {
-  color: #9ca3af;
+  color: var(--gray-400);
 }
 
 .action-btn-blue {

--- a/src/components/admin/SeancesList.vue
+++ b/src/components/admin/SeancesList.vue
@@ -202,8 +202,8 @@ function formatTime(dateString) {
 }
 
 .status-completed {
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--gray-100);
+  color: var(--gray-500);
 }
 
 .seance-body {

--- a/src/components/admin/SettingsPasswordModal.vue
+++ b/src/components/admin/SettingsPasswordModal.vue
@@ -114,7 +114,7 @@ const emit = defineEmits(['submit'])
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, var(--color-info-strong) 0%, #1d4ed8 100%);
+  background: linear-gradient(135deg, var(--color-info-strong) 0%, var(--color-info-stronger) 100%);
   transform: scale(1.02);
 }
 

--- a/src/components/admin/SettingsPermissions.vue
+++ b/src/components/admin/SettingsPermissions.vue
@@ -75,17 +75,17 @@ defineProps({
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
-  color: #0369a1;
+  background: linear-gradient(135deg, var(--sky-50) 0%, var(--sky-100) 100%);
+  color: var(--sky-700);
   border-radius: 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
-  border: 1px solid #bae6fd;
+  border: 1px solid var(--sky-200);
   transition: all 0.2s;
 }
 
 .permission-badge:hover {
-  background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%);
+  background: linear-gradient(135deg, var(--sky-100) 0%, var(--sky-200) 100%);
   transform: translateY(-2px);
   box-shadow: 0 4px 6px rgba(3, 105, 161, 0.1);
 }
@@ -95,13 +95,13 @@ defineProps({
 }
 
 :root[data-theme="dark"] .permission-badge {
-  background: linear-gradient(135deg, #0c4a6e 0%, #075985 100%);
-  color: #7dd3fc;
-  border-color: #0c4a6e;
+  background: linear-gradient(135deg, var(--sky-900) 0%, var(--sky-800) 100%);
+  color: var(--sky-300);
+  border-color: var(--sky-900);
 }
 
 :root[data-theme="dark"] .permission-badge:hover {
-  background: linear-gradient(135deg, #075985 0%, #0369a1 100%);
+  background: linear-gradient(135deg, var(--sky-800) 0%, var(--sky-700) 100%);
   box-shadow: 0 4px 6px rgba(125, 211, 252, 0.1);
 }
 </style>

--- a/src/components/admin/VisioGrid.vue
+++ b/src/components/admin/VisioGrid.vue
@@ -169,8 +169,8 @@ defineEmits(['join', 'view'])
 }
 
 .status-completed {
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--gray-100);
+  color: var(--gray-500);
 }
 
 .visio-body {

--- a/src/components/admin/VisioStatsCards.vue
+++ b/src/components/admin/VisioStatsCards.vue
@@ -96,7 +96,7 @@ defineProps({
 }
 
 .stat-icon-wrapper.completed {
-  background: #f3f4f6;
+  background: var(--gray-100);
 }
 
 .stat-icon-wrapper.total {
@@ -117,7 +117,7 @@ defineProps({
 }
 
 .stat-icon-wrapper.completed .stat-icon {
-  color: #6b7280;
+  color: var(--gray-500);
 }
 
 .stat-icon-wrapper.total .stat-icon {


### PR DESCRIPTION
## Clôture de la dette tracée en #137 (PR #144)

L'audit #135 listait les **gris Tailwind**, **sky/cyan** et `#1d4ed8` comme « besoin token #136 », mais **#136 n'avait créé que `emerald/red/amber/indigo/violet`**. Ces familles manquaient → **26 hex restaient en dur** dans `components/admin` après #144 (bucket C). Cette PR ajoute les échelles manquantes à `themes.css` puis tokenise le reliquat.

### `themes.css` — fondation (additif, theme-invariant, façon #136)
| Ajout | Détail |
|---|---|
| `--gray-50…900` | Tailwind « gray » canonique. Tons gris one-off **exacts**, distincts de l'échelle slate adaptative (`--text-`/`--bg-`/`--border-`). Migration **à pixel identique** ; une bascule vers des tokens adaptatifs reste un choix de design ultérieur. |
| `--sky-50…900` | Tailwind « sky ». Badges visio/permissions, dégradés d'en-tête. |
| `--color-info-stronger: #1d4ed8` | 3ᵉ stop des dégradés de boutons primaires (après `--color-info-strong: #2563eb`). |

### `components/admin` — 26 occurrences / 9 fichiers (diff in-line équilibré 22/22)
- **gris** : `#f3f4f6→--gray-100`, `#6b7280→--gray-500`, `#9ca3af→--gray-400`, `#d1d5db→--gray-300`
- **sky** : `#f0f9ff/#e0f2fe/#bae6fd/#7dd3fc→--sky-50/100/200/300`, `#0369a1/#075985/#0c4a6e→--sky-700/800/900`
- `#1d4ed8→--color-info-stronger`

### ⚠️ Ce que j'ai vu / laissé (compte-rendu)
- **Bug attrapé en validation** : mon commentaire de doc dans `themes.css` contenait `--text-*/--bg-*` → la séquence `*/` **fermait le commentaire CSS** et cassait le fichier (`Unknown word Theme-invariant`). Détecté par le parse PostCSS, corrigé (slashes retirés). Re-parse **OK**, marqueurs `/* */` équilibrés **55/55**.
- **Laissé volontairement** (vrais one-offs non-canoniques — décision de design individuelle requise, **pas** une échelle Tailwind) : `#ccc` (track du toggle `SettingsNotifications`), `#4a90e2`/`#5a9df2` (gradient « bleu vif » bespoke `MatieresTable`) et son `#ffffff` couplé.
- **Bonus** : `--gray-*`/`--sky-*` couvrent aussi les résidus signalés par #140/#141 (« familles Tailwind absentes »), réutilisables par les prochains correctifs.

### Validation
- `themes.css` re-parse PostCSS **OK** ; 12 nouveaux tokens tous définis.
- SFC (`@vue/compiler-sfc` 3.5.28) : **0 échec** de compilation des `<style>` modifiés.
- **0** gris/sky/`#1d4ed8` résiduel dans `components/admin`.

### DoD
✅ Toutes les couleurs *à échelle Tailwind* du périmètre admin sont désormais tokenisées. Restent seulement les rgba ombres/overlays (règle issue #137) et 4 one-offs bespoke documentés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
